### PR TITLE
Pinned memory staging WIP

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,13 @@
+# Extract CUDA headers from the official NVIDIA devel image.
+# Only the include directory is used — no CUDA runtime or libraries are copied.
+FROM nvidia/cuda:12.8.0-devel-ubuntu20.04 AS cuda-headers
+
 FROM ubuntu:20.04
+
+# Copy CUDA headers for compile-time type checking of the driver API (cuda.h etc.).
+# The actual libcuda.so is loaded at runtime via dlopen, so no CUDA installation
+# is required on the build host or the final image.
+COPY --from=cuda-headers /usr/local/cuda/include/ /usr/local/cuda/include/
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3 \

--- a/cpp/WORKSPACE
+++ b/cpp/WORKSPACE
@@ -1,5 +1,14 @@
 load("//toolchain:configure.bzl", "configure_toolchain")
 configure_toolchain(name = "toolchain")
+
+# CUDA SDK headers for compile-time type checking.
+# Only headers are used; the runtime library is loaded via dlopen at run time.
+# Adjust the path if your CUDA installation is in a different location.
+new_local_repository(
+    name = "cuda",
+    path = "/usr/local/cuda",
+    build_file = "//third_party:cuda.BUILD",
+)
 load("//toolchain:deps.bzl", "load_toolchain_deps")
 load_toolchain_deps()
 

--- a/cpp/cuda/cuda_mock/BUILD
+++ b/cpp/cuda/cuda_mock/BUILD
@@ -1,0 +1,11 @@
+load("//:rules.bzl", "runai_portable_so")
+
+# Mock CUDA driver library for unit testing without a GPU.
+# Built as libcuda.so.1 — the same name dlopen searches for — so the test
+# binary's DT_RPATH finds it before the system driver on any machine.
+runai_portable_so(
+    name = "libcuda.so.1",
+    srcs = ["libcuda_mock.cc"],
+    ldscript = ":libcuda.ldscript",
+    visibility = ["//visibility:public"],
+)

--- a/cpp/cuda/cuda_mock/libcuda.ldscript
+++ b/cpp/cuda/cuda_mock/libcuda.ldscript
@@ -9,6 +9,8 @@
         cuDevicePrimaryCtxRetain;
         cuDevicePrimaryCtxRelease;
         cuCtxSetCurrent;
+        get_cuMemcpyHtoDAsync_call_count;
+        reset_cuMemcpyHtoDAsync_call_count;
 
     local: *;
 };

--- a/cpp/cuda/cuda_mock/libcuda.ldscript
+++ b/cpp/cuda/cuda_mock/libcuda.ldscript
@@ -1,0 +1,14 @@
+{
+    global:
+        cuStreamCreate;
+        cuStreamDestroy_v2;
+        cuStreamSynchronize;
+        cuMemAllocHost_v2;
+        cuMemFreeHost;
+        cuMemcpyHtoDAsync_v2;
+        cuDevicePrimaryCtxRetain;
+        cuDevicePrimaryCtxRelease;
+        cuCtxSetCurrent;
+
+    local: *;
+};

--- a/cpp/cuda/cuda_mock/libcuda_mock.cc
+++ b/cpp/cuda/cuda_mock/libcuda_mock.cc
@@ -7,6 +7,7 @@
 // This library is built as libcuda.so.1 and injected via DT_RPATH in test
 // binaries, taking precedence over the real driver even on GPU machines.
 
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
 
@@ -81,13 +82,28 @@ CUresult cuCtxSetCurrent(CUcontext /*ctx*/)
 
 // --- Core copy: CUdeviceptr is uint64; treat as host pointer and memcpy ---
 
+static std::atomic<int> _cuMemcpyHtoDAsync_call_count{0};
+
 CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr  dstDevice,
                                const void * srcHost,
                                size_t       byteCount,
                                CUstream     /*hStream*/)
 {
+    ++_cuMemcpyHtoDAsync_call_count;
     memcpy(reinterpret_cast<void *>(dstDevice), srcHost, byteCount);
     return CUDA_SUCCESS;
+}
+
+// --- Test helpers: expose call counter so Python tests can verify mock usage ---
+
+int get_cuMemcpyHtoDAsync_call_count()
+{
+    return _cuMemcpyHtoDAsync_call_count.load();
+}
+
+void reset_cuMemcpyHtoDAsync_call_count()
+{
+    _cuMemcpyHtoDAsync_call_count.store(0);
 }
 
 } // extern "C"

--- a/cpp/cuda/cuda_mock/libcuda_mock.cc
+++ b/cpp/cuda/cuda_mock/libcuda_mock.cc
@@ -1,0 +1,93 @@
+// Mock implementation of the CUDA driver API for unit testing without a GPU.
+//
+// cuMemcpyHtoDAsync treats CUdeviceptr as a plain host pointer and performs
+// a memcpy, so tests can verify data correctness without any GPU hardware.
+// All stream and context operations are no-ops.
+//
+// This library is built as libcuda.so.1 and injected via DT_RPATH in test
+// binaries, taking precedence over the real driver even on GPU machines.
+
+#include <cstdlib>
+#include <cstring>
+
+// ABI-compatible type definitions — no CUDA SDK required.
+typedef int                  CUresult;
+typedef unsigned long long   CUdeviceptr;
+typedef int                  CUdevice;
+struct CUstream_st;
+typedef struct CUstream_st * CUstream;
+struct CUctx_st;
+typedef struct CUctx_st *    CUcontext;
+
+#define CUDA_SUCCESS             0
+#define CUDA_ERROR_OUT_OF_MEMORY 2
+
+extern "C"
+{
+
+// --- Pinned host memory: plain malloc/free ---
+
+CUresult cuMemAllocHost_v2(void ** pp, size_t bytesize)
+{
+    *pp = malloc(bytesize);
+    return *pp ? CUDA_SUCCESS : CUDA_ERROR_OUT_OF_MEMORY;
+}
+
+CUresult cuMemFreeHost(void * p)
+{
+    free(p);
+    return CUDA_SUCCESS;
+}
+
+// --- Streams: non-null sentinel so CudaDriver::get() passes all null-checks ---
+
+static int _stream_sentinel;
+
+CUresult cuStreamCreate(CUstream * phStream, unsigned int /*flags*/)
+{
+    *phStream = reinterpret_cast<CUstream>(&_stream_sentinel);
+    return CUDA_SUCCESS;
+}
+
+CUresult cuStreamDestroy_v2(CUstream /*hStream*/)
+{
+    return CUDA_SUCCESS;
+}
+
+CUresult cuStreamSynchronize(CUstream /*hStream*/)
+{
+    return CUDA_SUCCESS;
+}
+
+// --- Context: non-null sentinel ---
+
+static int _ctx_sentinel;
+
+CUresult cuDevicePrimaryCtxRetain(CUcontext * pctx, CUdevice /*dev*/)
+{
+    *pctx = reinterpret_cast<CUcontext>(&_ctx_sentinel);
+    return CUDA_SUCCESS;
+}
+
+CUresult cuDevicePrimaryCtxRelease(CUdevice /*dev*/)
+{
+    return CUDA_SUCCESS;
+}
+
+CUresult cuCtxSetCurrent(CUcontext /*ctx*/)
+{
+    return CUDA_SUCCESS;
+}
+
+// --- Core copy: CUdeviceptr is uint64; treat as host pointer and memcpy ---
+
+CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr  dstDevice,
+                               const void * srcHost,
+                               size_t       byteCount,
+                               CUstream     /*hStream*/)
+{
+    memcpy(reinterpret_cast<void *>(dstDevice), srcHost, byteCount);
+    return CUDA_SUCCESS;
+}
+
+} // extern "C"

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -101,7 +101,8 @@ extern "C" int runai_request(
     const char * secret,
     const char * token,
     const char * region,
-    const char * endpoint
+    const char * endpoint,
+    int /* cuda */
 )
 {
     __multi_state.clear();

--- a/cpp/streamer/impl/batch/BUILD
+++ b/cpp/streamer/impl/batch/BUILD
@@ -6,6 +6,7 @@ runai_cc_auto_library(
         "//common/responder",
         "//common/shared_queue",
         "//streamer/impl/config",
+        "//streamer/impl/cuda:cuda_loader",
         "//streamer/impl/file",
         "//streamer/impl/s3",
         "//streamer/impl/task",

--- a/cpp/streamer/impl/batch/BUILD
+++ b/cpp/streamer/impl/batch/BUILD
@@ -14,6 +14,24 @@ runai_cc_auto_library(
 )
 
 runai_cc_test(
+    name = "batch_cuda_test",
+    srcs = ["batch_cuda_test.cc"],
+    deps = [
+        ":batch",
+        "//utils/random",
+        "//utils/temp/file",
+        "//common/s3_wrapper",
+        "//cuda/cuda_mock:libcuda.so.1",
+    ],
+    data = ["//cuda/cuda_mock:libcuda.so.1"],
+    linkopts = [
+        # DT_RPATH (not RUNPATH) is searched before LD_LIBRARY_PATH, so the mock
+        # wins even on GPU machines where LD_LIBRARY_PATH includes the real CUDA.
+        "-Wl,-rpath=$$ORIGIN/../../../cuda/cuda_mock,--disable-new-dtags",
+    ],
+)
+
+runai_cc_test(
     name = "batch_test",
     srcs = ["batch_test.cc"],
     deps = [":batch",

--- a/cpp/streamer/impl/batch/batch.cc
+++ b/cpp/streamer/impl/batch/batch.cc
@@ -328,9 +328,19 @@ struct CudaStagingBuffer
             // Worker threads do not automatically inherit the CUDA context from
             // the Python main thread.  Make the already-retained primary context
             // current for this thread before any driver API calls.
-            drv.cuCtxSetCurrent(drv.ctx);
-
-            drv.cuStreamCreate(&stream, 0);
+            CUresult res = drv.cuCtxSetCurrent(drv.ctx);
+            if (res != CUDA_SUCCESS)
+            {
+                LOG(ERROR) << "cuCtxSetCurrent failed with error " << res;
+                throw common::Exception(common::ResponseCode::UnknownError);
+            }
+            res = drv.cuStreamCreate(&stream, 0);
+            if (res != CUDA_SUCCESS)
+            {
+                stream = nullptr;
+                LOG(ERROR) << "cuStreamCreate failed with error " << res;
+                throw common::Exception(common::ResponseCode::UnknownError);
+            }
         }
         if (needed > capacity)
         {
@@ -339,7 +349,20 @@ struct CudaStagingBuffer
                 drv.cuMemFreeHost(ptr);
                 ptr = nullptr;
             }
-            drv.cuMemAllocHost(reinterpret_cast<void **>(&ptr), needed);
+            const CUresult res = drv.cuMemAllocHost(reinterpret_cast<void **>(&ptr), needed);
+            if (res != CUDA_SUCCESS)
+            {
+                ptr = nullptr;
+                size_t free_bytes = 0, total_bytes = 0;
+                if (drv.cuMemGetInfo && drv.cuMemGetInfo(&free_bytes, &total_bytes) != CUDA_SUCCESS)
+                {
+                    free_bytes = total_bytes = 0;
+                }
+                LOG(ERROR) << "cuMemAllocHost failed: tried to allocate " << needed
+                           << " bytes; free GPU memory: " << free_bytes
+                           << " / " << total_bytes << " bytes; error " << res;
+                throw common::Exception(common::ResponseCode::UnknownError);
+            }
             capacity = needed;
         }
         return ptr;
@@ -381,13 +404,26 @@ void Batch::read_cuda(const Config & config, std::atomic<bool> & stopped, const 
         {
             const size_t to_read = std::min(remaining, config.fs_block_bytesize);
             _reader->read(to_read, staging_buf);
-            drv.cuMemcpyHtoDAsync(reinterpret_cast<::CUdeviceptr>(gpu_ptr), staging_buf, to_read, g_cuda_staging.stream);
-            drv.cuStreamSynchronize(g_cuda_staging.stream);
+            CUresult res = drv.cuMemcpyHtoDAsync(reinterpret_cast<::CUdeviceptr>(gpu_ptr), staging_buf, to_read, g_cuda_staging.stream);
+            if (res != CUDA_SUCCESS)
+            {
+                LOG(ERROR) << "cuMemcpyHtoDAsync failed with error " << res;
+                throw common::Exception(common::ResponseCode::UnknownError);
+            }
+            res = drv.cuStreamSynchronize(g_cuda_staging.stream);
+            if (res != CUDA_SUCCESS)
+            {
+                LOG(ERROR) << "cuStreamSynchronize failed with error " << res;
+                throw common::Exception(common::ResponseCode::UnknownError);
+            }
             gpu_ptr   += to_read;
             remaining -= to_read;
         }
 
-        finished_until(task.info.end, common::ResponseCode::Success);
+        if (remaining == 0)
+        {
+            finished_until(task.info.end, common::ResponseCode::Success);
+        }
     }
 
     LOG(DEBUG) << "Finished reading " << tasks.size() << " tasks from file " << path

--- a/cpp/streamer/impl/batch/batch.h
+++ b/cpp/streamer/impl/batch/batch.h
@@ -14,6 +14,7 @@
 //#include "common/range/range.h"
 
 #include "streamer/impl/config/config.h"
+#include "streamer/impl/cuda/cuda_loader.h"
 #include "streamer/impl/task/task.h"
 #include "streamer/impl/reader/reader.h"
 
@@ -56,7 +57,8 @@ struct Batch
         const common::s3::S3ClientWrapper::Params & params,
         const Tasks && tasks,
         std::shared_ptr<common::Responder> responder,
-        std::shared_ptr<const Config> config);
+        std::shared_ptr<const Config> config,
+        bool cuda = false);
 
   // total number of requested bytes
   size_t total_bytes() const;
