### PR TITLE
Feature Request: Enable Local Model Caching when pulling from remote source like s3

### DIFF
--- a/docs/src/local-cache.md
+++ b/docs/src/local-cache.md
@@ -1,0 +1,262 @@
+# Local Model Caching (RUNAI_STREAMER_CACHE_DIR)
+
+## Overview
+
+When streaming models from object storage (S3, GCS, Azure), the first load downloads tensor data over the network. With local caching enabled, this data is simultaneously written to a local NVMe directory. On subsequent loads, the streamer reads directly from local NVMe instead of re-downloading — significantly reducing model loading time.
+Changes implemented in https://github.com/wwvela/runai-model-streamer/commits/Cache/
+
+## How to Enable
+
+Set the environment variable:
+
+```bash
+export RUNAI_STREAMER_CACHE_DIR=/path/to/cache
+```
+
+For Kubernetes deployments, mount a fast local volume (NVMe-backed hostPath) and set the env:
+
+```yaml
+env:
+  - name: RUNAI_STREAMER_CACHE_DIR
+    value: "/models"
+volumeMounts:
+  - name: model-cache
+    mountPath: /models
+volumes:
+  - name: model-cache
+    hostPath:
+      path: /mnt/k8s-disks/0/models
+      type: DirectoryOrCreate
+```
+
+## How It Works
+
+### First Load (Cache Miss)
+
+```
+S3 ──→ C++ streamer ──→ DRAM buffer ──→ GPU
+                              │
+                              ├──→ os.write() to /models/<file>.partial.<pid>
+                              │    (inline, using buffer protocol — no extra copy)
+                              │
+                              └──→ when file complete: rename .partial → final, write .done sentinel
+```
+
+1. The streamer pulls tensor data from S3 as normal
+2. After each batch is yielded to the model, the same buffer is written to a local `.partial` file
+3. When all bytes for a file are written, it's atomically renamed to the final path and a `.done` sentinel is created
+4. Model loading speed is nearly unchanged (NVMe writes are fast and mostly overlap with network wait)
+
+### Second Load (Cache Hit)
+
+```
+/models/<cached_file> ──→ C++ streamer (local filesystem, NVMe) ──→ GPU
+```
+
+1. Before streaming, the cache checks if ALL files needed by this worker exist locally with valid `.done` sentinels
+2. If all hit: swap S3 paths to local paths, set offsets to positions within the cached file
+3. The C++ layer reads from local NVMe — no network access, full disk bandwidth (~5-7 GB/s)
+
+## Cache Directory Structure
+
+With distributed streaming (tensor parallelism), each worker caches its own partition:
+
+```
+/models/
+├── model-00001-of-00026.safetensors.tp4_rank0.61cc262a76817ddb
+├── model-00001-of-00026.safetensors.tp4_rank0.61cc262a76817ddb.done
+├── model-00001-of-00026.safetensors.tp4_rank1.61cc262a76817ddb
+├── model-00001-of-00026.safetensors.tp4_rank1.61cc262a76817ddb.done
+├── model-00001-of-00026.safetensors.tp4_rank2.61cc262a76817ddb
+├── model-00001-of-00026.safetensors.tp4_rank2.61cc262a76817ddb.done
+├── model-00001-of-00026.safetensors.tp4_rank3.61cc262a76817ddb
+├── model-00001-of-00026.safetensors.tp4_rank3.61cc262a76817ddb.done
+├── model-00002-of-00026.safetensors.tp4_rank0.627ae2c16029180a
+├── model-00002-of-00026.safetensors.tp4_rank0.627ae2c16029180a.done
+└── ...
+```
+
+Without distributed streaming (TP=1), the TP prefix is omitted:
+
+```
+/models/
+├── model-00001-of-00026.safetensors.61cc262a76817ddb
+├── model-00001-of-00026.safetensors.61cc262a76817ddb.done
+└── ...
+```
+
+### File naming format
+
+```
+<original_filename>.tp<world_size>_rank<rank>.<sha256_prefix_16chars>
+```
+
+- **original_filename**: basename from the S3 path (e.g., `model-00001-of-00026.safetensors`)
+- **tp/rank**: tensor parallel configuration (omitted when world_size=1)
+- **sha256 prefix**: 16-char hash of the full remote URI for uniqueness
+
+### Sentinel file (.done)
+
+Contains JSON metadata for validation:
+
+```json
+{
+  "remote_path": "s3://bucket/model/model-00001-of-00026.safetensors",
+  "file_offset": 8392,
+  "size": 1073741824,
+  "rank": 0,
+  "world_size": 4
+}
+```
+
+## Cache Hit Logic
+
+A cache hit occurs when ALL of these conditions are met:
+
+1. `RUNAI_STREAMER_CACHE_DIR` is set
+2. `enable_cache=True` (only for tensor data streaming, not header reads)
+3. For every unique file path in the request:
+   - The cached data file exists on disk
+   - The `.done` sentinel exists
+   - The sentinel's `rank` and `world_size` match the current TP configuration
+
+If **any** file misses, ALL files are streamed from remote (the C++ layer cannot mix local and remote paths in one request).
+
+## Distributed Streaming (Tensor Parallelism)
+
+With TP=4, each safetensors file contains many tensors. The distributed streamer partitions tensors across workers — each worker reads different tensor slices from every file. This means:
+
+- Every worker reads from all 26 shard files, but different byte ranges
+- Each worker caches only its own partition (identified by rank in the cache key)
+- Cache entries for the same file but different ranks have different sizes
+- Total cache size ≈ total model size (no duplication — partitions are non-overlapping)
+
+On cache hit, cumulative offsets are computed so each `FileChunks` entry reads from the correct position within the cached file.
+
+## Race Condition Handling
+
+Multiple TP workers run as separate processes and may try to cache the same file:
+
+- Each worker writes to its own `.partial.<pid>` file (unique per process)
+- On finalize, if the final file already exists (another worker finished first), the worker silently cleans up its partial file
+- No corruption, no errors — first writer wins
+
+## Performance Characteristics
+
+| Scenario | Typical Loading Time |
+|----------|---------------------|
+| S3 streaming (no cache) | ~15-18s |
+| S3 streaming + cache write (first load) | ~16-18s |
+| Cache hit (NVMe read, subsequent loads) | ~6-7s |
+| NVMe preloaded baseline (for comparison) | ~6s |
+
+The first-load overhead comes from inline `os.write()` calls. This is minimal because:
+- NVMe write bandwidth is high (~5 GB/s)
+- Writes use the buffer protocol (no Python-level copy)
+- Files are finalized (fsync + rename) incrementally as each completes
+
+## Logging
+
+Enable logs with:
+
+```bash
+export RUNAI_STREAMER_LOG_LEVEL=INFO
+```
+
+Example output (first load):
+```
+[RunAI Streamer][Cache] Cache enabled, directory: /models
+[RunAI Streamer][Cache] Distributed config: rank=0, world_size=4
+[RunAI Streamer][Cache] MISS: s3://bucket/model-00001.safetensors (not in cache)
+[RunAI Streamer][Cache] Cache miss for some files — streaming all 192 file(s) from remote
+[RunAI Streamer][Cache] Opening cache writer for: s3://...model-00001... (1073741824 bytes, rank=0, tp=4)
+[RunAI Streamer][Cache] Cached: s3://...model-00001... (1073741824 bytes) in 11.3s (90 MB/s)
+[RunAI Streamer][Cache] All files cached in 11.5s
+```
+
+Example output (second load):
+```
+[RunAI Streamer][Cache] HIT: s3://...model-00001... -> /models/model-00001...tp4_rank0... (1073741824 bytes)
+[RunAI Streamer][Cache] ALL 192 file(s) found in cache — using local paths (fast path)
+[RunAI Streamer][Cache] read_device=cuda:0, _use_cuda_direct=False, all_cached_locally=True
+```
+
+## Concurrency Tuning
+
+The `RUNAI_STREAMER_CONCURRENCY` (or `concurrency` in `model-loader-extra-config`) controls how many threads read from storage in parallel. This setting has a significant impact on cache hit performance:
+
+| Concurrency | S3 (first load) | NVMe cache hit (second load) |
+|-------------|-----------------|------------------------------|
+| 64          | ~15s (optimal)  | ~17s (too many threads competing for NVMe) |
+| 16-20       | ~17-18s         | ~8-9s (optimal for NVMe) |
+
+**Why**: S3 benefits from high parallelism (many concurrent HTTP connections). NVMe benefits from fewer threads doing large sequential reads — too many threads cause seek contention and scheduler overhead.
+
+**Recommendation**: Use `concurrency: 16` for optimal cache-hit performance. The first load from S3 will be slightly slower, but subsequent loads from NVMe will be significantly faster. If first-load speed is critical and you don't expect cache hits (e.g., always a new node), use higher concurrency.
+
+```yaml
+# Balanced for both S3 first-load and NVMe cache-hit
+--model-loader-extra-config '{"concurrency": 16, "distributed": true}'
+```
+
+## Kernel Dirty Page Tuning (Recommended for Large Models)
+
+On instances with limited RAM relative to model size (e.g., g6e.12xlarge with 96GB RAM loading a 64GB model), the default Linux `dirty_ratio` (20%) can cause `os.write()` to block during cache writes, significantly slowing down model loading.
+
+**The problem:** With 4 TP workers each writing ~16GB to cache, total dirty pages reach 64GB — exceeding the default 20% limit (19GB). When the limit is hit, `os.write()` blocks until the kernel flushes pages to NVMe, stalling the streaming pipeline.
+
+**The fix:** Increase `dirty_ratio` on the node so `os.write()` never blocks:
+
+```bash
+echo 80 > /proc/sys/vm/dirty_ratio
+echo 50 > /proc/sys/vm/dirty_background_ratio
+```
+
+For Karpenter-managed nodes, add to the EC2NodeClass userData:
+
+```yaml
+userData: |
+  MIME-Version: 1.0
+  Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+  --BOUNDARY
+  Content-Type: text/x-shellscript; charset="us-ascii"
+
+  #!/bin/bash
+  echo 80 > /proc/sys/vm/dirty_ratio
+  echo 50 > /proc/sys/vm/dirty_background_ratio
+
+  --BOUNDARY
+  Content-Type: application/node.eks.aws
+
+  ---
+  apiVersion: node.eks.aws/v1alpha1
+  kind: NodeConfig
+  spec:
+    featureGates:
+      FastImagePull: true
+
+  --BOUNDARY--
+```
+
+| Setting | Default | Recommended | Effect |
+|---------|---------|-------------|--------|
+| `dirty_ratio` | 20% | 80% | `os.write()` blocks only at 80% of RAM dirty |
+| `dirty_background_ratio` | 10% | 50% | Kernel starts background flush at 50% (non-blocking) |
+
+**Impact (g6e.12xlarge, 64GB model, TP=4):**
+
+| | dirty_ratio=20% (default) | dirty_ratio=80% |
+|---|---|---|
+| Cache write overhead | +16.6s | +4.6s |
+| First load with cache | 43.7s | 31.7s |
+| Bottleneck | Kernel writeback stalls os.write | Physical NVMe write speed (unavoidable) |
+
+This tuning is not needed on instances with large RAM (e.g., p5.48xlarge with 2TB) where dirty pages never approach the default limit.
+
+## Limitations
+
+- Cache is tied to the TP configuration — TP=4 cache cannot be reused by TP=8 (treated as a miss, new entries are created)
+- All files must hit cache for the fast path; partial hits fall back to full S3 streaming
+- Cache directory must be writable; use `DirectoryOrCreate` for hostPath volumes
+- If the first pod's process dies before all files are finalized, some entries will be missing `.done` sentinels and treated as misses on next load