@@ -102,6 +104,7 @@ struct Batch
 
  private:
   void read(const Config & config, std::atomic<bool> & stopped);
+  void read_cuda(const Config & config, std::atomic<bool> & stopped, const cuda::CudaDriver & drv);
 
   void async_wait(Reader * reader, std::atomic<bool> & stopped);
 
@@ -113,6 +116,8 @@ struct Batch
  private:
   // index of first unfinished task
   unsigned _unfinished = 0;
+
+  bool _cuda = false;
 
   std::unique_ptr<Reader> _reader;
 };

--- a/cpp/streamer/impl/batch/batch_cuda_test.cc
+++ b/cpp/streamer/impl/batch/batch_cuda_test.cc
@@ -1,0 +1,169 @@
+#include "streamer/impl/batch/batch.h"
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+
+#include "utils/random/random.h"
+#include "utils/temp/file/file.h"
+
+#include "common/s3_wrapper/s3_wrapper.h"
+
+#include "streamer/impl/cuda/cuda_loader.h"
+
+namespace runai::llm::streamer::impl
+{
+
+namespace
+{
+
+bool real_cuda_driver_present()
+{
+    struct stat st;
+    return stat("/dev/nvidiactl", &st) == 0;
+}
+
+} // anonymous namespace
+
+// N tensors of random sizes written to a contiguous destination buffer.
+// Also exercises multi-chunk reads by using a random fs_block_bytesize.
+TEST(ReadCuda, Sanity)
+{
+    if (real_cuda_driver_present())
+        GTEST_SKIP() << "Real CUDA driver present; mock test skipped on GPU machine";
+
+    ASSERT_NE(cuda::CudaDriver::get(), nullptr)
+        << "Mock libcuda.so.1 not loaded — check DT_RPATH in BUILD";
+
+    const unsigned num_tensors = utils::random::number(1, 8);
+    const size_t   file_start  = utils::random::number<size_t>(0, 512);
+
+    std::vector<size_t> sizes;
+    size_t total = 0;
+    for (unsigned i = 0; i < num_tensors; ++i)
+    {
+        sizes.push_back(utils::random::number<size_t>(1, 4096));
+        total += sizes.back();
+    }
+
+    const auto src = utils::random::buffer(file_start + total);
+    utils::temp::File file(src);
+
+    std::vector<char> dst(total, '\0');
+
+    const auto chunk_bytesize = utils::random::number<size_t>(1, total);
+    const auto config = std::make_shared<Config>(
+        utils::random::number(1, 4), chunk_bytesize,
+        utils::random::number<size_t>(1, chunk_bytesize),
+        false /* do not force minimum chunk size */);
+
+    auto responder = std::make_shared<common::Responder>(1);
+    auto request   = std::make_shared<Request>(file_start, 0, 0, num_tensors, total, dst.data());
+
+    Tasks tasks;
+    size_t file_off = file_start;
+    size_t rel_off  = 0;
+    for (unsigned i = 0; i < num_tensors; ++i)
+    {
+        tasks.emplace_back(request, file_off, sizes[i], rel_off);
+        file_off += sizes[i];
+        rel_off  += sizes[i];
+    }
+
+    common::s3::S3ClientWrapper::Params params;
+    Batch batch(0, 0, file.path, params, std::move(tasks), responder, config, /*cuda=*/true);
+
+    std::atomic<bool> stopped(false);
+    ASSERT_NO_THROW(batch.execute(stopped));
+    EXPECT_EQ(responder->pop().ret, common::ResponseCode::Success);
+
+    size_t pos = file_start;
+    for (unsigned i = 0; i < num_tensors; ++i)
+    {
+        for (size_t j = 0; j < sizes[i]; ++j)
+            EXPECT_EQ(dst[pos - file_start + j], static_cast<char>(src[pos + j]))
+                << "mismatch tensor=" << i << " byte=" << j;
+        pos += sizes[i];
+    }
+}
+
+// Tensors written to 512-byte aligned offsets within a larger buffer, matching
+// the layout that the Python alignment layer produces for real CUDA streaming.
+// Padding bytes between tensors must remain untouched.
+TEST(ReadCuda, AlignedDestinations)
+{
+    if (real_cuda_driver_present())
+        GTEST_SKIP() << "Real CUDA driver present; mock test skipped on GPU machine";
+
+    ASSERT_NE(cuda::CudaDriver::get(), nullptr)
+        << "Mock libcuda.so.1 not loaded — check DT_RPATH in BUILD";
+
+    constexpr size_t kAlign = 512;
+
+    // Sizes deliberately not multiples of kAlign
+    const std::vector<size_t> sizes     = {100, 200, 300};
+    const size_t              file_start = 0;
+
+    size_t file_total = 0;
+    for (auto s : sizes) file_total += s;
+
+    const auto src = utils::random::buffer(file_total);
+    utils::temp::File file(src);
+
+    // Compute per-tensor destination offsets as the Python layer would
+    auto align_up = [](size_t v, size_t a){ return (v + a - 1) & ~(a - 1); };
+
+    std::vector<size_t> dst_offsets;
+    size_t dst_cursor = 0;
+    for (size_t i = 0; i < sizes.size(); ++i)
+    {
+        dst_offsets.push_back(dst_cursor);
+        dst_cursor += align_up(sizes[i], kAlign);
+    }
+    const size_t dst_total = dst_cursor;
+
+    // Sentinel fill so any write into padding is detectable
+    constexpr char kSentinel = static_cast<char>(0xAB);
+    std::vector<char> dst(dst_total, kSentinel);
+
+    const auto config = std::make_shared<Config>();
+
+    auto responder = std::make_shared<common::Responder>(1);
+    // request->dst is the base; task relative_offset lands each tensor at its
+    // aligned slot: destination() == dst.data() + dst_offsets[i]
+    auto request   = std::make_shared<Request>(file_start, 0, 0, sizes.size(), file_total, dst.data());
+
+    Tasks tasks;
+    size_t file_off = file_start;
+    for (size_t i = 0; i < sizes.size(); ++i)
+    {
+        tasks.emplace_back(request, file_off, sizes[i], dst_offsets[i]);
+        file_off += sizes[i];
+    }
+
+    common::s3::S3ClientWrapper::Params params;
+    Batch batch(0, 0, file.path, params, std::move(tasks), responder, config, /*cuda=*/true);
+
+    std::atomic<bool> stopped(false);
+    ASSERT_NO_THROW(batch.execute(stopped));
+    EXPECT_EQ(responder->pop().ret, common::ResponseCode::Success);
+
+    size_t src_pos = file_start;
+    for (size_t i = 0; i < sizes.size(); ++i)
+    {
+        // Tensor data must match the source file
+        for (size_t j = 0; j < sizes[i]; ++j)
+            EXPECT_EQ(dst[dst_offsets[i] + j], static_cast<char>(src[src_pos + j]))
+                << "data mismatch tensor=" << i << " byte=" << j;
+
+        // Padding between this tensor and the next must be untouched
+        const size_t pad_start = dst_offsets[i] + sizes[i];
+        const size_t pad_end   = (i + 1 < sizes.size()) ? dst_offsets[i + 1] : dst_total;
+        for (size_t j = pad_start; j < pad_end; ++j)
+            EXPECT_EQ(dst[j], kSentinel)
+                << "padding corrupted at dst byte=" << j << " (between tensor " << i << " and " << i + 1 << ")";
+
+        src_pos += sizes[i];
+    }
+}
+
+}; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/batches/batches.cc
+++ b/cpp/streamer/impl/batches/batches.cc
@@ -88,8 +88,10 @@ Batches::Batches(unsigned file_index,
                  std::shared_ptr<common::Responder> responder,
                  const std::string & path,
                  const common::s3::S3ClientWrapper::Params & params,
-                 const std::vector<size_t> & internal_sizes) :
+                 const std::vector<size_t> & internal_sizes,
+                 bool cuda) :
     _file_index(file_index),
+    _cuda(cuda),
     _itr(file_read_tasks),
     _responder(responder)
 {
@@ -150,7 +152,7 @@ void Batches::build_tasks(std::shared_ptr<const Config> config, const std::strin
             continue;
         }
 
-        _batches.emplace_back(worker_index, _file_index, path, params, std::move(tasks), _responder, config);
+        _batches.emplace_back(worker_index, _file_index, path, params, std::move(tasks), _responder, config, _cuda);
     }
 
     for (auto & batch : _batches)

--- a/cpp/streamer/impl/batches/batches.h
+++ b/cpp/streamer/impl/batches/batches.h
@@ -27,7 +27,8 @@ struct Batches
            const std::string & path,
            const common::s3::S3ClientWrapper::Params & params,
            const std::vector<size_t> & internal_sizes,
-           bool cuda = false);
+           bool cuda = false,
+           std::vector<void*> cuda_tensor_dsts = {});
 
     Batches(Batches &&) = default;
     Batches & operator=(Batches &&) = default;
@@ -69,6 +70,7 @@ struct Batches
 
     unsigned _file_index;
     bool _cuda = false;
+    std::vector<void*> _cuda_tensor_dsts;
 
     unsigned _size;
 

--- a/cpp/streamer/impl/batches/batches.h
+++ b/cpp/streamer/impl/batches/batches.h
@@ -26,7 +26,8 @@ struct Batches
            std::shared_ptr<common::Responder> responder,
            const std::string & path,
            const common::s3::S3ClientWrapper::Params & params,
-           const std::vector<size_t> & internal_sizes);
+           const std::vector<size_t> & internal_sizes,
+           bool cuda = false);
 
     Batches(Batches &&) = default;
     Batches & operator=(Batches &&) = default;
@@ -67,6 +68,7 @@ struct Batches
     void handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size, char * destination);
 
     unsigned _file_index;
+    bool _cuda = false;
 
     unsigned _size;
 

--- a/cpp/streamer/impl/cuda/BUILD
+++ b/cpp/streamer/impl/cuda/BUILD
@@ -1,0 +1,11 @@
+load("//:rules.bzl", "runai_cc_auto_library")
+
+runai_cc_auto_library(
+    name = "cuda_loader",
+    deps = [
+        "@cuda//:cuda_headers",
+        "//utils/logging",
+    ],
+    # dlopen is used at runtime to load libcuda.so — no link-time dependency on CUDA.
+    linkopts = ["-ldl"],
+)

--- a/cpp/streamer/impl/cuda/cuda_loader.cc
+++ b/cpp/streamer/impl/cuda/cuda_loader.cc
@@ -1,0 +1,97 @@
+#include "streamer/impl/cuda/cuda_loader.h"
+
+#include <dlfcn.h>
+
+#include "utils/logging/logging.h"
+
+namespace runai::llm::streamer::impl::cuda
+{
+
+CudaDriver::~CudaDriver()
+{
+    if (ctx != nullptr && cuDevicePrimaryCtxRelease != nullptr)
+    {
+        cuDevicePrimaryCtxRelease(0);
+    }
+}
+
+namespace
+{
+
+template<typename T>
+T load_sym(void * handle, const char * versioned_name, const char * fallback_name = nullptr)
+{
+    auto fn = reinterpret_cast<T>(dlsym(handle, versioned_name));
+    if (!fn && fallback_name)
+    {
+        fn = reinterpret_cast<T>(dlsym(handle, fallback_name));
+    }
+    return fn;
+}
+
+CudaDriver load()
+{
+    // Try the stable SONAME first, then the unversioned symlink as fallback.
+    void * handle = nullptr;
+    for (const char * lib : {"libcuda.so.1", "libcuda.so"})
+    {
+        handle = dlopen(lib, RTLD_LAZY | RTLD_LOCAL);
+        if (handle)
+        {
+            break;
+        }
+    }
+
+    if (!handle)
+    {
+        LOG(INFO) << "[RunAI Streamer] CUDA driver library not found; CUDA streaming disabled";
+        return {};
+    }
+
+    CudaDriver d{};
+
+    // For driver API functions that were given a _v2 suffix in CUDA 4.0 when
+    // CUdeviceptr was widened to 64 bits, prefer the versioned symbol on 64-bit
+    // builds and fall back to the unversioned symbol for older drivers.
+    d.cuStreamCreate           = load_sym<decltype(d.cuStreamCreate)>           (handle, "cuStreamCreate");
+    d.cuStreamDestroy          = load_sym<decltype(d.cuStreamDestroy)>          (handle, "cuStreamDestroy_v2",  "cuStreamDestroy");
+    d.cuStreamSynchronize      = load_sym<decltype(d.cuStreamSynchronize)>      (handle, "cuStreamSynchronize");
+    d.cuMemAllocHost           = load_sym<decltype(d.cuMemAllocHost)>           (handle, "cuMemAllocHost_v2",   "cuMemAllocHost");
+    d.cuMemFreeHost            = load_sym<decltype(d.cuMemFreeHost)>            (handle, "cuMemFreeHost");
+    d.cuMemcpyHtoDAsync        = load_sym<decltype(d.cuMemcpyHtoDAsync)>        (handle, "cuMemcpyHtoDAsync_v2","cuMemcpyHtoDAsync");
+    d.cuDevicePrimaryCtxRelease = load_sym<decltype(d.cuDevicePrimaryCtxRelease)>(handle, "cuDevicePrimaryCtxRelease");
+    d.cuCtxSetCurrent          = load_sym<decltype(d.cuCtxSetCurrent)>          (handle, "cuCtxSetCurrent");
+
+    if (!d.cuStreamCreate || !d.cuStreamDestroy || !d.cuStreamSynchronize ||
+        !d.cuMemAllocHost || !d.cuMemFreeHost   || !d.cuMemcpyHtoDAsync  ||
+        !d.cuDevicePrimaryCtxRelease || !d.cuCtxSetCurrent)
+    {
+        LOG(WARNING) << "[RunAI Streamer] Not all CUDA driver symbols could be resolved; CUDA streaming disabled";
+        return {};
+    }
+
+    // Retain the primary context for device 0 once per process.
+    // Worker threads make it current via cuCtxSetCurrent(ctx) on first use.
+    // The matching cuDevicePrimaryCtxRelease(0) is called in ~CudaDriver().
+    auto cuDevicePrimaryCtxRetain =
+        load_sym<CUresult(*)(CUcontext *, CUdevice)>(handle, "cuDevicePrimaryCtxRetain");
+    if (!cuDevicePrimaryCtxRetain || cuDevicePrimaryCtxRetain(&d.ctx, 0) != CUDA_SUCCESS)
+    {
+        LOG(WARNING) << "[RunAI Streamer] Could not retain CUDA primary context; CUDA streaming disabled";
+        return {};
+    }
+
+    LOG(INFO) << "[RunAI Streamer] CUDA driver loaded successfully";
+    return d;
+}
+
+} // anonymous namespace
+
+const CudaDriver * CudaDriver::get()
+{
+    static const CudaDriver driver   = load();
+    static const bool       available = driver.cuStreamCreate != nullptr;
+    return available ? &driver : nullptr;
+}
+
+} // namespace runai::llm::streamer::impl::cuda

--- a/cpp/streamer/impl/cuda/cuda_loader.cc
+++ b/cpp/streamer/impl/cuda/cuda_loader.cc
@@ -61,6 +61,7 @@ CudaDriver load()
     d.cuMemcpyHtoDAsync        = load_sym<decltype(d.cuMemcpyHtoDAsync)>        (handle, "cuMemcpyHtoDAsync_v2","cuMemcpyHtoDAsync");
     d.cuDevicePrimaryCtxRelease = load_sym<decltype(d.cuDevicePrimaryCtxRelease)>(handle, "cuDevicePrimaryCtxRelease");
     d.cuCtxSetCurrent          = load_sym<decltype(d.cuCtxSetCurrent)>          (handle, "cuCtxSetCurrent");
+    d.cuMemGetInfo             = load_sym<decltype(d.cuMemGetInfo)>             (handle, "cuMemGetInfo_v2", "cuMemGetInfo");  // optional
 
     if (!d.cuStreamCreate || !d.cuStreamDestroy || !d.cuStreamSynchronize ||
         !d.cuMemAllocHost || !d.cuMemFreeHost   || !d.cuMemcpyHtoDAsync  ||

--- a/cpp/streamer/impl/cuda/cuda_loader.cc
+++ b/cpp/streamer/impl/cuda/cuda_loader.cc
@@ -11,7 +11,7 @@ CudaDriver::~CudaDriver()
 {
     if (ctx != nullptr && cuDevicePrimaryCtxRelease != nullptr)
     {
-        cuDevicePrimaryCtxRelease(0);
+        cuDevicePrimaryCtxRelease(device);
     }
 }
 
@@ -70,16 +70,40 @@ CudaDriver load()
         return {};
     }
 
-    // Retain the primary context for device 0 once per process.
+    // Detect the current CUDA device (set by the framework, e.g. torch.cuda.set_device).
+    // In multi-GPU / tensor-parallel setups each worker process may use a different
+    // device; we must retain the primary context for THAT device, not always device 0.
+    auto cuCtxGetCurrent =
+        load_sym<CUresult(*)(CUcontext *)>(handle, "cuCtxGetCurrent");
+    auto cuCtxGetDevice =
+        load_sym<CUresult(*)(CUdevice *)>(handle, "cuCtxGetDevice");
+
+    CUdevice device = 0;  // default fallback
+    if (cuCtxGetCurrent && cuCtxGetDevice)
+    {
+        CUcontext curr_ctx = nullptr;
+        if (cuCtxGetCurrent(&curr_ctx) == CUDA_SUCCESS && curr_ctx != nullptr)
+        {
+            CUdevice curr_dev = 0;
+            if (cuCtxGetDevice(&curr_dev) == CUDA_SUCCESS)
+            {
+                device = curr_dev;
+            }
+        }
+    }
+
+    // Retain the primary context for the detected device once per process.
     // Worker threads make it current via cuCtxSetCurrent(ctx) on first use.
-    // The matching cuDevicePrimaryCtxRelease(0) is called in ~CudaDriver().
+    // The matching cuDevicePrimaryCtxRelease(device) is called in ~CudaDriver().
     auto cuDevicePrimaryCtxRetain =
         load_sym<CUresult(*)(CUcontext *, CUdevice)>(handle, "cuDevicePrimaryCtxRetain");
-    if (!cuDevicePrimaryCtxRetain || cuDevicePrimaryCtxRetain(&d.ctx, 0) != CUDA_SUCCESS)
+    if (!cuDevicePrimaryCtxRetain || cuDevicePrimaryCtxRetain(&d.ctx, device) != CUDA_SUCCESS)
     {
-        LOG(WARNING) << "[RunAI Streamer] Could not retain CUDA primary context; CUDA streaming disabled";
+        LOG(WARNING) << "[RunAI Streamer] Could not retain CUDA primary context for device "
+                     << device << "; CUDA streaming disabled";
         return {};
     }
+    d.device = device;
 
     LOG(INFO) << "[RunAI Streamer] CUDA driver loaded successfully";
     return d;

--- a/cpp/streamer/impl/cuda/cuda_loader.h
+++ b/cpp/streamer/impl/cuda/cuda_loader.h
@@ -1,0 +1,39 @@
+
+#pragma once
+
+#include <cuda.h>
+
+namespace runai::llm::streamer::impl::cuda
+{
+
+// Subset of the CUDA driver API loaded at runtime from libcuda.so.1.
+// We include cuda.h for correct type definitions (CUresult, CUdeviceptr, CUstream)
+// so the compiler validates our function pointer signatures against the official ABI.
+// The actual library is loaded via dlopen at runtime, so the built .so has no hard
+// dependency on a specific libcuda.so version.
+//
+// Obtain the singleton via get(); returns nullptr if CUDA is unavailable at runtime.
+struct CudaDriver
+{
+    // Releases the retained primary context on destruction (see ctx below).
+    ~CudaDriver();
+
+    // The primary CUDA context for device 0, retained once at load time.
+    // Worker threads call cuCtxSetCurrent(ctx) on first use to make it current.
+    // cuDevicePrimaryCtxRelease(0) is called in the destructor to balance the retain.
+    CUcontext ctx = nullptr;
+
+    CUresult (*cuStreamCreate)           (CUstream *, unsigned int flags);
+    CUresult (*cuStreamDestroy)          (CUstream);
+    CUresult (*cuStreamSynchronize)      (CUstream);
+    CUresult (*cuMemAllocHost)           (void **, size_t);
+    CUresult (*cuMemFreeHost)            (void *);
+    CUresult (*cuMemcpyHtoDAsync)        (CUdeviceptr dst, const void * src, size_t count, CUstream);
+    CUresult (*cuDevicePrimaryCtxRelease)(CUdevice device);
+    CUresult (*cuCtxSetCurrent)          (CUcontext);
+
+    // Returns the process-wide singleton, or nullptr if libcuda.so could not be loaded.
+    static const CudaDriver * get();
+};
+
+} // namespace runai::llm::streamer::impl::cuda

--- a/cpp/streamer/impl/cuda/cuda_loader.h
+++ b/cpp/streamer/impl/cuda/cuda_loader.h
@@ -15,13 +15,16 @@ namespace runai::llm::streamer::impl::cuda
 // Obtain the singleton via get(); returns nullptr if CUDA is unavailable at runtime.
 struct CudaDriver
 {
-    // Releases the retained primary context on destruction (see ctx below).
+    // Releases the retained primary context on destruction (see device below).
     ~CudaDriver();
 
-    // The primary CUDA context for device 0, retained once at load time.
-    // Worker threads call cuCtxSetCurrent(ctx) on first use to make it current.
-    // cuDevicePrimaryCtxRelease(0) is called in the destructor to balance the retain.
-    CUcontext ctx = nullptr;
+    // The primary CUDA context for the device that was current when the driver
+    // was first loaded, retained once at load time.  Worker threads call
+    // cuCtxSetCurrent(ctx) on first use to make it current.
+    // cuDevicePrimaryCtxRelease(device) is called in the destructor to balance
+    // the retain.
+    CUcontext ctx    = nullptr;
+    CUdevice  device = 0;
 
     CUresult (*cuStreamCreate)           (CUstream *, unsigned int flags);
     CUresult (*cuStreamDestroy)          (CUstream);

--- a/cpp/streamer/impl/cuda/cuda_loader.h
+++ b/cpp/streamer/impl/cuda/cuda_loader.h
@@ -34,6 +34,7 @@ struct CudaDriver
     CUresult (*cuMemcpyHtoDAsync)        (CUdeviceptr dst, const void * src, size_t count, CUstream);
     CUresult (*cuDevicePrimaryCtxRelease)(CUdevice device);
     CUresult (*cuCtxSetCurrent)          (CUcontext);
+    CUresult (*cuMemGetInfo)             (size_t *free, size_t *total);  // optional; used for diagnostics
 
     // Returns the process-wide singleton, or nullptr if libcuda.so could not be loaded.
     static const CudaDriver * get();

--- a/cpp/streamer/impl/streamer/BUILD
+++ b/cpp/streamer/impl/streamer/BUILD
@@ -6,6 +6,7 @@ runai_cc_auto_library(
         "//streamer/impl/assigner",
         "//streamer/impl/config",
         "//streamer/impl/batches",
+        "//streamer/impl/cuda:cuda_loader",
         "//streamer/impl/workload",
         "//common/responder",
         "//utils/threadpool",

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -77,7 +77,7 @@ common::ResponseCode Streamer::async_read(const std::string & path, size_t file_
 
         internal_sizes_vv.push_back(internal_sizes_v);
 
-        async_request(paths, file_offsets, bytesizes, dsts, num_sizes_v, internal_sizes_vv, credentials);
+        async_request(paths, file_offsets, bytesizes, dsts, num_sizes_v, internal_sizes_vv, credentials, false);
     }
     catch(const common::Exception & e)
     {
@@ -105,7 +105,8 @@ common::ResponseCode Streamer::async_request(
     std::vector<void *> & dsts,
     std::vector<unsigned> & num_sizes,
     std::vector<std::vector<size_t>> & internal_sizes,
-    const common::s3::Credentials & credentials)
+    const common::s3::Credentials & credentials,
+    bool cuda)
 {
     // verify input
     verify_requests(paths, file_offsets, bytesizes, num_sizes, dsts);
@@ -136,7 +137,7 @@ common::ResponseCode Streamer::async_request(
     {
         auto params = handle_s3(i, paths[i], credentials);
         LOG(DEBUG) << "Creating batches for file index " << i << " path: " <<  paths[i];
-        Batches batches(i, assigner.file_assignments(i), _config, _responder, paths[i], params, internal_sizes[i]);
+        Batches batches(i, assigner.file_assignments(i), _config, _responder, paths[i], params, internal_sizes[i], cuda);
         const auto num_batches = batches.size();
         LOG(DEBUG) << "Created " << num_batches << " batches for file index " << i;
         for (size_t j = 0; j < num_batches; ++j)

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -12,6 +12,7 @@
 
 #include "streamer/impl/workload/workload.h"
 #include "streamer/impl/assigner/assigner.h"
+#include "streamer/impl/cuda/cuda_loader.h"
 #include "common/exception/exception.h"
 #include "common/storage_uri/storage_uri.h"
 
@@ -110,6 +111,15 @@ common::ResponseCode Streamer::async_request(
 {
     // verify input
     verify_requests(paths, file_offsets, bytesizes, num_sizes, dsts);
+
+    // Initialize the CUDA driver singleton on the calling thread (the Python thread),
+    // which has the correct CUDA device context set via torch.cuda.set_device().
+    // Worker threads have no CUDA context, so if we let them trigger the lazy init
+    // they would fall back to device 0 regardless of which GPU this process uses.
+    if (cuda)
+    {
+        cuda::CudaDriver::get();
+    }
 
     auto total_sizes =  std::accumulate(num_sizes.begin(), num_sizes.end(), 0u);
 

--- a/cpp/streamer/impl/streamer/streamer.h
+++ b/cpp/streamer/impl/streamer/streamer.h
@@ -44,7 +44,8 @@ struct Streamer
       std::vector<void *> & dsts,
       std::vector<unsigned> & num_sizes,
       std::vector<std::vector<size_t>> & internal_sizes,
-      const common::s3::Credentials & credentials);
+      const common::s3::Credentials & credentials,
+      bool cuda = false);
 
     // return when there is a ready chunk
     // returns common::ResponseCode::FinishedError if no responses are expected

--- a/cpp/streamer/streamer.cc
+++ b/cpp/streamer/streamer.cc
@@ -85,7 +85,8 @@ _RUNAI_EXTERN_C int runai_request(
     const char * secret,
     const char * token,
     const char * region,
-    const char * endpoint
+    const char * endpoint,
+    int cuda
 )
 {
     try
@@ -111,7 +112,7 @@ _RUNAI_EXTERN_C int runai_request(
             internal_sizes_vv[i] = std::vector<size_t>(internal_sizes_v[i], internal_sizes_v[i] + num_sizes_v[i]);
         }
 
-        return static_cast<int>(s->async_request(paths_v, file_offsets_v, bytesizes_v, dsts_v, num_sizes_v, internal_sizes_vv, credentials));
+        return static_cast<int>(s->async_request(paths_v, file_offsets_v, bytesizes_v, dsts_v, num_sizes_v, internal_sizes_vv, credentials, cuda != 0));
     }
     catch(...)
     {

--- a/cpp/streamer/streamer.h
+++ b/cpp/streamer/streamer.h
@@ -51,7 +51,8 @@ _RUNAI_EXTERN_C int runai_request(
     const char * secret,
     const char * token,
     const char * region,
-    const char * endpoint
+    const char * endpoint,
+    int cuda  /* 0 = read to CPU host memory (dsts), non-zero = read to CUDA device memory (dsts) */
 );
 
 _RUNAI_EXTERN_C int runai_response(void * streamer, unsigned * file_index /* return parameter */, unsigned * index /* return parameter */);

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -136,7 +136,8 @@ TEST_F(StreamerTest, Async_Read)
                         credentials_c.secret_access_key,
                         credentials_c.session_token,
                         credentials_c.region,
-                        credentials_c.endpoint);
+                        credentials_c.endpoint,
+                             0);
     }
     else
     {
@@ -152,7 +153,8 @@ TEST_F(StreamerTest, Async_Read)
                         nullptr,
                         nullptr,
                         nullptr,
-                        nullptr);
+                        nullptr,
+                         0);
     }
 
     EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
@@ -211,7 +213,8 @@ TEST_F(StreamerTest, Increase_Insufficient_Fd_Limit)
                             credentials_c.secret_access_key,
                             credentials_c.session_token,
                             credentials_c.region,
-                            credentials_c.endpoint);
+                            credentials_c.endpoint,
+                             0);
         }
         else
         {
@@ -227,7 +230,8 @@ TEST_F(StreamerTest, Increase_Insufficient_Fd_Limit)
                             nullptr,
                             nullptr,
                             nullptr,
-                            nullptr);
+                            nullptr,
+                             0);
         }
         EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
 