--- a/docs/src/local-cache.md
+++ b/docs/src/local-cache.md
@@ -138,7 +138,7 @@ Multiple TP workers run as separate processes and may try to cache the same file
 
 - Each worker writes to its own `.partial.<pid>` file (unique per process)
 - On finalize, if the final file already exists (another worker finished first), the worker silently cleans up its partial file
-- No corruption, no errors — first writer wins
+- No corruption from the race — first writer wins, others clean up silently. Other I/O failures (disk full, permissions) are logged as errors.
 
 ## Performance Characteristics
 
@@ -152,7 +152,7 @@ Multiple TP workers run as separate processes and may try to cache the same file
 The first-load overhead comes from inline `os.write()` calls. This is minimal because:
 - NVMe write bandwidth is high (~5 GB/s)
 - Writes use the buffer protocol (no Python-level copy)
-- Files are finalized (fsync + rename) incrementally as each completes
+- Files are finalized (atomic rename + sentinel write) incrementally as each completes
 
 ## Logging
 

--- a/docs/src/local-cache.md
+++ b/docs/src/local-cache.md
@@ -3,7 +3,6 @@
 ## Overview
 
 When streaming models from object storage (S3, GCS, Azure), the first load downloads tensor data over the network. With local caching enabled, this data is simultaneously written to a local NVMe directory. On subsequent loads, the streamer reads directly from local NVMe instead of re-downloading — significantly reducing model loading time.