@@ -271,7 +275,8 @@ TEST_F(StreamerTest, Stop_Before_Async_Read)
                             credentials_c.secret_access_key,
                             credentials_c.session_token,
                             credentials_c.region,
-                            credentials_c.endpoint);
+                            credentials_c.endpoint,
+                             0);
         }
         else
         {
@@ -287,7 +292,8 @@ TEST_F(StreamerTest, Stop_Before_Async_Read)
                             nullptr,
                             nullptr,
                             nullptr,
-                            nullptr);
+                            nullptr,
+                             0);
         }
 
         // request was not sent to the S3 server
@@ -335,7 +341,8 @@ TEST_F(StreamerTest, End_During_Async_Read)
                             credentials_c.secret_access_key,
                             credentials_c.session_token,
                             credentials_c.region,
-                            credentials_c.endpoint);
+                            credentials_c.endpoint,
+                             0);
         }
         else
         {
@@ -351,7 +358,8 @@ TEST_F(StreamerTest, End_During_Async_Read)
                             nullptr,
                             nullptr,
                             nullptr,
-                            nullptr);
+                            nullptr,
+                             0);
         }
 
         ::usleep(utils::random::number(300));
@@ -386,7 +394,8 @@ TEST_F(StreamerTest, Multiple_Files)
                              credentials_c.secret_access_key,
                              credentials_c.session_token,
                              credentials_c.region,
-                             credentials_c.endpoint);
+                             credentials_c.endpoint,
+                             0);
 
     EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
 
@@ -438,7 +447,8 @@ TEST_F(StreamerTest, Multiple_Files_Error)
                              credentials_c.secret_access_key,
                              credentials_c.session_token,
                              credentials_c.region,
-                             credentials_c.endpoint);
+                             credentials_c.endpoint,
+                             0);
 
     EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
 

--- a/cpp/streamer/streamer_test.cc
+++ b/cpp/streamer/streamer_test.cc
@@ -38,7 +38,7 @@ struct StreamerTest : ::testing::Test
         internal_sizes.push_back(sizes.data());
         std::vector<unsigned> num_sizes;
         num_sizes.push_back(1);
-        return runai::llm::streamer::runai_request(streamer, 1, &path, &offset, &size, &dst, num_sizes.data(), internal_sizes.data(), nullptr, nullptr, nullptr, nullptr, nullptr);
+        return runai::llm::streamer::runai_request(streamer, 1, &path, &offset, &size, &dst, num_sizes.data(), internal_sizes.data(), nullptr, nullptr, nullptr, nullptr, nullptr, 0);
     }
 
     int runai_read_file(void * streamer, const char * path, size_t offset, size_t size, void * dst)
@@ -49,7 +49,7 @@ struct StreamerTest : ::testing::Test
         internal_sizes.push_back(sizes.data());
         std::vector<unsigned> num_sizes;
         num_sizes.push_back(1);
-        auto res = runai::llm::streamer::runai_request(streamer, 1, &path, &offset, &size, &dst, num_sizes.data(), internal_sizes.data(), nullptr, nullptr, nullptr, nullptr, nullptr);
+        auto res = runai::llm::streamer::runai_request(streamer, 1, &path, &offset, &size, &dst, num_sizes.data(), internal_sizes.data(), nullptr, nullptr, nullptr, nullptr, nullptr, 0);
         if (res != static_cast<int>(runai::llm::streamer::common::ResponseCode::Success))
         {
             return res;
@@ -368,7 +368,7 @@ TEST_F(StreamerTest, Multiple_Files)
     auto res = runai_start(&streamer);
     EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
 
-    EXPECT_EQ(runai_request(streamer, num_files, file_paths.data(), file_offsets.data(), sizes.data(), dsts.data(), num_ranges.data(), internal_sizes.data(), nullptr, nullptr, nullptr, nullptr, nullptr), static_cast<int>(common::ResponseCode::Success));
+    EXPECT_EQ(runai_request(streamer, num_files, file_paths.data(), file_offsets.data(), sizes.data(), dsts.data(), num_ranges.data(), internal_sizes.data(), nullptr, nullptr, nullptr, nullptr, nullptr, 0), static_cast<int>(common::ResponseCode::Success));
 
     // wait for all the responses to arrive
     unsigned r;

--- a/cpp/third_party/cuda.BUILD
+++ b/cpp/third_party/cuda.BUILD
@@ -1,0 +1,15 @@
+# Headers-only target for the CUDA driver API.
+# Provides cuda.h and related headers for compile-time type checking.
+# The actual libcuda.so is NOT linked here — it is loaded at runtime via dlopen,
+# so the built binary has no hard dependency on any specific CUDA version.
+cc_library(
+    name = "cuda_headers",
+    hdrs = glob([
+        "include/cuda.h",
+        "include/cuda_runtime.h",
+        "include/driver_types.h",
+        "include/vector_types.h",
+    ], allow_empty = True),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -234,6 +234,7 @@ class _distributedStreamer:
     def __init__(self, file_streamer : FileStreamer) -> None:
         self.file_streamer = file_streamer
         self.device = None
+        self._device_str = None
         self.partitions = {} # partitions of all the input file_stream_requests
         self.rank_file_chunks_list = {} # post Partitioning FileChunks to be streamed by this rank
         self.rank_dicts_map = {} # maps post partitioning FileChunks.id and chunk index to the original FileChunks.id and chunk index and chunk size
@@ -327,6 +328,7 @@ class _distributedStreamer:
     ) -> None:
 
         self.device = torch.device(device)
+        self._device_str = device
         self.my_global_rank = params.my_global_rank
         self.groups_by_ranks = params.groups_by_ranks
         self.broadcast_timeout = params.broadcast_timeout
@@ -365,14 +367,19 @@ class _distributedStreamer:
             return
 
         # read files
+        # For NVIDIA CUDA with local filesystem, stream directly to GPU via read_cuda
+        # (cuMemcpyHtoDAsync). Otherwise fall back to CPU.
+        read_device = device if self._use_cuda_direct() else "cpu"
         original_memory_limit = os.environ.get("RUNAI_STREAMER_MEMORY_LIMIT")
         try:
-            # for distributed streaming only - change default memory limit to unlimited
+            # Change default memory limit to unlimited so the file_streamer reads as
+            # much as possible in one pass. For CUDA, with_memory_cap caps the buffer
+            # at free GPU memory automatically, preventing OOM.
             if self.original_group_rank == 0:
-                logger.debug(f"[RunAI Streamer][Distributed] Setting memory limit to unlimited")
-            if original_memory_limit == None:
+                logger.debug(f"[RunAI Streamer][Distributed] Setting memory limit to unlimited, read device: {read_device}")
+            if original_memory_limit is None:
                 os.environ["RUNAI_STREAMER_MEMORY_LIMIT"] = "-1"
-            self.file_streamer.stream_files(self.rank_file_chunks_list, credentials, "cpu")
+            self.file_streamer.stream_files(self.rank_file_chunks_list, credentials, read_device)
         except Exception as e:
             raise e
         finally:
@@ -385,7 +392,11 @@ class _distributedStreamer:
     def get_chunks(self) -> Iterator:
         if not self.file_streamer:
             raise ValueError("Streamer not initialized")
-        
+
+        if self._use_cuda_direct():
+            yield from self._get_chunks_cuda()
+            return
+
         MAX_CHUNKS_PER_BATCH = 256
         DEFAULT_BUFFER_MIN_BYTESIZE = 1024 * 1024 * 1024
         BUFFER_MIN_BYTESIZE = int(os.environ.get("RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE", str(DEFAULT_BUFFER_MIN_BYTESIZE))) # environment variable used for testing
@@ -443,6 +454,164 @@ class _distributedStreamer:
                
         except RuntimeError as e:
             # Check if the error is a timeout
+            self.is_error = True
+            if "timed out" in str(e).lower() or "timeout" in str(e).lower():
+                logger.exception(f"[RunAI Streamer][Distributed] Rank {self.original_group_rank}: broadcast timed out - Could not complete broadcast.")
+            else:
+                logger.exception(f"[RunAI Streamer][Distributed] rank {self.original_group_rank} error: {e}")
+            raise e
+        except Exception as e:
+            self.is_error = True
+            logger.exception(f"[RunAI Streamer][Distributed] rank {self.original_group_rank} error: {e}")
+            raise e
+
+    def _all_paths_local(self) -> bool:
+        remote_prefixes = ("s3://", "gs://", "az://")
+        return all(
+            not fc.path.startswith(remote_prefixes)
+            for fc in self.rank_file_chunks_list
+        )
+
+    def _use_cuda_direct(self) -> bool:
+        return (
+            self._device_str is not None
+            and self._device_str.startswith("cuda")
+            and torch.version.hip is None
+            and torch.cuda.is_available()
+            and self._all_paths_local()
+        )
+
+    def _get_chunks_cuda(self) -> Iterator:
+        alignment = get_cuda_alignment()
+
+        # Receive buffer sized to hold one tensor at a time.
+        max_chunk = max(self.max_chunk, 1)
+        extra = alignment - 1 if alignment > 1 else 0
+        receive_buffer_raw = torch.empty(max_chunk + extra, dtype=torch.uint8, device=self.device)
+        if alignment > 1:
+            aligned_start = (-receive_buffer_raw.data_ptr()) % alignment
+            receive_buffer = receive_buffer_raw[aligned_start : aligned_start + max_chunk]
+        else:
+            receive_buffer = receive_buffer_raw
+
+        # Two-row metadata tensor: row 0 = [count, 0, 0, 0],
+        # row 1 = [orig_req_idx, orig_chunk_idx, size, 0]
+        batch_metadata_tensor = torch.zeros(2, 4, dtype=torch.int64, device=self.device)
+        received_metadata_tensor = torch.zeros(2, 4, dtype=torch.int64, device=self.device)
+
+        chunks_to_read = [self.total_chunks_to_read]
+
+        ready_chunks_iterator = self.file_streamer.get_chunks()
+
+        def chunk_generator():
+            yield from ready_chunks_iterator
+            while True:
+                yield None
+
+        chunk_gen = chunk_generator()
+
+        total_meta_bcast_time = 0.0
+        total_data_bcast_time = 0.0
+        total_sync_time = 0.0
+        total_read_time = 0.0
+        total_inter_yield_time = 0.0
+        max_inter_yield_time = 0.0
+        total_meta_item_time = 0.0
+
+        try:
+            while chunks_to_read[0] > 0:
+                total_broadcast_chunks = 0
+
+                for broadcasting_rank in range(self.group_size):
+                    global_broadcasting_rank = self.local_group_global_ranks[broadcasting_rank]
+
+                    if global_broadcasting_rank == self.original_group_rank:
+                        t0 = timer()
+                        chunk_item = next(chunk_gen) if self.reading_from_storage else None
+                        total_read_time += timer() - t0
+
+                        if chunk_item is not None:
+                            ready_request_id, ready_chunk_index, gpu_tensor = chunk_item
+                            orig_req_idx, orig_chunk_idx, _ = self.rank_dicts_map[ready_request_id][ready_chunk_index]
+                            chunk_size = gpu_tensor.numel()
+                            batch_metadata_tensor[0, 0] = 1
+                            batch_metadata_tensor[1, 0] = orig_req_idx
+                            batch_metadata_tensor[1, 1] = orig_chunk_idx
+                            batch_metadata_tensor[1, 2] = chunk_size
+                        else:
+                            batch_metadata_tensor[0, 0] = 0
+
+                        t0 = timer()
+                        dist.broadcast(batch_metadata_tensor, global_broadcasting_rank, group=self.distribution_group)
+                        total_meta_bcast_time += timer() - t0
+
+                        t0 = timer()
+                        count = batch_metadata_tensor[0, 0].item()
+                        total_meta_item_time += timer() - t0
+                        if count > 0:
+                            logger.debug(f"[RunAI Streamer][Distributed] Rank {self.original_group_rank}: Broadcasting tensor {orig_req_idx}:{orig_chunk_idx} size {humanize.naturalsize(chunk_size)}")
+                            t0 = timer()
+                            dist.broadcast(gpu_tensor, global_broadcasting_rank, group=self.distribution_group)
+                            total_data_bcast_time += timer() - t0
+                            chunks_to_read[0] -= 1
+                            total_broadcast_chunks += 1
+                            _t_yield = timer()
+                            yield orig_req_idx, orig_chunk_idx, gpu_tensor
+                            _dt = timer() - _t_yield
+                            total_inter_yield_time += _dt
+                            max_inter_yield_time = max(max_inter_yield_time, _dt)
+                        else:
+                            logger.debug(f"[RunAI Streamer][Distributed] Rank {self.original_group_rank}: No more tensors to broadcast")
+
+                    else:
+                        t0 = timer()
+                        dist.broadcast(received_metadata_tensor, global_broadcasting_rank, group=self.distribution_group)
+                        total_meta_bcast_time += timer() - t0
+
+                        t0 = timer()
+                        count = received_metadata_tensor[0, 0].item()
+                        total_meta_item_time += timer() - t0
+                        if count == 0:
+                            logger.debug(f"[RunAI Streamer][Distributed] Rank {self.original_group_rank}: No tensors from rank {global_broadcasting_rank}")
+                            continue
+
+                        orig_req_idx = received_metadata_tensor[1, 0].item()
+                        orig_chunk_idx = received_metadata_tensor[1, 1].item()
+                        chunk_size = received_metadata_tensor[1, 2].item()
+
+                        logger.debug(f"[RunAI Streamer][Distributed] Rank {self.original_group_rank}: Receiving tensor {orig_req_idx}:{orig_chunk_idx} size {humanize.naturalsize(chunk_size)} from rank {global_broadcasting_rank}")
+
+                        received_view = receive_buffer[:chunk_size]
+                        t0 = timer()
+                        torch.cuda.synchronize()
+                        total_sync_time += timer() - t0
+                        t0 = timer()
+                        dist.broadcast(received_view, global_broadcasting_rank, group=self.distribution_group)
+                        total_data_bcast_time += timer() - t0
+                        chunks_to_read[0] -= 1
+                        total_broadcast_chunks += 1
+                        _t_yield = timer()
+                        yield orig_req_idx, orig_chunk_idx, received_view
+                        _dt = timer() - _t_yield
+                        total_inter_yield_time += _dt
+                        max_inter_yield_time = max(max_inter_yield_time, _dt)
+
+                if total_broadcast_chunks == 0 and chunks_to_read[0] > 0:
+                    logger.error(f"[RunAI Streamer][Distributed] Error: rank {self.rank} is missing {chunks_to_read[0]} chunks")
+                    raise RuntimeError("No chunks to read")
+
+            logger.info(
+                f"[RunAI Streamer][Distributed] Rank {self.original_group_rank} CUDA timing: "
+                f"read={total_read_time:.3f}s  "
+                f"meta_bcast={total_meta_bcast_time:.3f}s  "
+                f"meta_item={total_meta_item_time:.3f}s  "
+                f"data_bcast={total_data_bcast_time:.3f}s  "
+                f"sync={total_sync_time:.3f}s  "
+                f"inter_yield={total_inter_yield_time:.3f}s  "
+                f"max_inter_yield={max_inter_yield_time:.3f}s"
+            )
+
+        except RuntimeError as e:
             self.is_error = True
             if "timed out" in str(e).lower() or "timeout" in str(e).lower():
                 logger.exception(f"[RunAI Streamer][Distributed] Rank {self.original_group_rank}: broadcast timed out - Could not complete broadcast.")

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -581,6 +581,10 @@ class _distributedStreamer:
 
                         logger.debug(f"[RunAI Streamer][Distributed] Rank {self.original_group_rank}: Receiving tensor {orig_req_idx}:{orig_chunk_idx} size {humanize.naturalsize(chunk_size)} from rank {global_broadcasting_rank}")
 
+                        # receive_buffer is 1-D (shape (max_chunk,)) while the broadcasting rank's
+                        # gpu_tensor has shape (1, N). dist.broadcast does not enforce shape equality —
+                        # it only requires the same numel() and dtype, operating on flat byte buffers
+                        # under the hood. Both sides have chunk_size uint8 elements, so this is correct.
                         received_view = receive_buffer[:chunk_size]
                         t0 = timer()
                         torch.cuda.synchronize()

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -11,6 +11,8 @@ from runai_model_streamer.file_streamer import (
     FileChunks,
 )
 
+from runai_model_streamer.file_streamer.requests_iterator import get_cuda_alignment
+
 from runai_model_streamer.distributed_streamer.partition import (
     partition,
     get_total_number_of_chunks,
@@ -28,20 +30,6 @@ import logging
 import humanize
 
 logger = logging.getLogger(__name__)
-
-RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR = "RUNAI_STREAMER_CUDA_ALIGNMENT"
-DEFAULT_DIST_BUFFER_ALIGNMENT = 512
-MAX_DIST_BUFFER_ALIGNMENT = 1024 * 1024
-
-
-def get_dist_buffer_alignment() -> int:
-    """
-    Get the alignment for the distributed buffer.
-    """
-    value = int(os.environ.get(RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR, str(DEFAULT_DIST_BUFFER_ALIGNMENT)))
-    if value < 0 or value > MAX_DIST_BUFFER_ALIGNMENT:
-        raise ValueError(f"Invalid value for RUNAI_STREAMER_CUDA_ALIGNMENT: {value}, must be between 0 and {MAX_DIST_BUFFER_ALIGNMENT} bytes")
-    return value
 
 
 def aligned_offset(base_ptr: int, current_offset: int, alignment: int) -> int:
@@ -402,7 +390,7 @@ class _distributedStreamer:
         DEFAULT_BUFFER_MIN_BYTESIZE = 1024 * 1024 * 1024
         BUFFER_MIN_BYTESIZE = int(os.environ.get("RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE", str(DEFAULT_BUFFER_MIN_BYTESIZE))) # environment variable used for testing
         BUFFER_BYTESIZE = max(BUFFER_MIN_BYTESIZE, self.max_chunk)
-        alignment = get_dist_buffer_alignment()
+        alignment = get_cuda_alignment()
 
         # Over-allocate by alignment so we can slice to the first aligned address within each buffer.
         # This guarantees data_buffer.data_ptr() % alignment == 0 and

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/dist_test_distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/dist_test_distributed_streamer.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import ctypes
 import torch
 import torch.distributed as dist
 from typing import List
@@ -12,6 +13,8 @@ from unittest.mock import patch
 
 from runai_model_streamer.distributed_streamer.distributed_streamer import (
     DistributedStreamer,
+)
+from runai_model_streamer.file_streamer.requests_iterator import (
     RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR,
 )
 from runai_model_streamer.file_streamer import FileChunks
@@ -268,6 +271,177 @@ class TestDistributedStreamer(unittest.TestCase):
                 f"Rank {self.rank} caught an unexpected error: '{context.exception}'"
             )
             print(f"Rank {self.rank}: Correctly caught expected timeout exception.")
+
+    def _load_cuda_mock(self):
+        """Load libcuda.so.1 and return it if it is the test mock (has call counter).
+
+        Returns None if libcuda.so.1 is not found or is the real CUDA driver
+        (which does not export get_cuMemcpyHtoDAsync_call_count).  Tests that
+        call this helper must skip when it returns None.
+        """
+        try:
+            lib = ctypes.CDLL("libcuda.so.1")
+            lib.get_cuMemcpyHtoDAsync_call_count.restype = ctypes.c_int
+            # Accessing the symbol raises AttributeError on real libcuda.so.1
+            _ = lib.reset_cuMemcpyHtoDAsync_call_count
+            return lib
+        except Exception:
+            return None
+
+    def _wrap_get_chunks_as_tensors(self, streamer):
+        """Wrap file_streamer.get_chunks to convert numpy slices to CPU torch tensors.
+
+        When _use_cuda_direct is mocked, the file_streamer reads to a CPU numpy
+        buffer (device="cpu"), but _get_chunks_cuda expects torch.Tensors so it
+        can call .numel() and pass them to dist.broadcast.  This wrapper sits
+        between the two without touching any production code.
+        """
+        orig_get_chunks = streamer.distributed_streamer.file_streamer.get_chunks
+        def _tensor_get_chunks():
+            for req_id, chunk_idx, chunk in orig_get_chunks():
+                if not isinstance(chunk, torch.Tensor):
+                    chunk = torch.as_tensor(chunk)
+                yield req_id, chunk_idx, chunk
+        streamer.distributed_streamer.file_streamer.get_chunks = _tensor_get_chunks
+
+    def test_1_success_cuda_direct_data_correctness(self):
+        """Test _get_chunks_cuda tensor-by-tensor broadcast with fixed file specs.
+
+        Mocks _use_cuda_direct to force the CUDA direct path and patches
+        torch.cuda.synchronize so the test runs without GPU hardware.
+        Uses CPU tensors throughout; data correctness is verified end-to-end.
+        """
+        file_specs = [{"size": 2580, "chunks": [500, 260, 260, 260, 260, 260, 260, 260, 260]}]
+        requests = self._prepare_file_requests(file_specs)
+        original_data_map = {}
+        for req in requests:
+            with open(req.path, "rb") as f:
+                original_data_map[req.id] = f.read()
+
+        reconstructed_data_map = {req.id: [None] * len(req.chunks) for req in requests}
+        env_vars = {"RUNAI_STREAMER_DIST": "1", "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0"}
+        with patch.dict(os.environ, env_vars), \
+             patch("runai_model_streamer.distributed_streamer.distributed_streamer._distributedStreamer._use_cuda_direct", return_value=True), \
+             patch("torch.cuda.synchronize"):
+            with DistributedStreamer() as streamer:
+                streamer.stream_files(requests, None, "cpu", True)
+                self._wrap_get_chunks_as_tensors(streamer)
+                for req_id, chunk_idx, data_tensor in streamer.get_chunks():
+                    reconstructed_data_map[req_id][chunk_idx] = data_tensor.cpu().numpy().tobytes()
+
+        for req in requests:
+            reconstructed_bytes = b"".join(reconstructed_data_map[req.id])
+            self.assertEqual(original_data_map[req.id], reconstructed_bytes)
+
+        if self.rank == 0:
+            print(f"\n✅ CUDA direct data correctness test verified on all {self.world_size} ranks.")
+
+    def test_1_success_cuda_direct_random_files(self):
+        """Test _get_chunks_cuda tensor-by-tensor broadcast with random file/chunk sizes."""
+        num_files = random.randint(1, 10)
+        file_specs = []
+        for _ in range(num_files):
+            total_size = random.randint(1, 1 * 1024 * 1024)
+            chunks = []
+            remaining = total_size
+            while remaining > 0:
+                chunk = random.randint(1, min(remaining, 256 * 1024))
+                chunks.append(chunk)
+                remaining -= chunk
+            file_specs.append({"size": total_size, "chunks": chunks})
+
+        requests = self._prepare_file_requests(file_specs)
+        original_data_map = {}
+        for req in requests:
+            with open(req.path, "rb") as f:
+                original_data_map[req.id] = f.read()
+
+        reconstructed_data_map = {req.id: [None] * len(req.chunks) for req in requests}
+        env_vars = {"RUNAI_STREAMER_DIST": "1", "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0"}
+        with patch.dict(os.environ, env_vars), \
+             patch("runai_model_streamer.distributed_streamer.distributed_streamer._distributedStreamer._use_cuda_direct", return_value=True), \
+             patch("torch.cuda.synchronize"):
+            with DistributedStreamer() as streamer:
+                streamer.stream_files(requests, None, "cpu", True)
+                self._wrap_get_chunks_as_tensors(streamer)
+                for req_id, chunk_idx, data_tensor in streamer.get_chunks():
+                    reconstructed_data_map[req_id][chunk_idx] = data_tensor.cpu().numpy().tobytes()
+
+        for req in requests:
+            reconstructed_bytes = b"".join(reconstructed_data_map[req.id])
+            self.assertEqual(original_data_map[req.id], reconstructed_bytes)
+
+        if self.rank == 0:
+            print(f"\n✅ CUDA direct random files test verified on all {self.world_size} ranks.")
+
+    def test_1_success_cuda_direct_verifies_mock(self):
+        """Verify that the CUDA direct path actually calls cuMemcpyHtoDAsync.
+
+        Loads libcuda.so.1 via ctypes and checks the call counter exported by
+        the mock.  Skips automatically when the mock is not in LD_LIBRARY_PATH
+        (real GPU machine or no mock built) — identical skip logic to
+        ReadCuda/Sanity in batch_cuda_test.cc.
+
+        torch.empty is redirected to CPU so no real GPU is needed; data
+        correctness is verified end-to-end alongside the counter check.
+        """
+        if self.world_size < 2:
+            self.skipTest("Distributed CUDA direct test requires at least 2 processes.")
+
+        cuda_mock = self._load_cuda_mock()
+        if cuda_mock is None:
+            self.skipTest("Mock libcuda.so.1 not available — set LD_LIBRARY_PATH to the mock build directory.")
+
+        file_specs = [{"size": 2580, "chunks": [500, 260, 260, 260, 260, 260, 260, 260, 260]}]
+        requests = self._prepare_file_requests(file_specs)
+        original_data_map = {}
+        for req in requests:
+            with open(req.path, "rb") as f:
+                original_data_map[req.id] = f.read()
+
+        cuda_mock.reset_cuMemcpyHtoDAsync_call_count()
+
+        # Redirect torch.empty(device="cuda:X") to CPU so tests run without a GPU.
+        _orig_empty = torch.empty
+        def _cpu_empty(*args, **kwargs):
+            if str(kwargs.get("device", "")).startswith("cuda"):
+                kwargs = {**kwargs, "device": "cpu"}
+            return _orig_empty(*args, **kwargs)
+
+        reconstructed_data_map = {req.id: [None] * len(req.chunks) for req in requests}
+        env_vars = {"RUNAI_STREAMER_DIST": "1", "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0"}
+        with patch.dict(os.environ, env_vars), \
+             patch("torch.cuda.is_available", return_value=True), \
+             patch("torch.empty", side_effect=_cpu_empty), \
+             patch("torch.cuda.mem_get_info", return_value=(2**33, 2**33)), \
+             patch("torch.cuda.synchronize"):
+            with DistributedStreamer() as streamer:
+                # Bypass the gloo+non-cpu backend check in set_is_distributed so
+                # distributed streaming is active even with device="cuda:0".
+                def _force_distributed(is_distributed, device):
+                    streamer.is_distributed = (
+                        is_distributed
+                        and dist.is_initialized()
+                        and dist.get_world_size() > 1
+                    )
+                with patch.object(streamer, "set_is_distributed", side_effect=_force_distributed):
+                    streamer.stream_files(requests, None, "cuda:0", True)
+                for req_id, chunk_idx, data_tensor in streamer.get_chunks():
+                    reconstructed_data_map[req_id][chunk_idx] = data_tensor.cpu().numpy().tobytes()
+
+        call_count = cuda_mock.get_cuMemcpyHtoDAsync_call_count()
+        self.assertGreater(
+            call_count, 0,
+            f"Rank {self.rank}: expected cuMemcpyHtoDAsync to be called but count was {call_count}"
+        )
+
+        for req in requests:
+            reconstructed_bytes = b"".join(reconstructed_data_map[req.id])
+            self.assertEqual(original_data_map[req.id], reconstructed_bytes)
+
+        if self.rank == 0:
+            print(f"\n✅ CUDA mock verified: cuMemcpyHtoDAsync called {call_count} times, data correct on all {self.world_size} ranks.")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -124,6 +124,7 @@ class FileStreamer:
             [file_request.chunks for file_request in self.active_request.files],
             self.s3_credentials,
             cuda=self._is_nvidia_cuda,
+            cuda_tensor_ptrs=self.requests_iterator.cuda_tensor_ptrs if self._is_nvidia_cuda else None,
         )
 
     def get_chunks(self) -> Iterator:
@@ -166,6 +167,7 @@ class FileStreamer:
                     [file_request.chunks for file_request in self.active_request.files],
                     self.s3_credentials,
                     cuda=True,
+                    cuda_tensor_ptrs=self.requests_iterator.cuda_tensor_ptrs,
                 )
 
     def _get_chunks_cpu(self) -> Iterator:

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List, Tuple, Optional
 from collections import deque
+import ctypes
 import enum
 import numpy as np
 import os
@@ -14,6 +15,19 @@ logger = logging.getLogger(__name__)
 RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME = "RUNAI_STREAMER_MEMORY_LIMIT"
 DEFAULT_MEMORY_LIMIT_STRING = "40000000000" # 40 GB (to be set to unlimited for distributed streaming)
 
+RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR = "RUNAI_STREAMER_CUDA_ALIGNMENT"
+DEFAULT_CUDA_ALIGNMENT = 256
+
+def align_up(size: int, alignment: int) -> int:
+    if alignment <= 1:
+        return size
+    return ((size + alignment - 1) // alignment) * alignment
+
+def get_cuda_alignment() -> int:
+    """Return the CUDA buffer alignment in bytes (default 256). Set to 0 or 1 to disable."""
+    val = int(os.getenv(RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR, str(DEFAULT_CUDA_ALIGNMENT)))
+    return val if val > 1 else 1
+
 class RunaiStreamerMemoryLimitException(Exception):
     pass
 
@@ -24,11 +38,19 @@ class MemoryCapMode(enum.Enum):
     largest_chunk = 3
 
 class FileChunks:
-    def __init__(self, id: int, path: str, offset: int, chunks: List[int]) -> None:
+    def __init__(self, id: int, path: str, offset: int, chunks: List[int],
+                 buffer_strides: Optional[List[int]] = None) -> None:
         self.id = id # the id of the file chunk must be unique in the context of a single stream_files request
         self.path = path
         self.offset = offset
         self.chunks = chunks
+        # buffer_strides: padded sizes for each chunk in the GPU buffer.
+        # When None, effective_strides == chunks (no padding, backward-compatible).
+        self.buffer_strides = buffer_strides
+
+    @property
+    def effective_strides(self) -> List[int]:
+        return self.buffer_strides if self.buffer_strides is not None else self.chunks
 
     def total_size(self) -> int:
         return sum(self.chunks)
@@ -63,7 +85,16 @@ class FilesRequestsIteratorWithBuffer:
         if self._is_nvidia_cuda:
             # CUDA device buffer: C++ writes directly via cuMemcpyHtoDAsync using
             # an internal thread-local pinned staging buffer (2 MB per worker).
-            self.buffer = torch.empty(buffer_size, dtype=torch.uint8, device=device)
+            # Over-allocate by (alignment - 1) bytes so we can slice to an aligned
+            # start address, guaranteeing that every per-tensor offset (which is a
+            # multiple of `alignment`) also lands on an aligned address.
+            alignment = get_cuda_alignment()
+            if alignment > 1:
+                _raw = torch.empty(buffer_size + alignment - 1, dtype=torch.uint8, device=device)
+                aligned_start = (-_raw.data_ptr()) % alignment
+                self.buffer = _raw[aligned_start : aligned_start + buffer_size]
+            else:
+                self.buffer = torch.empty(buffer_size, dtype=torch.uint8, device=device)
             logger.debug(
                 f"[RunAI Streamer] CUDA buffer size: {humanize.naturalsize(buffer_size, binary=True)} "
                 f"on {device} for files: {[fc.path for fc in files_chunks]}"
@@ -76,15 +107,20 @@ class FilesRequestsIteratorWithBuffer:
                 f"for files: {[fc.path for fc in files_chunks]}"
             )
         self.file_buffers: List = []
+        # Flat list of per-tensor aligned GPU ctypes pointers (CUDA only).
+        self.cuda_tensor_ptrs: List[ctypes.c_void_p] = []
 
     def get_global_file_and_chunk(self, local_file_index: int, local_chunk_index: int) -> Tuple:
         file_id, global_chunk_index = self.files_requests_iterator.get_global_file_and_chunk(
             local_file_index, local_chunk_index
         )
-        file_active_chunks = self.files_requests_iterator.active_request.files[local_file_index].chunks
-        chunk_offset_start = sum(file_active_chunks[:local_chunk_index])
-        chunk_offset_end = chunk_offset_start + file_active_chunks[local_chunk_index]
-        return file_id, global_chunk_index, self.file_buffers[local_file_index][chunk_offset_start:chunk_offset_end]
+        active_file = self.files_requests_iterator.active_request.files[local_file_index]
+        # Use padded strides to compute where in the buffer this tensor starts,
+        # but return only the actual (unpadded) tensor bytes.
+        strides = active_file.effective_strides
+        padded_offset = sum(strides[:local_chunk_index])
+        actual_size = active_file.chunks[local_chunk_index]
+        return file_id, global_chunk_index, self.file_buffers[local_file_index][padded_offset:padded_offset + actual_size]
 
     def next_request(self) -> Optional[FilesRequest]:
         next_requests = self.files_requests_iterator.next_request()
@@ -92,11 +128,20 @@ class FilesRequestsIteratorWithBuffer:
             return None
 
         self.file_buffers = []
+        self.cuda_tensor_ptrs = []
         global_buffer_offset = 0
         for file_request in next_requests.files:
-            chunks_size = sum(file_request.chunks)
-            self.file_buffers.append(self.buffer[global_buffer_offset: global_buffer_offset + chunks_size])
-            global_buffer_offset += chunks_size
+            # Use padded strides to determine how much buffer space this file occupies.
+            padded_total = sum(file_request.effective_strides)
+            self.file_buffers.append(self.buffer[global_buffer_offset: global_buffer_offset + padded_total])
+            if self._is_nvidia_cuda:
+                # Build a per-tensor GPU pointer list for this file.
+                tensor_offset = 0
+                for stride in file_request.effective_strides:
+                    ptr = ctypes.c_void_p(self.buffer.data_ptr() + global_buffer_offset + tensor_offset)
+                    self.cuda_tensor_ptrs.append(ptr)
+                    tensor_offset += stride
+            global_buffer_offset += padded_total
 
         return next_requests
 
@@ -109,7 +154,8 @@ class FilesRequestsIteratorWithBuffer:
     ) -> FilesRequestsIteratorWithBuffer:
         memory_limit = 0
         if memory_mode == MemoryCapMode.unlimited:
-            total_size = sum(sum(file.chunks) for file in files_chunks)
+            # Use padded strides for the total size so the buffer is large enough.
+            total_size = sum(sum(file.effective_strides) for file in files_chunks)
             is_nvidia_cuda = (
                 device is not None
                 and device.startswith("cuda")
@@ -124,18 +170,18 @@ class FilesRequestsIteratorWithBuffer:
             else:
                 memory_limit = total_size
         elif memory_mode == MemoryCapMode.largest_chunk:
-            memory_limit = max(max(file_chunks.chunks) for file_chunks in files_chunks)
+            memory_limit = max(max(file_chunks.effective_strides) for file_chunks in files_chunks)
         elif memory_mode == MemoryCapMode.limited:
             if user_memory_limit is None:
                 raise RunaiStreamerMemoryLimitException(
                     f"MemoryCapMode is Limited, but no limit supplied"
                 )
-            largest_chunk = max((max(file_chunks.chunks, default=0) for file_chunks in files_chunks), default=0)
+            largest_chunk = max((max(file_chunks.effective_strides, default=0) for file_chunks in files_chunks), default=0)
             if user_memory_limit < largest_chunk:
                 raise RunaiStreamerMemoryLimitException(
                     f"Memory limit supplied: {user_memory_limit} cannot be smaller than: {largest_chunk}"
                 )
-            memory_limit = min(user_memory_limit, sum(sum(file.chunks) for file in files_chunks))
+            memory_limit = min(user_memory_limit, sum(sum(file.effective_strides) for file in files_chunks))
 
         return FilesRequestsIteratorWithBuffer(memory_limit, files_chunks, device=device)
 
@@ -159,7 +205,7 @@ class FilesRequestsIterator:
         self.memory_limit = memory_limit
         self.q = deque(FileChunksIterator(file_chunks)
             for file_chunks in files_chunks)
-        
+
         self.file_to_current_chunk_index = {}
         for file_chunks in files_chunks:
             self.file_to_current_chunk_index[file_chunks.id] = 0
@@ -173,11 +219,11 @@ class FilesRequestsIterator:
     def next_request(self) -> Optional[FilesRequest]:
         if not self.q:
             return None
-        
+
         if self.active_request is not None:
             for file_chunks in self.active_request.files:
                 self.file_to_current_chunk_index[file_chunks.id] += len(file_chunks.chunks)
-            
+
         files_request = FilesRequest()
         current_request_memory_size = 0
         while self.q:
@@ -187,12 +233,13 @@ class FilesRequestsIterator:
             )
             if file_chunks_iterator.is_finished():
                 self.q.popleft()