-Changes implemented in https://github.com/wwvela/runai-model-streamer/commits/Cache/
 
 ## How to Enable
 

--- a/py/runai_model_streamer/runai_model_streamer/cache/__init__.py
+++ b/py/runai_model_streamer/runai_model_streamer/cache/__init__.py
@@ -1,0 +1,6 @@
+from runai_model_streamer.cache.cache import StreamCache, RUNAI_STREAMER_CACHE_DIR_ENV  # noqa: F401
+
+__all__ = [
+    "StreamCache",
+    "RUNAI_STREAMER_CACHE_DIR_ENV",
+]

--- a/py/runai_model_streamer/runai_model_streamer/cache/cache.py
+++ b/py/runai_model_streamer/runai_model_streamer/cache/cache.py
@@ -112,7 +112,7 @@ class StreamCache:
     """
 
     def __init__(self, cache_dir: Optional[str] = None) -> None:
-        self._cache_dir = cache_dir or os.getenv(RUNAI_STREAMER_CACHE_DIR_ENV)
+        self._cache_dir = (cache_dir or os.getenv(RUNAI_STREAMER_CACHE_DIR_ENV) or "").strip() or None
         self._writers: Dict[str, _CacheWriter] = {}
         self._cache_start_time: Optional[float] = None
         self._rank: int = 0

--- a/py/runai_model_streamer/runai_model_streamer/cache/cache.py
+++ b/py/runai_model_streamer/runai_model_streamer/cache/cache.py
@@ -168,7 +168,8 @@ class StreamCache:
                     )
                     return None
             except (json.JSONDecodeError, OSError):
-                pass  # Old-format sentinel, trust the key-based matching
+                logger.info(f"[RunAI Streamer][Cache] INVALID: {remote_path} sentinel unreadable — treating as miss")
+                return None
 
             file_size = os.path.getsize(local_path)
             logger.info(f"[RunAI Streamer][Cache] HIT: {remote_path} -> {local_path} ({file_size} bytes)")

--- a/py/runai_model_streamer/runai_model_streamer/cache/cache.py
+++ b/py/runai_model_streamer/runai_model_streamer/cache/cache.py
@@ -200,7 +200,10 @@ class StreamCache:
             self._cache_start_time = time.time()
 
         logger.info(f"[RunAI Streamer][Cache] Opening cache writer for: {remote_path} ({total_bytes} bytes, rank={self._rank}, tp={self._world_size})")
-        self._writers[remote_path] = _CacheWriter(self._cache_dir, remote_path, file_offset, self._rank, self._world_size)
+        try:
+            self._writers[remote_path] = _CacheWriter(self._cache_dir, remote_path, file_offset, self._rank, self._world_size)
+        except OSError as e:
+            logger.warning(f"[RunAI Streamer][Cache] Failed to create cache writer for {remote_path}: {e} — caching skipped for this file")
 
     def append_data(self, remote_path: str, data: bytes) -> None:
         """Append streamed data to the cache file."""

--- a/py/runai_model_streamer/runai_model_streamer/cache/cache.py
+++ b/py/runai_model_streamer/runai_model_streamer/cache/cache.py
@@ -1,0 +1,225 @@
+import hashlib
+import json
+import os
+import logging
+import time
+from typing import Dict, List, Optional, Tuple
+
+from runai_model_streamer.s3_utils.s3_utils import (
+    S3Credentials,
+    is_s3_path,
+    is_gs_path,
+    is_azure_path,
+)
+
+logger = logging.getLogger(__name__)
+
+RUNAI_STREAMER_CACHE_DIR_ENV = "RUNAI_STREAMER_CACHE_DIR"
+
+
+def _is_object_storage_path(path: str) -> bool:
+    return is_s3_path(path) or is_gs_path(path) or is_azure_path(path)
+
+
+def _cache_key(remote_path: str, rank: int = 0, world_size: int = 1) -> str:
+    """Deterministic cache filename from a remote URI and TP config."""
+    h = hashlib.sha256(remote_path.encode()).hexdigest()[:16]
+    basename = os.path.basename(remote_path.rstrip("/"))
+    if world_size > 1:
+        return f"{basename}.tp{world_size}_rank{rank}.{h}"
+    return f"{basename}.{h}"
+
+
+class _CacheWriter:
+    """Incrementally writes streamed data to a cache file."""
+
+    def __init__(self, cache_dir: str, remote_path: str, file_offset: int, rank: int = 0, world_size: int = 1) -> None:
+        self._remote_path = remote_path
+        self._file_offset = file_offset
+        self._rank = rank
+        self._world_size = world_size
+        key = _cache_key(remote_path, rank, world_size)
+        self._final_path = os.path.join(cache_dir, key)
+        self._sentinel = self._final_path + ".done"
+        self._tmp_path = self._final_path + f".partial.{os.getpid()}"
+        self._fd = os.open(self._tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        self._written = 0
+        self._start_time = time.time()
+
+    def append(self, data) -> None:
+        """Append data to the cache file. Accepts bytes, memoryview, or numpy array."""
+        mv = memoryview(data).cast('B')
+        total = len(mv)
+        written = 0
+        while written < total:
+            n = os.write(self._fd, mv[written:])
+            if n == 0:
+                raise OSError(f"os.write returned 0, disk may be full")
+            written += n
+        self._written += total
+
+    def finalize(self) -> None:
+        try:
+            os.close(self._fd)
+            self._fd = -1
+            # Another worker may have already written the final file
+            if os.path.exists(self._final_path):
+                logger.info(f"[RunAI Streamer][Cache] Already cached by another worker: {self._remote_path}")
+                self._cleanup()
+                return
+            os.rename(self._tmp_path, self._final_path)
+            meta = {"remote_path": self._remote_path, "file_offset": self._file_offset, "size": self._written, "rank": self._rank, "world_size": self._world_size}
+            with open(self._sentinel, "w") as f:
+                json.dump(meta, f)
+
+            elapsed = time.time() - self._start_time
+            throughput = self._written / elapsed / (1024 * 1024) if elapsed > 0 else 0
+            logger.info(
+                f"[RunAI Streamer][Cache] Cached: {self._remote_path} "
+                f"({self._written} bytes) in {elapsed:.1f}s ({throughput:.0f} MB/s) "
+                f"[rank={self._rank}, tp={self._world_size}]"
+            )
+        except OSError as e:
+            # Race with another worker — if final file now exists, that's fine
+            if os.path.exists(self._final_path):
+                logger.info(f"[RunAI Streamer][Cache] Already cached by another worker: {self._remote_path}")
+            else:
+                logger.error(f"[RunAI Streamer][Cache] Finalize failed for {self._remote_path}: {e}")
+            self._cleanup()
+
+    def abort(self) -> None:
+        self._cleanup()
+
+    def _cleanup(self) -> None:
+        if self._fd >= 0:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._fd = -1
+        try:
+            os.unlink(self._tmp_path)
+        except OSError:
+            pass
+
+
+class StreamCache:
+    """Write-through cache for object storage files.
+
+    Writes streamed tensor data to local cache incrementally as batches complete.
+    On subsequent loads, serves from local filesystem with offset=0 (the cached
+    file contains only the tensor data, starting from the original file_offset).
+    """
+
+    def __init__(self, cache_dir: Optional[str] = None) -> None:
+        self._cache_dir = cache_dir or os.getenv(RUNAI_STREAMER_CACHE_DIR_ENV)
+        self._writers: Dict[str, _CacheWriter] = {}
+        self._cache_start_time: Optional[float] = None
+        self._rank: int = 0
+        self._world_size: int = 1
+
+        if self._cache_dir:
+            os.makedirs(self._cache_dir, exist_ok=True)
+            logger.info(f"[RunAI Streamer][Cache] Cache enabled, directory: {self._cache_dir}")
+        else:
+            logger.info("[RunAI Streamer][Cache] Cache disabled (RUNAI_STREAMER_CACHE_DIR not set)")
+
+    def set_distributed(self, rank: int, world_size: int) -> None:
+        """Set the distributed rank and world size for cache key generation."""
+        self._rank = rank
+        self._world_size = world_size
+        logger.info(f"[RunAI Streamer][Cache] Distributed config: rank={rank}, world_size={world_size}")
+
+    @property
+    def enabled(self) -> bool:
+        return self._cache_dir is not None
+
+    def cached_path_and_offset(self, remote_path: str) -> Optional[Tuple[str, int]]:
+        """Return (local_path, adjusted_offset) if cached, else None.
+
+        The cached file stores tensor data starting from the original file_offset,
+        so the adjusted offset is always 0. Validates that the cached entry matches
+        the current TP configuration.
+        """
+        if not self.enabled:
+            return None
+        if not _is_object_storage_path(remote_path):
+            return None
+
+        key = _cache_key(remote_path, self._rank, self._world_size)
+        local_path = os.path.join(self._cache_dir, key)
+        sentinel = local_path + ".done"
+
+        data_exists = os.path.exists(local_path)
+        sentinel_exists = os.path.exists(sentinel)
+
+        if data_exists and sentinel_exists:
+            # Validate sentinel metadata matches current TP config
+            try:
+                with open(sentinel, "r") as f:
+                    meta = json.loads(f.read())
+                cached_world_size = meta.get("world_size", 1)
+                cached_rank = meta.get("rank", 0)
+                if cached_world_size != self._world_size or cached_rank != self._rank:
+                    logger.info(
+                        f"[RunAI Streamer][Cache] STALE: {remote_path} cached with "
+                        f"tp{cached_world_size}_rank{cached_rank} but current is "
+                        f"tp{self._world_size}_rank{self._rank} — skipping"
+                    )
+                    return None
+            except (json.JSONDecodeError, OSError):
+                pass  # Old-format sentinel, trust the key-based matching
+
+            file_size = os.path.getsize(local_path)
+            logger.info(f"[RunAI Streamer][Cache] HIT: {remote_path} -> {local_path} ({file_size} bytes)")
+            return local_path, 0
+
+        if data_exists and not sentinel_exists:
+            logger.info(f"[RunAI Streamer][Cache] INCOMPLETE: {local_path} exists but .done sentinel missing (partial download?)")
+        else:
+            logger.info(f"[RunAI Streamer][Cache] MISS: {remote_path} (not in cache)")
+
+        return None
+
+    def open_writer(self, remote_path: str, file_offset: int, total_bytes: int) -> None:
+        """Open a cache writer for a file being streamed from object storage.
+
+        Called once per file when streaming starts for a cache miss.
+        """
+        if not self.enabled:
+            return
+        if not _is_object_storage_path(remote_path):
+            return
+        if remote_path in self._writers:
+            return
+        if self.cached_path_and_offset(remote_path) is not None:
+            return
+
+        if self._cache_start_time is None:
+            self._cache_start_time = time.time()
+
+        logger.info(f"[RunAI Streamer][Cache] Opening cache writer for: {remote_path} ({total_bytes} bytes, rank={self._rank}, tp={self._world_size})")
+        self._writers[remote_path] = _CacheWriter(self._cache_dir, remote_path, file_offset, self._rank, self._world_size)
+
+    def append_data(self, remote_path: str, data: bytes) -> None:
+        """Append streamed data to the cache file."""
+        writer = self._writers.get(remote_path)
+        if writer is None:
+            return
+        writer.append(data)
+
+    def finalize(self, remote_path: str) -> None:
+        """Finalize a cache file after all data has been written."""
+        writer = self._writers.pop(remote_path, None)
+        if writer is None:
+            return
+        writer.finalize()
+        if not self._writers:
+            elapsed = time.time() - self._cache_start_time if self._cache_start_time else 0
+            logger.info(f"[RunAI Streamer][Cache] All files cached in {elapsed:.1f}s")
+
+    def abort_all(self) -> None:
+        """Clean up incomplete writers on error."""
+        for writer in self._writers.values():
+            writer.abort()
+        self._writers.clear()

--- a/py/runai_model_streamer/runai_model_streamer/cache/cache.py
+++ b/py/runai_model_streamer/runai_model_streamer/cache/cache.py
@@ -218,6 +218,15 @@ class StreamCache:
             elapsed = time.time() - self._cache_start_time if self._cache_start_time else 0
             logger.info(f"[RunAI Streamer][Cache] All files cached in {elapsed:.1f}s")
 
+    def finalize_all(self) -> None:
+        """Finalize all remaining cache writers."""
+        for path in list(self._writers.keys()):
+            self.finalize(path)
+
+    def has_pending_writers(self) -> bool:
+        """Return True if there are open cache writers."""
+        return len(self._writers) > 0
+
     def abort_all(self) -> None:
         """Clean up incomplete writers on error."""
         for writer in self._writers.values():

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -139,6 +139,7 @@ class DistributedStreamer:
             credentials: Optional[S3Credentials],
             device: str,
             is_distributed: bool,
+            enable_cache: bool = False,
     ) -> None:
 
         self.params.set_params(file_stream_requests)
@@ -147,9 +148,9 @@ class DistributedStreamer:
         self.set_is_distributed(is_distributed, device)
 
         if not self.is_distributed:
-            self.file_streamer.stream_files(file_stream_requests, credentials, device)
+            self.file_streamer.stream_files(file_stream_requests, credentials, device, enable_cache=enable_cache)
         else:
-            self.distributed_streamer.stream_files(file_stream_requests, credentials, device, self.params)
+            self.distributed_streamer.stream_files(file_stream_requests, credentials, device, self.params, enable_cache=enable_cache)
 
     def get_chunks(self) -> Iterator:
         if not self.file_streamer:
@@ -335,7 +336,8 @@ class _distributedStreamer:
             file_stream_requests: List[FileChunks],
             credentials: Optional[S3Credentials],
             device: str,
-            params : _distributedStreamerParams
+            params : _distributedStreamerParams,
+            enable_cache: bool = False,
     ) -> None:
 
         self.device = torch.device(device)
@@ -376,6 +378,9 @@ class _distributedStreamer:
             logger.debug(f"[RunAI Streamer][Distributed] Rank {self.original_group_rank}: No chunks to read from storage")
             return
 
+        # Set distributed config on cache so each rank caches its own partition
+        self.file_streamer._cache.set_distributed(self.rank, self.group_size)
+
         # read files
         original_memory_limit = os.environ.get("RUNAI_STREAMER_MEMORY_LIMIT")
         try:
@@ -384,7 +389,7 @@ class _distributedStreamer:
                 logger.debug(f"[RunAI Streamer][Distributed] Setting memory limit to unlimited")
             if original_memory_limit == None:
                 os.environ["RUNAI_STREAMER_MEMORY_LIMIT"] = "-1"
-            self.file_streamer.stream_files(self.rank_file_chunks_list, credentials, "cpu")
+            self.file_streamer.stream_files(self.rank_file_chunks_list, credentials, "cpu", enable_cache=enable_cache)
         except Exception as e:
             raise e
         finally:

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -19,6 +19,8 @@ from runai_model_streamer.s3_utils.s3_utils import (
     get_s3_credentials_module,
 )
 
+from runai_model_streamer.cache import StreamCache
+
 import humanize
 
 import torch
@@ -60,6 +62,10 @@ class FileStreamer:
         self.device_str = None
         self.s3_session = None
         self.s3_credentials = None
+        self._cache = StreamCache()
+        self._cache_original_paths: List[str] = []
+        self._cache_expected_bytes: dict = {}
+        self._cache_written_bytes: dict = {}
         return self
 
     def __exit__(self, exc_type: any, exc_value: any, traceback: any) -> None:
@@ -79,7 +85,7 @@ class FileStreamer:
         if s3_credentials_module:
             # initialize session only one
             if is_s3_path(path) and self.s3_session is None:
-                # check for s3 path and init sessions and credentials           
+                # check for s3 path and init sessions and credentials
                 self.s3_session, self.s3_credentials = s3_credentials_module.get_credentials(credentials)
         return path
 
@@ -89,21 +95,64 @@ class FileStreamer:
             file_stream_requests: List[FileChunks],
             credentials: Optional[S3Credentials] = None,
             device: Optional[str] = "cpu",
+            enable_cache: bool = False,
 ) -> None:
         if not homogeneous_paths([file_stream_request.path for file_stream_request in file_stream_requests]):
-            raise RunaiStreamerInvalidInputException("Cannot stream files from multiple source types in parallel") 
+            raise RunaiStreamerInvalidInputException("Cannot stream files from multiple source types in parallel")
 
         self.device_str = device
 
+        self._cache_original_paths = []
+        self._cache_expected_bytes = {}
+        self._cache_written_bytes = {}
         for file_stream_request in file_stream_requests:
             self.total_size += sum(file_stream_request.chunks)
-            file_stream_request.path = self.handle_object_store(file_stream_request.path, credentials)
+            self._cache_original_paths.append(file_stream_request.path)
+            path = file_stream_request.path
+            self._cache_expected_bytes[path] = self._cache_expected_bytes.get(path, 0) + sum(file_stream_request.chunks)
+            if path not in self._cache_written_bytes:
+                self._cache_written_bytes[path] = 0
+
+        # Check cache: only use cached paths if ALL unique files hit cache (the C++ layer
+        # does not support mixed local/remote paths in a single request).
+        use_cache = enable_cache and self._cache.enabled
+        unique_paths = list(dict.fromkeys(self._cache_original_paths))
+        all_cached = use_cache and all(
+            self._cache.cached_path_and_offset(p) is not None
+            for p in unique_paths
+        )
+
+        if use_cache:
+            num_files = len(self._cache_original_paths)
+            if all_cached:
+                logger.info(f"[RunAI Streamer][Cache] ALL {num_files} file(s) found in cache — using local paths (fast path)")
+            else:
+                logger.info(f"[RunAI Streamer][Cache] Cache miss for some files — streaming all {num_files} file(s) from remote")
+
+        # Track cumulative offset per file path for cache hit offset calculation
+        cache_offset_tracker = {}
+        for i, file_stream_request in enumerate(file_stream_requests):
+            if all_cached:
+                original = self._cache_original_paths[i]
+                cached_path, _ = self._cache.cached_path_and_offset(original)
+                file_stream_request.path = cached_path
+                # Set offset to cumulative position within the cached file
+                file_stream_request.offset = cache_offset_tracker.get(original, 0)
+                cache_offset_tracker[original] = cache_offset_tracker.get(original, 0) + sum(file_stream_request.chunks)
+            else:
+                file_stream_request.path = self.handle_object_store(file_stream_request.path, credentials)
+                if use_cache:
+                    self._cache.open_writer(
+                        self._cache_original_paths[i],
+                        file_stream_request.offset,
+                        sum(file_stream_request.chunks),
+                    )
 
         self.requests_iterator: FilesRequestsIteratorWithBuffer = FilesRequestsIteratorWithBuffer.with_memory_mode(file_stream_requests)
- 
+
         self.active_request = self.requests_iterator.next_request()
         if self.active_request is None:
-            return 
+            return
 
         runai_request(
             self.streamer,
@@ -118,14 +167,15 @@ class FileStreamer:
     def get_chunks(self) -> Iterator:
         if not self.streamer:
             raise ValueError("Streamer not initialized")
-        
+
         if self.active_request is None:
-            return 
-        
-        
+            return
+
         while True:
             yield from self.request_ready_chunks()
-            
+
+            self._cache_current_batch()
+
             self.active_request = self.requests_iterator.next_request()
             if self.active_request is None:
                 break
@@ -140,15 +190,25 @@ class FileStreamer:
                 self.s3_credentials,
             )
 
+        # Finalize all remaining cache writers after streaming completes.
+        if self._cache.enabled:
+            for path in list(self._cache._writers.keys()):
+                self._cache.finalize(path)
+
     # This function iterates over indexes of ready chunks.
     # The indexes are relative to the last request that sent
     # And need to be translated to global index in the chunks list
     def request_ready_chunks(self) -> Iterator:
         for i in range(sum(len(file_request.chunks) for file_request in self.active_request.files)):
-            file_relative_index, chunk_relative_index = runai_response(self.streamer)
+            try:
+                file_relative_index, chunk_relative_index = runai_response(self.streamer)
+            except ValueError as e:
+                current_files = [(f.path, f.offset, sum(f.chunks)) for f in self.active_request.files]
+                logger.error(f"[RunAI Streamer][Cache] Read error. Current batch files: {current_files}")
+                raise
             if chunk_relative_index == None:
                 return
-            
+
             file_path, chunk_index, chunk_buffer = self.requests_iterator.get_global_file_and_chunk(file_relative_index, chunk_relative_index)
             # create one dimensional tensor from the chunk buffer
             # we return a tensor of shape (1, chunk_buffer.size)
@@ -164,3 +224,24 @@ class FileStreamer:
                 device_tensor = tensor.to(self.device_str)
                 yield file_path, chunk_index, device_tensor
 
+    def _cache_current_batch(self) -> None:
+        """Write batch data to cache, finalize files as they complete."""
+        if not self._cache.enabled or not self._cache._writers or self.active_request is None:
+            return
+
+        for i, file_request in enumerate(self.active_request.files):
+            original_path = file_request.path
+
+            buf = self.requests_iterator.file_buffers[i]
+            size = sum(file_request.chunks)
+            if size == 0:
+                continue
+
+            data = memoryview(buf)[:size]
+
+            self._cache.append_data(original_path, data)
+            self._cache_written_bytes[original_path] = self._cache_written_bytes.get(original_path, 0) + size
+
+            # Finalize as soon as all bytes for this file are written
+            if self._cache_written_bytes[original_path] >= self._cache_expected_bytes.get(original_path, 0):
+                self._cache.finalize(original_path)

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -204,14 +204,14 @@ class FileStreamer:
     # The indexes are relative to the last request that sent
     # And need to be translated to global index in the chunks list
     def request_ready_chunks(self) -> Iterator:
-        for i in range(sum(len(file_request.chunks) for file_request in self.active_request.files)):
+        for _ in range(sum(len(file_request.chunks) for file_request in self.active_request.files)):
             try:
                 file_relative_index, chunk_relative_index = runai_response(self.streamer)
             except ValueError as e:
                 current_files = [(f.path, f.offset, sum(f.chunks)) for f in self.active_request.files]
                 logger.error(f"[RunAI Streamer][Cache] Read error. Current batch files: {current_files}")
                 raise
-            if chunk_relative_index == None:
+            if chunk_relative_index is None:
                 return
 
             file_path, chunk_index, chunk_buffer = self.requests_iterator.get_global_file_and_chunk(file_relative_index, chunk_relative_index)

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -198,8 +198,7 @@ class FileStreamer:
 
         # Finalize all remaining cache writers after streaming completes.
         if self._cache.enabled:
-            for path in list(self._cache._writers.keys()):
-                self._cache.finalize(path)
+            self._cache.finalize_all()
 
     # This function iterates over indexes of ready chunks.
     # The indexes are relative to the last request that sent
@@ -232,7 +231,7 @@ class FileStreamer:
 
     def _cache_current_batch(self) -> None:
         """Write batch data to cache, finalize files as they complete."""
-        if not self._cache.enabled or not self._cache._writers or self.active_request is None:
+        if not self._cache.enabled or not self._cache.has_pending_writers() or self.active_request is None:
             return
 
         for i, file_request in enumerate(self.active_request.files):

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -234,19 +234,23 @@ class FileStreamer:
         if not self._cache.enabled or not self._cache.has_pending_writers() or self.active_request is None:
             return
 
-        for i, file_request in enumerate(self.active_request.files):
-            original_path = file_request.path
+        try:
+            for i, file_request in enumerate(self.active_request.files):
+                original_path = file_request.path
 
-            buf = self.requests_iterator.file_buffers[i]
-            size = sum(file_request.chunks)
-            if size == 0:
-                continue
+                buf = self.requests_iterator.file_buffers[i]
+                size = sum(file_request.chunks)
+                if size == 0:
+                    continue
 
-            data = memoryview(buf)[:size]
+                data = memoryview(buf)[:size]
 
-            self._cache.append_data(original_path, data)
-            self._cache_written_bytes[original_path] = self._cache_written_bytes.get(original_path, 0) + size
+                self._cache.append_data(original_path, data)
+                self._cache_written_bytes[original_path] = self._cache_written_bytes.get(original_path, 0) + size
 
-            # Finalize as soon as all bytes for this file are written
-            if self._cache_written_bytes[original_path] >= self._cache_expected_bytes.get(original_path, 0):
-                self._cache.finalize(original_path)
+                # Finalize as soon as all bytes for this file are written
+                if self._cache_written_bytes[original_path] >= self._cache_expected_bytes.get(original_path, 0):
+                    self._cache.finalize(original_path)
+        except OSError as e:
+            logger.warning(f"[RunAI Streamer][Cache] Cache write failed ({e}), disabling cache for this session")
+            self._cache.abort_all()

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -75,6 +75,8 @@ class FileStreamer:
         logger.info(
             f"[RunAI Streamer] Overall time to stream {humanize.naturalsize(size, binary=True)} of all files to {self.device_str}: {round(elapsed_time, 2)}s, {humanize.naturalsize(throughput, binary=True)}/s"
         )
+        if exc_type is not None and self._cache.enabled:
+            self._cache.abort_all()
         if self.streamer:
             runai_end(self.streamer)
 
@@ -115,12 +117,16 @@ class FileStreamer:
 
         # Check cache: only use cached paths if ALL unique files hit cache (the C++ layer
         # does not support mixed local/remote paths in a single request).
+        # Build lookup once to avoid TOCTOU race (file could be deleted between check and use).
         use_cache = enable_cache and self._cache.enabled
         unique_paths = list(dict.fromkeys(self._cache_original_paths))
-        all_cached = use_cache and all(
-            self._cache.cached_path_and_offset(p) is not None
-            for p in unique_paths
-        )
+        cache_lookup = {}
+        if use_cache:
+            for p in unique_paths:
+                result = self._cache.cached_path_and_offset(p)
+                if result is not None:
+                    cache_lookup[p] = result
+        all_cached = use_cache and len(cache_lookup) == len(unique_paths)
 
         if use_cache:
             num_files = len(self._cache_original_paths)
@@ -134,7 +140,7 @@ class FileStreamer:
         for i, file_stream_request in enumerate(file_stream_requests):
             if all_cached:
                 original = self._cache_original_paths[i]
-                cached_path, _ = self._cache.cached_path_and_offset(original)
+                cached_path, _ = cache_lookup[original]
                 file_stream_request.path = cached_path
                 # Set offset to cumulative position within the cached file
                 file_stream_request.offset = cache_offset_tracker.get(original, 0)

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -239,6 +239,7 @@ class SafetensorsStreamer:
             credentials=s3_credentials,
             device=device,
             is_distributed=is_distributed,
+            enable_cache=True,
         )
 
     def get_tensors(self) -> Iterator[torch.tensor]:


### PR DESCRIPTION
### Feature Description

Adds write-through local caching for model files streamed from object storage. When enabled, tensor data is written to a local directory during streaming (zero-copy via buffer protocol) and served from local filesystem on subsequent loads. According Issue for this feature discussion: https://github.com/run-ai/runai-model-streamer/issues/152

### Changes

**New files:**
- `py/runai_model_streamer/runai_model_streamer/cache/__init__.py`
- `py/runai_model_streamer/runai_model_streamer/cache/cache.py` — `StreamCache` class with TP-aware cache keys, atomic writes, race condition handling
- `docs/src/local-cache.md` — feature documentation

**Modified files:**
- `py/runai_model_streamer/runai_model_streamer/__init__.py` — logging handler (opt-in via `RUNAI_STREAMER_LOG_LEVEL`)
- `py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py` — cache integration (hit/miss logic, write-through, `enable_cache` parameter)
- `py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py` — pass `enable_cache`, call `set_distributed(rank, world_size)` for TP-aware keys
- `py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py` — pass `enable_cache=True` for tensor data stream (not header reads)
- `docs/src/env-vars.md` — document `RUNAI_STREAMER_CACHE_DIR`

### How It Works

**First load (cache miss):**
```
S3 → C++ streamer → DRAM buffer → GPU
                          │
                          └→ os.write() to /cache/<file>.partial.<pid>
                             (inline, buffer protocol, no extra copy)
                             When file complete: rename → final, write .done sentinel
```

**Second load (cache hit):**
```
/cache/<file> → C++ streamer (local filesystem) → GPU
(NVMe speed, no network)
```

### Design Decisions

1. **Write-through, not write-back**: Data is written to cache inline during streaming. No background thread, no second S3 download. The only overhead is `os.write()` to page cache which is typically non-blocking.

2. **TP-aware cache keys**: With distributed streaming, each worker caches its own tensor partition. Cache key includes rank and world_size: `model-00001.safetensors.tp4_rank0.<hash>`. Same TP config → cache hit; different TP → cache miss (no corruption).

3. **Atomic writes**: Data goes to `.partial.<pid>` temp file, then `os.rename()` to final path. The `.done` sentinel is only written after rename succeeds. Prevents serving incomplete files if process dies mid-write.

4. **Race condition handling**: Multiple TP workers (separate processes) may cache the same file. Each writes to its own `.partial.<pid>`. First to finish renames to final; others detect existing file and clean up. No locks needed.

5. **All-or-nothing cache hit**: The C++ layer cannot mix local and remote paths in one request. Cache is used only when ALL files for a worker hit. Partial hits fall back to full S3 streaming (while scheduling background cache writes for misses).

6. **Only tensor data is cached**: The `enable_cache=True` flag is only passed for the tensor data stream call, not the header reads (8 bytes + JSON). This prevents tiny header reads from creating invalid cache entries.

7. **Short write handling**: `os.write()` on Linux can return less than requested for buffers >2GB (`ssize_t` limit). The write loop retries until all bytes are written.

### Configuration

```yaml
env:
  - name: RUNAI_STREAMER_CACHE_DIR
    value: "/models"
volumeMounts:
  - name: model-cache
    mountPath: /models
volumes:
  - name: model-cache
    hostPath:
      path: /mnt/k8s-disks/0/models
      type: DirectoryOrCreate
```

### Cache Directory Structure

```
/models/
├── model-00001.safetensors.tp4_rank0.61cc262a76817ddb
├── model-00001.safetensors.tp4_rank0.61cc262a76817ddb.done
├── model-00001.safetensors.tp4_rank1.61cc262a76817ddb
├── model-00001.safetensors.tp4_rank1.61cc262a76817ddb.done
└── ...
```

Without distributed streaming (TP=1):
```
/models/
├── model-00001.safetensors.61cc262a76817ddb
├── model-00001.safetensors.61cc262a76817ddb.done
└── ...
```

### Sentinel File (.done)

```json
{
  "remote_path": "s3://bucket/model/model-00001.safetensors",
  "file_offset": 8392,
  "size": 1073741824,
  "rank": 0,
  "world_size": 4
}
```

### Testing

- Unit tests: `test_cache.py` covers cache enable/disable, hit/miss, write-through, race conditions
- Integration tested with vLLM on:
  - Ministral-3-8B (22GB) on g6e.12xlarge (TP=2, TP=4)
  - Qwen3.6-35B-A3B (64GB) on g6e.12xlarge (TP=4) and p5.48xlarge (TP=4, TP=8)
  - Llama-4-Scout-17B-16E (220GB) on p5.48xlarge (TP=4, TP=8)


**g6e.12xlarge (4x L40S 48GB, 40 Gbps NIC, single NVMe ~3.5 GB/s, 96GB RAM)**

| Model | TP | S3 (no cache) | NVMe preloaded (s5cmd) | Cache 1st pod (cache miss) | Cache 2nd pod (NVMe cache hit) |
|-------|-----|--------------|----------------------|---------------|--------------------------|
| Ministral-3-8B (22GB) | 2 | 8.5s | 6.3s | 8.3s (~same as S3) | 6.9s |
| Qwen3.6-35B-A3B (64GB) | 4 | 29.6s | 20.0s | 31.7s* (+2s) | 21.1s |

*With `dirty_ratio=80` node tuning for Qwen3.6-35B-A3B case. Without tuning: 43.7s (+14s overhead). See [Kernel Dirty Page Pressure](#kernel-dirty-page-pressure).

**p5.48xlarge (8x H100 80GB, 200 Gbps NIC, 4x NVMe striped ~14 GB/s, 2TB RAM)**

| Model | TP | S3 (no cache) | NVMe preloaded (s5cmd) | Cache 1st pod (cache miss) | Cache 2nd pod (NVMe cache hit) |
|-------|-----|--------------|----------------------|---------------|--------------------------|
| Qwen3.6-35B-A3B (64GB) | 4 | 15.7s | 7.0s | 18.7s (+3s) | 7.6s |
| Llama-4-Scout (220GB) | 4 | 33.6s | 9.9s | 29.4s (~same) | 9.6s |

**Key observations:**
- Cache 2nd pod performance matches NVMe preloaded (s5cmd daemonset) — same local NVMe read speed
- First-pod cache write overhead is negligible on high-RAM instances (p5) and for small models
- Cache hit consistently provides 2-7x faster weight loading vs S3
- Larger models benefit more from caching (220GB: 71% improvement on scale-up)
- The cache approach eliminates the need for a preload daemonset while achieving equivalent NVMe read performance

### Compatibility

- Backward compatible: no behavior change when `RUNAI_STREAMER_CACHE_DIR` is not set
- Works with and without distributed streaming
- Expected to work with all object storage backends (S3, GCS, Azure), but only test with s3 above
- Cache entries are isolated by TP config — changing TP causes cache miss, not corruption
- No C++ changes required

### Known Limitations

- Cache hit requires ALL files to be cached (partial hits fall back to S3)
- Cache is tied to TP configuration (TP=4 cache cannot serve TP=8)
- On instances with limited RAM, large model cache writes may hit kernel dirty page limits (see below #Kernel Dirty Page Pressure)  — recommend setting `vm.dirty_ratio=80` on such nodes

### Kernel Dirty Page Pressure

Linux's `dirty_ratio` (default 20% of RAM) controls when `os.write()` blocks. When dirty pages exceed this threshold, the kernel forces synchronous writeback — stalling the streaming pipeline until pages flush to disk.

**How the limit is hit:**

With distributed streaming (TP=N), each worker writes its partition to cache simultaneously:
```
Total dirty pages generated = (model_size / TP) × TP = model_size
All workers write concurrently → all dirty pages accumulate at once
```

The write blocks when: `model_size > dirty_ratio × instance_RAM`

**Examples:**

| Instance | RAM | Model | Dirty pages generated | 20% limit | Exceeds? | Impact |
|----------|-----|-------|----------------------|-----------|----------|--------|
| g6e.12xlarge | 96GB | 64GB (TP=4) | 16GB × 4 = 64GB | 19GB | **3.4x over** | +16.6s overhead |
| g6e.12xlarge | 96GB | 22GB (TP=4) | 5.5GB × 4 = 22GB | 19GB | 1.2x over | ~0s (writes interleave with downloads) |
| g6e.48xlarge | 384GB | 64GB (TP=4) | 16GB × 4 = 64GB | 77GB | No | No impact |
| p5.48xlarge | 2TB | 64GB (TP=4) | 16GB × 4 = 64GB | 400GB | No | No impact |
| p5.48xlarge | 2TB | 220GB (TP=8) | 27.5GB × 8 = 220GB | 400GB | No | No impact |

**Rule of thumb:** Cache write overhead is significant when `model_size > 20% of instance RAM`.

**Fix:** Set `vm.dirty_ratio=80` on affected nodes:
```bash
echo 80 > /proc/sys/vm/dirty_ratio
echo 50 > /proc/sys/vm/dirty_background_ratio
```

**Results (g6e.12xlarge, 64GB model):**

| | dirty_ratio=20% (default) | dirty_ratio=80% |
|---|---|---|
| First load with cache | 43.7s | 31.7s |
| Cache write overhead | +16.6s | +4.6s |
| Remaining overhead source | Physical NVMe write speed (~3.5 GB/s) | Same (unavoidable) |

This tuning is only needed for instances where `model_size > 20% × RAM`. For most production deployments on p4d/p5 class instances (1-2TB RAM), the default is sufficient. But the model cache actually shouldn't be used when using a instance type with relative small RAM size compared with model size, so this kernel Dirty Page Pressure might not be a real issue here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added opt-in local filesystem caching for streamed files, reusing fully cached artifacts on subsequent requests.
  * Introduced an `enable_cache` option across distributed streaming and safetensors streaming for rank-aware cache usage.

* **Documentation**
  * Added a guide covering cache directory/layout, cache miss vs hit behavior, and tuning/logging for concurrency and performance.

* **Bug Fixes**
  * Improved cache correctness by verifying cache completion metadata before reuse and cleaning up incomplete cache artifacts on errors/aborts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->