-            
+
             if len(file_chunks.chunks) == 0 or sum(file_chunks.chunks) == 0:
                 break
 
             files_request.append(file_chunks)
-            current_request_memory_size += sum(file_chunks.chunks)
+            # Account for padded buffer space in the memory limit.
+            current_request_memory_size += sum(file_chunks.effective_strides)
 
         if len(files_request.files) == 0:
             files_request = None
@@ -207,39 +254,53 @@ class FileChunksIterator:
         self.id = file_chunks.id
         self.path = file_chunks.path
         self.next_request_offset = file_chunks.offset
-        self.chunks_iterator = ChunksIterator(file_chunks.chunks)
+        self.chunks_iterator = ChunksIterator(file_chunks.chunks, file_chunks.effective_strides)
 
     def is_finished(self) -> bool:
         return self.chunks_iterator.is_finished()
 
     def next_chunks(self, size: int) -> FileChunks:
-        chunks = self.chunks_iterator.next_chunks(size)
+        chunks, strides = self.chunks_iterator.next_chunks(size)
         starting_offset = self.next_request_offset
         self.next_request_offset += sum(chunks)
-        return FileChunks(self.id, self.path, starting_offset, chunks)
+        # Preserve buffer_strides only when they differ from chunks.
+        buffer_strides = strides if strides != chunks else None
+        return FileChunks(self.id, self.path, starting_offset, chunks, buffer_strides)
 
 class ChunksIterator:
     def __init__(
-        self, chunks: List[int]
+        self, chunks: List[int], strides: Optional[List[int]] = None
     ) -> None:
         self.q = deque(chunks)
+        # strides_q holds the padded sizes used for memory-limit accounting.
+        # When strides equal chunks there is no padding and we use a single queue.
+        self.strides_q: Optional[deque] = (
+            deque(strides) if strides is not None and strides != chunks else None
+        )
 
     def is_finished(self) -> bool:
         return len(self.q) == 0
 
-    def next_chunks(self, size: int) -> List[int]:
+    def next_chunks(self, size: int) -> Tuple[List[int], List[int]]:
+        """Return (chunks, strides) that fit within `size` bytes of buffer space."""
         chunks = []
+        strides = []
         current_request_size = 0
 
         while not self.is_finished():
             candidate_chunk = self.q[0]
-            if current_request_size + candidate_chunk > size:
-                return chunks
+            candidate_stride = self.strides_q[0] if self.strides_q else candidate_chunk
+            if current_request_size + candidate_stride > size:
+                return chunks, strides
 
             chunks.append(self.q.popleft())
-            current_request_size += candidate_chunk
+            if self.strides_q:
+                strides.append(self.strides_q.popleft())
+            else:
+                strides.append(candidate_chunk)
+            current_request_size += candidate_stride
 
-        return chunks
+        return chunks, strides
 
 def _get_memory_mode(memory_limit: str | None) -> MemoryCapMode:
     if memory_limit == "-1":

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -124,11 +124,13 @@ class FilesRequestsIteratorWithBuffer:
         return file_id, global_chunk_index, self.file_buffers[local_file_index][padded_offset:padded_offset + actual_size]
 
     def next_request(self) -> Optional[FilesRequest]:
-        if self._is_nvidia_cuda:
+        if self._is_nvidia_cuda and self.file_buffers:
             # Buffer is on GPU: drain all CUDA streams before reusing it for new
             # writes. Guards against two classes of async operations still in flight:
             #   1. NCCL broadcasts reading from the yielded tensor slices.
             #   2. Async user-application ops (e.g. sharding) on those slices.
+            # Skipped on the first call (file_buffers is empty) since no GPU writes
+            # have occurred yet.
             _t0 = time.perf_counter()
             torch.cuda.synchronize()
             _sync_ms = (time.perf_counter() - _t0) * 1000

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -5,6 +5,7 @@ import ctypes
 import enum
 import numpy as np
 import os
+import time
 import humanize
 import torch
 
@@ -128,7 +129,6 @@ class FilesRequestsIteratorWithBuffer:
             # writes. Guards against two classes of async operations still in flight:
             #   1. NCCL broadcasts reading from the yielded tensor slices.
             #   2. Async user-application ops (e.g. sharding) on those slices.
-            import time
             _t0 = time.perf_counter()
             torch.cuda.synchronize()
             _sync_ms = (time.perf_counter() - _t0) * 1000

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -123,6 +123,17 @@ class FilesRequestsIteratorWithBuffer:
         return file_id, global_chunk_index, self.file_buffers[local_file_index][padded_offset:padded_offset + actual_size]
 
     def next_request(self) -> Optional[FilesRequest]:
+        if self._is_nvidia_cuda:
+            # Buffer is on GPU: drain all CUDA streams before reusing it for new
+            # writes. Guards against two classes of async operations still in flight:
+            #   1. NCCL broadcasts reading from the yielded tensor slices.
+            #   2. Async user-application ops (e.g. sharding) on those slices.
+            import time
+            _t0 = time.perf_counter()
+            torch.cuda.synchronize()
+            _sync_ms = (time.perf_counter() - _t0) * 1000
+            logger.info(f"[RunAI Streamer] cuda synchronize in next_request took {_sync_ms:.1f} ms")
+
         next_requests = self.files_requests_iterator.next_request()
         if next_requests is None or len(next_requests.files) == 0:
             return None
@@ -153,20 +164,22 @@ class FilesRequestsIteratorWithBuffer:
         device: str = "cpu",
     ) -> FilesRequestsIteratorWithBuffer:
         memory_limit = 0
+        is_nvidia_cuda = (
+            device is not None
+            and device.startswith("cuda")
+            and torch.version.hip is None
+        )
+        # Leave a 5% safety margin so PyTorch's allocator rounding doesn't cause OOM.
+        # mem_get_info returns physical free bytes, but torch.empty rounds up internally.
+        free_cuda_memory = int(torch.cuda.mem_get_info(device)[0] * 0.95) if (is_nvidia_cuda and torch.cuda.is_available()) else None
         if memory_mode == MemoryCapMode.unlimited:
             # Use padded strides for the total size so the buffer is large enough.
             total_size = sum(sum(file.effective_strides) for file in files_chunks)
-            is_nvidia_cuda = (
-                device is not None
-                and device.startswith("cuda")
-                and torch.version.hip is None
-            )
-            if is_nvidia_cuda and torch.cuda.is_available():
+            if free_cuda_memory is not None:
                 # For NVIDIA CUDA, cap the buffer at available GPU memory so that we
                 # don't OOM during allocation. If the model is larger than free VRAM,
                 # the buffer is reused in chunks just like the limited-memory path.
-                free_gpu, _ = torch.cuda.mem_get_info(device)
-                memory_limit = min(total_size, free_gpu)
+                memory_limit = min(total_size, free_cuda_memory)
             else:
                 memory_limit = total_size
         elif memory_mode == MemoryCapMode.largest_chunk:
@@ -182,6 +195,8 @@ class FilesRequestsIteratorWithBuffer:
                     f"Memory limit supplied: {user_memory_limit} cannot be smaller than: {largest_chunk}"
                 )
             memory_limit = min(user_memory_limit, sum(sum(file.effective_strides) for file in files_chunks))
+            if free_cuda_memory is not None:
+                memory_limit = min(memory_limit, free_cuda_memory)
 
         return FilesRequestsIteratorWithBuffer(memory_limit, files_chunks, device=device)
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -16,7 +16,7 @@ RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME = "RUNAI_STREAMER_MEMORY_LIMIT"
 DEFAULT_MEMORY_LIMIT_STRING = "40000000000" # 40 GB (to be set to unlimited for distributed streaming)
 
 RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR = "RUNAI_STREAMER_CUDA_ALIGNMENT"
-DEFAULT_CUDA_ALIGNMENT = 256
+DEFAULT_CUDA_ALIGNMENT = 512
 
 def align_up(size: int, alignment: int) -> int:
     if alignment <= 1:
@@ -24,7 +24,7 @@ def align_up(size: int, alignment: int) -> int:
     return ((size + alignment - 1) // alignment) * alignment
 
 def get_cuda_alignment() -> int:
-    """Return the CUDA buffer alignment in bytes (default 256). Set to 0 or 1 to disable."""
+    """Return the CUDA buffer alignment in bytes (default 512). Set to 0 or 1 to disable."""
     val = int(os.getenv(RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR, str(DEFAULT_CUDA_ALIGNMENT)))
     return val if val > 1 else 1
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -1,5 +1,10 @@
+import os
 import unittest
+from unittest.mock import patch
 from runai_model_streamer.file_streamer.requests_iterator import (
+    align_up,
+    get_cuda_alignment,
+    RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR,
     ChunksIterator,
     FileChunksIterator,
     FilesRequestsIterator,
@@ -12,44 +17,44 @@ class TestChunksIterator(unittest.TestCase):
     def test_next_request_exact_limit(self):
         chunks_iterator = ChunksIterator([1, 2, 3, 4])
 
-        chunks = chunks_iterator.next_chunks(6)
+        chunks, _ = chunks_iterator.next_chunks(6)
         self.assertFalse(chunks_iterator.is_finished())
         self.assertEqual(chunks, [1, 2, 3])
 
-        chunks = chunks_iterator.next_chunks(4)
+        chunks, _ = chunks_iterator.next_chunks(4)
         self.assertTrue(chunks_iterator.is_finished())
         self.assertEqual(chunks, [4])
 
     def test_next_request_high_limit(self):
         chunks_iterator = ChunksIterator([1, 2, 3, 4])
 
-        chunks = chunks_iterator.next_chunks(6)
+        chunks, _ = chunks_iterator.next_chunks(6)
         self.assertFalse(chunks_iterator.is_finished())
         self.assertEqual(chunks, [1, 2, 3])
-        
-        chunks = chunks_iterator.next_chunks(6)
+
+        chunks, _ = chunks_iterator.next_chunks(6)
         self.assertTrue(chunks_iterator.is_finished())
         self.assertEqual(chunks, [4])
 
     def test_next_request_low_limit(self):
         chunks_iterator = ChunksIterator([1, 2, 3, 4])
 
-        chunks = chunks_iterator.next_chunks(6)
+        chunks, _ = chunks_iterator.next_chunks(6)
         self.assertFalse(chunks_iterator.is_finished())
         self.assertEqual(chunks, [1, 2, 3])
-        
-        chunks = chunks_iterator.next_chunks(2)
+
+        chunks, _ = chunks_iterator.next_chunks(2)
         self.assertFalse(chunks_iterator.is_finished())
         self.assertEqual(chunks, [])
-    
+
     def test_next_request_with_item_zero(self):
         chunks_iterator = ChunksIterator([1, 0, 3, 4])
 
-        chunks = chunks_iterator.next_chunks(4)
+        chunks, _ = chunks_iterator.next_chunks(4)
         self.assertFalse(chunks_iterator.is_finished())
         self.assertEqual(chunks, [1, 0, 3])
-        
-        chunks = chunks_iterator.next_chunks(4)
+
+        chunks, _ = chunks_iterator.next_chunks(4)
         self.assertTrue(chunks_iterator.is_finished())
         self.assertEqual(chunks, [4])
 
@@ -247,6 +252,128 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         requests_iterator.buffer[3] = 8
         self.assertEqual(requests_iterator.file_buffers[0][0], 9)
         self.assertEqual(requests_iterator.file_buffers[1][0], 8)
+
+class TestAlignment(unittest.TestCase):
+    """Test CPU buffer allocation and chunk slicing when buffer_strides differ from chunks."""
+
+    def _make_file_chunks(self, chunks, alignment):
+        strides = [align_up(c, alignment) for c in chunks]
+        buffer_strides = strides if strides != chunks else None
+        return FileChunks(0, "test.bin", 0, chunks, buffer_strides=buffer_strides)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '256'})
+    def test_get_cuda_alignment_256(self):
+        self.assertEqual(get_cuda_alignment(), 256)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '16'})
+    def test_get_cuda_alignment_16(self):
+        self.assertEqual(get_cuda_alignment(), 16)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '256'})
+    def test_buffer_size_alignment_256(self):
+        # align_up(100,256)=256, align_up(200,256)=256, align_up(300,256)=512 → total 1024
+        fc = self._make_file_chunks([100, 200, 300], get_cuda_alignment())
+        iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.unlimited, [fc], device="cpu"
+        )
+        self.assertEqual(len(iterator.buffer), 256 + 256 + 512)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '16'})
+    def test_buffer_size_alignment_16(self):
+        # align_up(10,16)=16, align_up(20,16)=32, align_up(30,16)=32 → total 80
+        fc = self._make_file_chunks([10, 20, 30], get_cuda_alignment())
+        iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.unlimited, [fc], device="cpu"
+        )
+        self.assertEqual(len(iterator.buffer), 16 + 32 + 32)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '256'})
+    def test_file_buffer_covers_padded_region_alignment_256(self):
+        fc = self._make_file_chunks([100, 200, 300], get_cuda_alignment())
+        iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.unlimited, [fc], device="cpu"
+        )
+        iterator.next_request()
+        self.assertEqual(len(iterator.file_buffers), 1)
+        self.assertEqual(len(iterator.file_buffers[0]), 256 + 256 + 512)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '256'})
+    def test_chunk_slices_return_actual_size_alignment_256(self):
+        # get_global_file_and_chunk must return the actual (unpadded) bytes per tensor
+        chunks = [100, 200, 300]
+        fc = self._make_file_chunks(chunks, get_cuda_alignment())
+        iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.unlimited, [fc], device="cpu"
+        )
+        iterator.next_request()
+        for i, expected_size in enumerate(chunks):
+            _, _, buf = iterator.get_global_file_and_chunk(0, i)
+            self.assertEqual(len(buf), expected_size)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '16'})
+    def test_chunk_slices_return_actual_size_alignment_16(self):
+        chunks = [10, 20, 30]
+        fc = self._make_file_chunks(chunks, get_cuda_alignment())
+        iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.unlimited, [fc], device="cpu"
+        )
+        iterator.next_request()
+        for i, expected_size in enumerate(chunks):
+            _, _, buf = iterator.get_global_file_and_chunk(0, i)
+            self.assertEqual(len(buf), expected_size)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '256'})
+    def test_memory_limit_enforced_against_padded_strides(self):
+        # chunks [100, 200, 300] → strides [256, 256, 512]
+        # memory_limit=512: first two tensors fit (256+256=512), third does not
+        chunks = [100, 200, 300]
+        fc = self._make_file_chunks(chunks, get_cuda_alignment())
+        iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.limited, [fc], user_memory_limit=512, device="cpu"
+        )
+        req = iterator.next_request()
+        self.assertIsNotNone(req)
+        self.assertEqual(req.files[0].chunks, [100, 200])
+
+        req = iterator.next_request()
+        self.assertIsNotNone(req)
+        self.assertEqual(req.files[0].chunks, [300])
+
+        req = iterator.next_request()
+        self.assertIsNone(req)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '256'})
+    def test_cpu_buffer_base_alignment_256(self):
+        # For CPU buffers the base address is not controlled, but the buffer object
+        # must be sized to sum(effective_strides) so per-tensor slices are correct.
+        # This test confirms the buffer length is right regardless of actual base addr.
+        chunks = [100, 200, 300]
+        fc = self._make_file_chunks(chunks, get_cuda_alignment())
+        iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.unlimited, [fc], device="cpu"
+        )
+        self.assertEqual(len(iterator.buffer), 256 + 256 + 512)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR: '16'})
+    def test_memory_limit_enforced_against_padded_strides_alignment_16(self):
+        # chunks [10, 20, 30] → strides [16, 32, 32]
+        # memory_limit=48: first two tensors fit (16+32=48), third does not
+        chunks = [10, 20, 30]
+        fc = self._make_file_chunks(chunks, get_cuda_alignment())
+        iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.limited, [fc], user_memory_limit=48, device="cpu"
+        )
+        req = iterator.next_request()
+        self.assertIsNotNone(req)
+        self.assertEqual(req.files[0].chunks, [10, 20])
+
+        req = iterator.next_request()
+        self.assertIsNotNone(req)
+        self.assertEqual(req.files[0].chunks, [30])
+
+        req = iterator.next_request()
+        self.assertIsNone(req)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
@@ -22,7 +22,7 @@ class LibstreamerDLLWrapper:
 
         self.fn_runai_request = self.lib.runai_request
         self.fn_runai_request.argtypes = [
-            t_streamer, 
+            t_streamer,
             ctypes.c_uint32, # num_files
             ctypes.POINTER(ctypes.c_char_p), # paths
             ctypes.POINTER(ctypes.c_size_t), # file_offsets
@@ -35,6 +35,7 @@ class LibstreamerDLLWrapper:
             ctypes.c_char_p, # token
             ctypes.c_char_p, # region
             ctypes.c_char_p, # endpoint
+            ctypes.c_int,    # cuda (0 = CPU, non-zero = CUDA device memory)
         ]
         self.fn_runai_request.restype = ctypes.c_int
 

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -42,15 +42,10 @@ def runai_request(
         # to aligned destinations without computing offsets itself.
         dst_addrs = cuda_tensor_ptrs
     elif cuda:
-        # Fallback: build one pointer per tensor from each per-file CUDA buffer
-        # base + cumulative offset, matching the per-tensor contract expected by C++.
-        dst_addrs = []
-        for file_idx, dst in enumerate(dsts):
-            base = dst.data_ptr()
-            offset = 0
-            for size in internal_sizes[file_idx]:
-                dst_addrs.append(ctypes.c_void_p(base + offset))
-                offset += size
+        raise ValueError(
+            "cuda=True requires cuda_tensor_ptrs to be provided; "
+            "passing None would produce misaligned GPU destinations"
+        )
     else:
         dst_addrs = [
             ctypes.cast(ctypes.c_void_p(ctypes.addressof(ctypes.c_char.from_buffer(dst))), ctypes.c_void_p)

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -8,6 +8,7 @@ import shutil
 from typing import List
 
 from runai_model_streamer.file_streamer import FileChunks
+from runai_model_streamer.file_streamer.requests_iterator import align_up, get_cuda_alignment
 
 from runai_model_streamer.distributed_streamer import DistributedStreamer
 
@@ -219,11 +220,14 @@ class SafetensorsStreamer:
             paths: List[str],
             s3_credentials : Optional[S3Credentials] = None,
             device: Optional[str] = "cpu",
-            is_distributed: bool = False, 
+            is_distributed: bool = False,
         ) -> None:
         self.files_to_tensors_metadata = {}
 
         file_stream_requests: List[FileChunks] = []
+
+        # Compute alignment for CUDA devices (default 256 bytes, disabled on CPU).
+        alignment = get_cuda_alignment() if (device and device.startswith("cuda")) else 1
 
         # metadata is created on cpu and each process reads it individually
         safetensors_metadatas = safetensors_pytorch.prepare_request(self.file_streamer, paths, s3_credentials)
@@ -232,7 +236,9 @@ class SafetensorsStreamer:
             (file_offset, tensors_metadata, tensor_sizes) = safetensors_metadatas[i]
             path = paths[i]
             self.files_to_tensors_metadata[i] = tensors_metadata
-            file_stream_requests.append(FileChunks(i, path, file_offset, tensor_sizes))
+            padded_sizes = [align_up(s, alignment) for s in tensor_sizes] if alignment > 1 else None
+            file_stream_requests.append(FileChunks(i, path, file_offset, tensor_sizes,
+                                                   buffer_strides=padded_sizes))
 
         self.file_streamer.stream_files(
             file_stream_requests,

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -226,8 +226,10 @@ class SafetensorsStreamer:
 
         file_stream_requests: List[FileChunks] = []
 
-        # Compute alignment for CUDA devices (default 256 bytes, disabled on CPU).
-        alignment = get_cuda_alignment() if (device and device.startswith("cuda")) else 1
+        # Compute alignment only for NVIDIA CUDA (the C++ write path only pads on NVIDIA).
+        # AMD ROCm also reports "cuda" devices but uses the CPU path, so no padding there.
+        is_nvidia_cuda = device and device.startswith("cuda") and torch.version.hip is None
+        alignment = get_cuda_alignment() if is_nvidia_cuda else 1
 
         # metadata is created on cpu and each process reads it individually
         safetensors_metadatas = safetensors_pytorch.prepare_request(self.file_streamer, paths, s3_credentials)


### PR DESCRIPTION
# Direct GPU Streaming via Pinned Staging Buffer

## Overview

This branch adds NVIDIA CUDA direct streaming: instead of reading file data into a
CPU buffer and then copying it to the GPU, the C++ worker threads read each block
into a thread-local **pinned (page-locked) host staging buffer** and DMA it straight
to a pre-allocated PyTorch CUDA tensor via `cuMemcpyHtoDAsync`. The tensor lives in
device memory for its entire lifetime and is yielded directly to the caller — no
extra host-to-device copy, no intermediate NumPy array.

The yielded GPU tensor has an aligned address in GPU memory similar to the native Pytorch tensor.

**This path is NVIDIA CUDA only.** AMD ROCm and all other device types fall back to the
CPU path (read to CPU, then copy to device). Remote backends (S3, GCS, Azure) also
always use the CPU path regardless of device.

For **distributed streaming** the feature is transparent: no changes are required in
the caller (e.g. vLLM). The distributed streamer detects the device and switches
paths internally, and each rank receives GPU tensors directly without any API change.
For **TP=1** (non-distributed) usage, integration changes in the caller are required
to pass a CUDA device string and consume the yielded GPU tensors directly.

Direct streaming to GPU also reduces the CPU memory requirements. The minimal additional device memory is two times the size of the largest tensor.


## Benchmarks

**Cluster:** NVIDIA H200, 8 GPUs per node
**Storage:** Nebius shared filesystem

**Qwen1.5-110B-Chat — TP=8 (25.91 GiB per GPU)**
```
Run                  Load Time   Speedup
tp8 (baseline)        80.7s       1.0x
tp8_runai             58.6s       1.4x
tp8_runai_dist        25.5s       3.2x
```

**Qwen1.5-110B-Chat — TP=4 (51.8 GiB per GPU)**
```
Run                  Load Time   Speedup
tp4 (baseline)        73.9s       1.0x
tp4_runai             34.5s       2.1x
tp4_runai_dist        23.6s       3.1x
```

**Qwen3-235B-A22B — TP=8 (54.92 GiB per GPU)**
```
Run                  Load Time   Speedup
tp8 (baseline)       320.8s       1.0x
tp8_runai            129.3s       2.5x
tp8_runai_dist        47.3s       6.8x
```

---

## TP=1 (non-distributed) streaming

`FilesRequestsIteratorWithBuffer` accepts a `device` argument. When the device is an
NVIDIA CUDA device (`device.startswith("cuda")` and `torch.version.hip is None`):

- The staging buffer is allocated as `torch.empty(..., device=device)` instead of
  `np.empty(...)`. Slices of this buffer become the yielded tensors.
- Buffer size is capped at 95% of free GPU memory so allocation cannot OOM.
- `runai_request` is called with `cuda=True`, routing C++ worker threads into
  `Batch::read_cuda()`.
- `next_request()` calls `torch.cuda.synchronize()` before reusing the buffer for the
  next batch, ensuring any async operations still holding a reference to the previous
  slice (e.g. dtype casts, user application ops) have completed.

In C++, each worker thread owns a `thread_local CudaStagingBuffer`: a pinned host
buffer (`cuMemAllocHost`) and a private CUDA stream (`cuStreamCreate`). 
`read_cuda` reads the file in `fs_block_bytesize` chunks, copies each to the device
pointer via `cuMemcpyHtoDAsync`, and synchronizes the stream after every chunk so the
staging buffer can be immediately reused for the next read.

---

## Distributed streaming

When `_use_cuda_direct()` is true (NVIDIA CUDA, local paths, no ROCm), the distributed
streamer takes a new code path with no API changes required in the caller:

- `stream_files()` passes the real CUDA device string to `file_streamer.stream_files()`
  instead of `"cpu"`, so tensors land in GPU memory from the start.
- `get_chunks()` delegates to the new `_get_chunks_cuda()` method instead of the
  existing `prefill`/broadcast loop.

`_get_chunks_cuda()` broadcasts **one tensor at a time** across the distribution group:

1. All ranks iterate over broadcasting ranks in round-robin order, keeping all ranks
   in lockstep.
2. The **broadcasting rank** pulls the next tensor from `file_streamer.get_chunks()`
   (already on the GPU), fills a two-row metadata tensor
   `[count | orig_req_idx, orig_chunk_idx, size, 0]`, and does two `dist.broadcast`
   calls: first the metadata, then the GPU tensor itself.
3. **Receiving ranks** broadcast the metadata tensor, read `count` and `size`, call
   `torch.cuda.synchronize()` to ensure the previous receive buffer is no longer in
   use, then broadcast into a pre-allocated `receive_buffer[:chunk_size]` view and
   yield it.

The receive buffer is sized to hold one tensor at a time (`max_chunk` bytes), so GPU
memory usage on receiving ranks is proportional to the largest single tensor rather
than to the full batch buffer used by the CPU path.

---

## Fallback conditions

The CUDA direct path is skipped and the original CPU path is used when:

- `device` is `None` or does not start with `"cuda"`
- ROCm/AMD GPU (`torch.version.hip is not None`)
- CUDA not available (`not torch.cuda.is_available()`)
- Any file path is a remote URI (`s3://`, `gs://`, `az://`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU-accelerated file streaming with an optional CUDA-direct fast path and per-request GPU destination support
  * Pinned host staging buffers and CUDA-aware buffer alignment for efficient host↔device transfers
  * Python bindings and runtime plumbing to request CUDA-mode transfers from user code

* **Tests**
  * Added CUDA mock libs and extensive CUDA-focused unit/integration tests validating end-to-end correctness and alignment

* **Chores**
  * Build environment updated to include CUDA headers for compile-time support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->