### PR TITLE
List files

### DIFF
--- a/cpp/azure/azure.cc
+++ b/cpp/azure/azure.cc
@@ -1,6 +1,7 @@
 #include "azure/azure.h"
 #include "azure/client/client.h"
 
+#include "common/backend_api/object_storage/list_files_impl.h"
 #include "common/client_mgr/client_mgr.h"
 #include "common/exception/exception.h"
 #include "utils/env/env.h"
@@ -195,6 +196,24 @@ common::backend_api::ResponseCode_t obj_wait_for_completions(common::backend_api
     }
 
     return common::ResponseCode::Success;
+}
+
+common::backend_api::ResponseCode_t obj_list_files(
+    common::backend_api::ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries)
+{
+    return common::backend_api::impl_obj_list_files<AzureClient>(
+        client_handle, prefix, is_recursive, out_entries, out_num_entries);
+}
+
+void obj_free_file_list(
+    common::backend_api::ObjectFileEntry_t* entries,
+    unsigned num_entries)
+{
+    common::backend_api::impl_obj_free_file_list(entries, num_entries);
 }
 
 }; // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/azure.h
+++ b/cpp/azure/azure.h
@@ -82,4 +82,18 @@ extern "C" common::backend_api::ResponseCode_t obj_cancel_all_reads();
 // release clients
 extern "C" common::backend_api::ResponseCode_t obj_remove_all_clients();
 
+// list files
+extern "C" common::backend_api::ResponseCode_t obj_list_files(
+    common::backend_api::ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries
+);
+
+extern "C" void obj_free_file_list(
+    common::backend_api::ObjectFileEntry_t* entries,
+    unsigned num_entries
+);
+
 }; //namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/azure.ldscript
+++ b/cpp/azure/azure.ldscript
@@ -9,5 +9,7 @@
     obj_wait_for_completions;
     obj_cancel_all_reads;
     obj_remove_all_clients;
+    obj_list_files;
+    obj_free_file_list;
   local: *;
 };

--- a/cpp/azure/client/client.cc
+++ b/cpp/azure/client/client.cc
@@ -317,4 +317,50 @@ common::ResponseCode AzureClient::async_read(const char* path,
     return _stop ? common::ResponseCode::FinishedError : common::ResponseCode::Success;
 }
 
+common::ResponseCode AzureClient::list_files(
+    const char* prefix,
+    int is_recursive,
+    std::vector<std::pair<std::string, size_t>>& results)
+{
+    const auto uri = common::s3::StorageUri(prefix);
+    const std::string uri_prefix = uri.scheme + "://" + uri.bucket + "/";
+
+    auto container_client = _blob_service_client->GetBlobContainerClient(uri.bucket);
+
+    ListBlobsOptions options;
+    if (!uri.path.empty())
+    {
+        options.Prefix = uri.path;
+    }
+
+    auto process_page = [&](const auto& page_result)
+    {
+        for (const auto& blob : page_result.Blobs)
+        {
+            if (!blob.Name.empty() && blob.Name.back() == '/')
+            {
+                continue;
+            }
+            results.emplace_back(uri_prefix + blob.Name, static_cast<size_t>(blob.BlobSize));
+        }
+    };
+
+    if (is_recursive)
+    {
+        for (auto page = container_client.ListBlobs(options); page.HasPage(); page.MoveToNextPage())
+        {
+            process_page(page);
+        }
+    }
+    else
+    {
+        for (auto page = container_client.ListBlobsByHierarchy("/", options); page.HasPage(); page.MoveToNextPage())
+        {
+            process_page(page);
+        }
+    }
+
+    return common::ResponseCode::Success;
+}
+
 } // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/client/client.h
+++ b/cpp/azure/client/client.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <string>
 #include <optional>
+#include <utility>
+#include <vector>
 
 #include "azure/client_configuration/client_configuration.h"
 #include "azure/client/async_azure_client/async_azure_client.h"
@@ -28,12 +30,15 @@ struct AzureClient : common::IClient
     // verify that client's credentials have not changed
     bool verify_credentials(const common::backend_api::ObjectClientConfig_t & config) const;
 
-    common::ResponseCode async_read(const char* path, 
-                                    common::backend_api::ObjectRange_t range, 
-                                    char* destination_buffer, 
+    common::ResponseCode async_read(const char* path,
+                                    common::backend_api::ObjectRange_t range,
+                                    char* destination_buffer,
                                     common::backend_api::ObjectRequestId_t request_id);
 
     common::backend_api::Response async_read_response();
+
+    common::ResponseCode list_files(const char* prefix, int is_recursive,
+                                    std::vector<std::pair<std::string, size_t>>& results);
 
     // Stop sending requests to the object store
     // If stopped before all requests for an async_read() call are sent, subsequent request chunks will not be sent.

--- a/cpp/common/backend_api/object_storage/BUILD
+++ b/cpp/common/backend_api/object_storage/BUILD
@@ -1,8 +1,18 @@
-load("//:rules.bzl", "runai_cc_auto_library")
+load("//:rules.bzl", "runai_cc_auto_library", "runai_cc_test")
 
 runai_cc_auto_library(
     name = "object_storage",
     deps = [
         "//common/response",
+    ],
+)
+
+runai_cc_test(
+    name = "list_files_impl_test",
+    srcs = ["list_files_impl_test.cc"],
+    deps = [
+        ":object_storage",
+        "//common/response_code",
+        "//utils/logging",
     ],
 )

--- a/cpp/common/backend_api/object_storage/list_files_impl.h
+++ b/cpp/common/backend_api/object_storage/list_files_impl.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/backend_api/object_storage/object_storage.h"
+#include "common/response/response.h"
+#include "utils/logging/logging.h"
+
+namespace runai::llm::streamer::common::backend_api
+{
+
+namespace
+{
+
+ObjectFileEntry_t* make_entries(
+    const std::vector<std::pair<std::string, size_t>>& results)
+{
+    size_t path_bytes = 0;
+    for (const auto& r : results)
+        path_bytes += r.first.size() + 1;
+
+    const size_t entries_bytes = results.size() * sizeof(ObjectFileEntry_t);
+
+    auto* buf       = new char[entries_bytes + path_bytes];
+    auto* entries   = reinterpret_cast<ObjectFileEntry_t*>(buf);
+    char* path_area = buf + entries_bytes;
+
+    for (size_t i = 0; i < results.size(); ++i)
+    {
+        const auto& path_str = results[i].first;
+        entries[i].path = path_area;
+        path_str.copy(path_area, path_str.size());
+        path_area[path_str.size()] = '\0';
+        path_area += path_str.size() + 1;
+        entries[i].size = results[i].second;
+    }
+
+    return entries;
+}
+
+} // anonymous namespace
+
+template<typename ClientT>
+ResponseCode_t impl_obj_list_files(
+    ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries)
+{
+    if (!client_handle || !prefix || !out_entries || !out_num_entries)
+    {
+        return common::ResponseCode::InvalidParameterError;
+    }
+
+    try
+    {
+        auto* client = static_cast<ClientT*>(client_handle);
+        std::vector<std::pair<std::string, size_t>> results;
+
+        const auto ret = client->list_files(prefix, is_recursive, results);
+        if (ret != common::ResponseCode::Success)
+        {
+            return ret;
+        }
+
+        *out_num_entries = static_cast<unsigned>(results.size());
+
+        if (results.empty())
+        {
+            *out_entries = nullptr;
+            return common::ResponseCode::Success;
+        }
+
+        *out_entries = make_entries(results);
+        return common::ResponseCode::Success;
+    }
+    catch (const std::exception& e)
+    {
+        LOG(ERROR) << "Failed to list files: " << e.what();
+    }
+    return common::ResponseCode::UnknownError;
+}
+
+inline void impl_obj_free_file_list(ObjectFileEntry_t* entries, unsigned /* num_entries */)
+{
+    delete[] reinterpret_cast<char*>(entries);
+}
+
+} // namespace runai::llm::streamer::common::backend_api

--- a/cpp/common/backend_api/object_storage/list_files_impl_test.cc
+++ b/cpp/common/backend_api/object_storage/list_files_impl_test.cc
@@ -1,0 +1,152 @@
+#include "common/backend_api/object_storage/list_files_impl.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/response_code/response_code.h"
+
+namespace runai::llm::streamer::common::backend_api
+{
+
+namespace
+{
+
+// Minimal stand-in for a backend client: records the arguments it was called with
+// and returns a caller-configured result / error / exception.
+struct FakeClient
+{
+    std::vector<std::pair<std::string, size_t>> to_return;
+    common::ResponseCode ret = common::ResponseCode::Success;
+    bool should_throw = false;
+
+    int seen_is_recursive = -1;
+    std::string seen_prefix;
+
+    common::ResponseCode list_files(const char* prefix, int is_recursive, std::vector<std::pair<std::string, size_t>>& results)
+    {
+        seen_prefix = prefix;
+        seen_is_recursive = is_recursive;
+        if (should_throw)
+        {
+            throw std::runtime_error("list_files failed");
+        }
+        results = to_return;
+        return ret;
+    }
+};
+
+// Sentinel pointer used to prove out_entries is left untouched on error paths
+ObjectFileEntry_t* const sentinel = reinterpret_cast<ObjectFileEntry_t*>(0xdead);
+
+} // namespace
+
+TEST(ListFilesImpl, SuccessPacksEntries)
+{
+    FakeClient client;
+    client.to_return = {
+        {"s3://bucket/a", 10},
+        {"s3://bucket/longer/path/b", 20},
+        {"", 0}, // empty path exercises the path_area offset arithmetic
+    };
+
+    ObjectFileEntry_t* entries = nullptr;
+    unsigned num_entries = 0;
+
+    const auto ret = impl_obj_list_files<FakeClient>(&client, "s3://bucket/", 1, &entries, &num_entries);
+
+    EXPECT_EQ(ret, common::ResponseCode::Success);
+    ASSERT_EQ(num_entries, 3u);
+    ASSERT_NE(entries, nullptr);
+
+    EXPECT_STREQ(entries[0].path, "s3://bucket/a");
+    EXPECT_EQ(entries[0].size, 10u);
+    EXPECT_STREQ(entries[1].path, "s3://bucket/longer/path/b");
+    EXPECT_EQ(entries[1].size, 20u);
+    EXPECT_STREQ(entries[2].path, "");
+    EXPECT_EQ(entries[2].size, 0u);
+
+    // each path is independently null-terminated and lives at a distinct offset
+    EXPECT_NE(entries[0].path, entries[1].path);
+    EXPECT_EQ(std::strlen(entries[0].path), std::string("s3://bucket/a").size());
+
+    impl_obj_free_file_list(entries, num_entries);
+}
+
+TEST(ListFilesImpl, ForwardsPrefixAndIsRecursive)
+{
+    FakeClient client;
+    ObjectFileEntry_t* entries = nullptr;
+    unsigned num_entries = 0;
+
+    impl_obj_list_files<FakeClient>(&client, "s3://bucket/p", 0, &entries, &num_entries);
+    EXPECT_EQ(client.seen_prefix, "s3://bucket/p");
+    EXPECT_EQ(client.seen_is_recursive, 0);
+
+    impl_obj_list_files<FakeClient>(&client, "s3://bucket/p", 1, &entries, &num_entries);
+    EXPECT_EQ(client.seen_is_recursive, 1);
+}
+
+TEST(ListFilesImpl, EmptyResultsYieldNullptr)
+{
+    FakeClient client; // empty to_return, Success
+
+    ObjectFileEntry_t* entries = sentinel;
+    unsigned num_entries = 123;
+
+    const auto ret = impl_obj_list_files<FakeClient>(&client, "s3://bucket/", 1, &entries, &num_entries);
+
+    EXPECT_EQ(ret, common::ResponseCode::Success);
+    EXPECT_EQ(num_entries, 0u);
+    EXPECT_EQ(entries, nullptr);
+
+    // freeing an empty listing is a safe no-op (delete[] nullptr)
+    impl_obj_free_file_list(entries, num_entries);
+}
+
+TEST(ListFilesImpl, ClientErrorDoesNotAllocate)
+{
+    FakeClient client;
+    client.ret = common::ResponseCode::FileAccessError;
+    client.to_return = {{"s3://bucket/a", 10}}; // would-be entries must not be allocated
+
+    ObjectFileEntry_t* entries = sentinel;
+    unsigned num_entries = 123;
+
+    const auto ret = impl_obj_list_files<FakeClient>(&client, "s3://bucket/", 1, &entries, &num_entries);
+
+    EXPECT_EQ(ret, common::ResponseCode::FileAccessError);
+    EXPECT_EQ(entries, sentinel); // out_entries untouched -> caller has nothing to free
+}
+
+TEST(ListFilesImpl, ClientThrowsReturnsUnknownError)
+{
+    FakeClient client;
+    client.should_throw = true;
+
+    ObjectFileEntry_t* entries = sentinel;
+    unsigned num_entries = 123;
+
+    const auto ret = impl_obj_list_files<FakeClient>(&client, "s3://bucket/", 1, &entries, &num_entries);
+
+    EXPECT_EQ(ret, common::ResponseCode::UnknownError);
+    EXPECT_EQ(entries, sentinel);
+}
+
+TEST(ListFilesImpl, NullArgumentsRejected)
+{
+    FakeClient client;
+    ObjectFileEntry_t* entries = nullptr;
+    unsigned num_entries = 0;
+
+    EXPECT_EQ(impl_obj_list_files<FakeClient>(nullptr, "s3://bucket/", 1, &entries, &num_entries), common::ResponseCode::InvalidParameterError);
+    EXPECT_EQ(impl_obj_list_files<FakeClient>(&client, nullptr, 1, &entries, &num_entries), common::ResponseCode::InvalidParameterError);
+    EXPECT_EQ(impl_obj_list_files<FakeClient>(&client, "s3://bucket/", 1, nullptr, &num_entries), common::ResponseCode::InvalidParameterError);
+    EXPECT_EQ(impl_obj_list_files<FakeClient>(&client, "s3://bucket/", 1, &entries, nullptr), common::ResponseCode::InvalidParameterError);
+}
+
+} // namespace runai::llm::streamer::common::backend_api

--- a/cpp/common/backend_api/object_storage/object_storage.h
+++ b/cpp/common/backend_api/object_storage/object_storage.h
@@ -201,4 +201,40 @@ ResponseCode_t obj_cancel_all_reads();
  */
 ResponseCode_t obj_remove_all_clients();
 
+// --- File Listing ---
+
+/**
+ * A single entry returned by obj_list_files.
+ * 'path' is heap-allocated (strdup) and must be freed via obj_free_file_list.
+ */
+struct ObjectFileEntry_t
+{
+    char*  path;  // full URI (e.g. "s3://bucket/key"), null-terminated
+    size_t size;  // file size in bytes
+};
+
+/**
+ * Synchronously lists all files under a given URI prefix.
+ * Cloud pagination is handled internally; the full result is returned in one call.
+ *
+ * - client_handle   - handle obtained from obj_create_client
+ * - prefix          - full URI prefix to list (e.g. "s3://bucket/models/")
+ * - is_recursive    - 0 = immediate children only, non-zero = all descendants
+ * - out_entries     - set to a malloc'd array of ObjectFileEntry_t; free with obj_free_file_list
+ * - out_num_entries - number of entries in *out_entries
+ * Returns Success or an error code.
+ */
+ResponseCode_t obj_list_files(
+    ObjectClientHandle_t  client_handle,
+    const char*           prefix,
+    int                   is_recursive,
+    ObjectFileEntry_t**   out_entries,
+    unsigned*             out_num_entries
+);
+
+/**
+ * Frees the array returned by obj_list_files.
+ */
+void obj_free_file_list(ObjectFileEntry_t* entries, unsigned num_entries);
+
 } // namespace runai::llm::streamer::common::backend_api

--- a/cpp/common/backend_api/object_storage/object_storage.h
+++ b/cpp/common/backend_api/object_storage/object_storage.h
@@ -205,7 +205,9 @@ ResponseCode_t obj_remove_all_clients();
 
 /**
  * A single entry returned by obj_list_files.
- * 'path' is heap-allocated (strdup) and must be freed via obj_free_file_list.
+ * 'path' points into a buffer owned by the entry array; it is NOT an independent
+ * allocation. Do not free/delete individual paths. The whole result (entries and
+ * all their paths) is released as one unit via obj_free_file_list.
  */
 struct ObjectFileEntry_t
 {
@@ -220,9 +222,13 @@ struct ObjectFileEntry_t
  * - client_handle   - handle obtained from obj_create_client
  * - prefix          - full URI prefix to list (e.g. "s3://bucket/models/")
  * - is_recursive    - 0 = immediate children only, non-zero = all descendants
- * - out_entries     - set to a malloc'd array of ObjectFileEntry_t; free with obj_free_file_list
+ * - out_entries     - set to a single heap-allocated array of ObjectFileEntry_t (the
+ *                     entries and their path strings share one allocation); release
+ *                     the whole thing with obj_free_file_list and never free the
+ *                     entries or individual paths directly. Set to nullptr when empty.
  * - out_num_entries - number of entries in *out_entries
- * Returns Success or an error code.
+ * Returns Success or an error code. On error nothing is allocated and the output
+ * parameters are left untouched.
  */
 ResponseCode_t obj_list_files(
     ObjectClientHandle_t  client_handle,
@@ -233,7 +239,8 @@ ResponseCode_t obj_list_files(
 );
 
 /**
- * Frees the array returned by obj_list_files.
+ * Frees the result returned by obj_list_files as a single allocation (entries and
+ * all their path strings). Safe to call with a nullptr entries pointer.
  */
 void obj_free_file_list(ObjectFileEntry_t* entries, unsigned num_entries);
 

--- a/cpp/common/s3_wrapper/s3_wrapper.cc
+++ b/cpp/common/s3_wrapper/s3_wrapper.cc
@@ -266,6 +266,31 @@ common::ResponseCode S3ClientWrapper::async_read_response(std::vector<backend_ap
     return ret;
 }
 
+common::ResponseCode S3ClientWrapper::list_files(
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries)
+{
+    auto list_files_ = _backend_handle->dylib_ptr->dlsym<
+        common::backend_api::ResponseCode_t(*)(
+            common::backend_api::ObjectClientHandle_t,
+            const char*,
+            int,
+            common::backend_api::ObjectFileEntry_t**,
+            unsigned*)>("obj_list_files");
+    return list_files_(_s3_client, prefix, is_recursive, out_entries, out_num_entries);
+}
+
+void S3ClientWrapper::free_file_list(
+    common::backend_api::ObjectFileEntry_t* entries,
+    unsigned num_entries)
+{
+    auto free_file_list_ = _backend_handle->dylib_ptr->dlsym<
+        void(*)(common::backend_api::ObjectFileEntry_t*, unsigned)>("obj_free_file_list");
+    free_file_list_(entries, num_entries);
+}
+
 common::backend_api::ObjectShutdownPolicy_t S3ClientWrapper::get_backend_shutdown_policy(std::shared_ptr<S3ClientWrapper::BackendHandle> handle)
 {
     ASSERT(handle != nullptr) << "object storage backend handle is not initialized";

--- a/cpp/common/s3_wrapper/s3_wrapper.h
+++ b/cpp/common/s3_wrapper/s3_wrapper.h
@@ -108,6 +108,11 @@ struct S3ClientWrapper
       common::ResponseCode async_read(const Params & params, backend_api::ObjectRequestId_t request_id, const Range & ranges, char * buffer);
       common::ResponseCode async_read_response(std::vector<backend_api::ObjectCompletionEvent_t> & event_buffer, unsigned max_events_to_retrieve);
 
+      common::ResponseCode list_files(const char* prefix, int is_recursive,
+                                      backend_api::ObjectFileEntry_t** out_entries,
+                                      unsigned* out_num_entries);
+      void free_file_list(backend_api::ObjectFileEntry_t* entries, unsigned num_entries);
+
       // stop - stops the responder of each S3 client, in order to notify callers which sent a request and are waiting for a response
       //        required for stopping the threadpool workers, which are bloking on the client responder
       static void stop();

--- a/cpp/gcs/client/client.cc
+++ b/cpp/gcs/client/client.cc
@@ -161,4 +161,45 @@ void GCSClient::stop()
     }
 }
 
+common::ResponseCode GCSClient::list_files(
+    const char* prefix,
+    int is_recursive,
+    std::vector<std::pair<std::string, size_t>>& results)
+{
+    const auto uri = common::s3::StorageUri(prefix);
+    const std::string uri_prefix = uri.scheme + "://" + uri.bucket + "/";
+
+    google::cloud::storage::Client gcs_client(_client_config.options);
+
+    namespace gcs = google::cloud::storage;
+
+    auto list_objects = [&](auto&&... opts)
+    {
+        for (auto&& meta : gcs_client.ListObjects(uri.bucket, opts...))
+        {
+            if (!meta)
+            {
+                LOG(ERROR) << "GCS ListObjects error: " << meta.status().message();
+                return common::ResponseCode::FileAccessError;
+            }
+            const auto& name = meta->name();
+            if (!name.empty() && name.back() == '/')
+            {
+                continue;
+            }
+            results.emplace_back(uri_prefix + name, static_cast<size_t>(meta->size()));
+        }
+        return common::ResponseCode::Success;
+    };
+
+    if (is_recursive)
+    {
+        return list_objects(gcs::Prefix(uri.path));
+    }
+    else
+    {
+        return list_objects(gcs::Prefix(uri.path), gcs::Delimiter("/"));
+    }
+}
+
 }; // namespace runai::llm::streamer::impl::gcs

--- a/cpp/gcs/client/client.h
+++ b/cpp/gcs/client/client.h
@@ -34,6 +34,9 @@ struct GCSClient : common::IClient
 
     common::backend_api::Response async_read_response();
 
+    common::ResponseCode list_files(const char* prefix, int is_recursive,
+                                    std::vector<std::pair<std::string, size_t>>& results);
+
     // Stop sending requests to the object store
     // If stopped before all requests for an async_read() call are sent, subsequent request chunks will not be sent.
     void stop();

--- a/cpp/gcs/gcs.cc
+++ b/cpp/gcs/gcs.cc
@@ -1,5 +1,6 @@
 #include "gcs/gcs.h"
 #include "gcs/client/client.h"
+#include "common/backend_api/object_storage/list_files_impl.h"
 #include "common/client_mgr/client_mgr.h"
 
 #include "common/exception/exception.h"
@@ -158,6 +159,24 @@ common::backend_api::ResponseCode_t obj_wait_for_completions(common::backend_api
         LOG(ERROR) << "Caught exception while sending async request";
     }
     return common::ResponseCode::UnknownError;
+}
+
+common::backend_api::ResponseCode_t obj_list_files(
+    common::backend_api::ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries)
+{
+    return common::backend_api::impl_obj_list_files<GCSClient>(
+        client_handle, prefix, is_recursive, out_entries, out_num_entries);
+}
+
+void obj_free_file_list(
+    common::backend_api::ObjectFileEntry_t* entries,
+    unsigned num_entries)
+{
+    common::backend_api::impl_obj_free_file_list(entries, num_entries);
 }
 
 }; // namespace runai::llm::streamer::impl::gcs

--- a/cpp/gcs/gcs.h
+++ b/cpp/gcs/gcs.h
@@ -46,4 +46,18 @@ extern "C" common::backend_api::ResponseCode_t obj_cancel_all_reads();
 // release clients
 extern "C" common::backend_api::ResponseCode_t obj_remove_all_clients();
 
+// list files
+extern "C" common::backend_api::ResponseCode_t obj_list_files(
+    common::backend_api::ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries
+);
+
+extern "C" void obj_free_file_list(
+    common::backend_api::ObjectFileEntry_t* entries,
+    unsigned num_entries
+);
+
 }; //namespace runai::llm::streamer::impl::gcs

--- a/cpp/gcs/gcs.ldscript
+++ b/cpp/gcs/gcs.ldscript
@@ -9,5 +9,7 @@
         obj_cancel_all_reads;
         obj_remove_all_clients;
         obj_get_backend_shutdown_policy;
+        obj_list_files;
+        obj_free_file_list;
     local: *;
 };

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -158,6 +158,11 @@ extern "C" int runai_list_files(
 {
     namespace fs = std::filesystem;
 
+    if (prefix == nullptr || callback == nullptr)
+    {
+        return -1;
+    }
+
     // Object storage paths are not supported in the mock
     if (::strncmp(prefix, "s3://", 5) == 0 ||
         ::strncmp(prefix, "gs://", 5) == 0 ||
@@ -175,7 +180,7 @@ extern "C" int runai_list_files(
     auto fire = [&](const fs::path& p, size_t size)
     {
         const char* cpath = p.c_str();
-        if (num_allow_patterns > 0)
+        if (allow_patterns != nullptr && num_allow_patterns > 0)
         {
             bool matched = false;
             for (unsigned j = 0; j < num_allow_patterns; ++j)
@@ -184,7 +189,7 @@ extern "C" int runai_list_files(
             }
             if (!matched) return;
         }
-        for (unsigned j = 0; j < num_ignore_patterns; ++j)
+        for (unsigned j = 0; ignore_patterns != nullptr && j < num_ignore_patterns; ++j)
         {
             if (::fnmatch(ignore_patterns[j], cpath, 0) == 0) return;
         }

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -1,7 +1,9 @@
 #include <fcntl.h>
+#include <fnmatch.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <cstring>
+#include <filesystem>
 #include <vector>
 #include "utils/fd/fd.h"
 #include "utils/logging/logging.h"
@@ -140,4 +142,73 @@ extern "C" const char * runai_response_str(int response_code)
 {
     return 0;
 }
+
+extern "C" int runai_list_files(
+    const char *  prefix,
+    int           is_recursive,
+    const char ** allow_patterns,
+    unsigned      num_allow_patterns,
+    const char ** ignore_patterns,
+    unsigned      num_ignore_patterns,
+    void (*callback)(const char*, size_t, void*),
+    void *        user_data,
+    const char ** param_keys,
+    const char ** param_values,
+    unsigned      num_params)
+{
+    namespace fs = std::filesystem;
+
+    // Object storage paths are not supported in the mock
+    if (::strncmp(prefix, "s3://", 5) == 0 ||
+        ::strncmp(prefix, "gs://", 5) == 0 ||
+        ::strncmp(prefix, "az://", 5) == 0)
+    {
+        return 0;
+    }
+
+    const fs::path root(prefix);
+    if (!fs::exists(root))
+    {
+        return 1;
+    }
+
+    auto fire = [&](const fs::path& p, size_t size)
+    {
+        const char* cpath = p.c_str();
+        if (num_allow_patterns > 0)
+        {
+            bool matched = false;
+            for (unsigned j = 0; j < num_allow_patterns; ++j)
+            {
+                if (::fnmatch(allow_patterns[j], cpath, 0) == 0) { matched = true; break; }
+            }
+            if (!matched) return;
+        }
+        for (unsigned j = 0; j < num_ignore_patterns; ++j)
+        {
+            if (::fnmatch(ignore_patterns[j], cpath, 0) == 0) return;
+        }
+        callback(cpath, size, user_data);
+    };
+
+    auto visit = [&](const fs::directory_entry& entry)
+    {
+        if (entry.is_regular_file())
+        {
+            fire(entry.path(), static_cast<size_t>(entry.file_size()));
+        }
+    };
+
+    if (is_recursive)
+    {
+        for (const auto& e : fs::recursive_directory_iterator(root)) visit(e);
+    }
+    else
+    {
+        for (const auto& e : fs::directory_iterator(root)) visit(e);
+    }
+
+    return 0;
+}
+
 } // namespace runai::llm::streamer

--- a/cpp/s3/client/BUILD
+++ b/cpp/s3/client/BUILD
@@ -21,5 +21,15 @@ runai_cc_auto_library(
 runai_cc_test(
     name = "client_test",
     srcs = ["client_test.cc"],
-    deps = [":client"],
+    deps = [
+        ":client",
+        "//s3/s3_init",
+        "//common/exception",
+        "//common/response_code",
+        "//common/s3_credentials",
+        "//common/backend_api/object_storage",
+        "//utils/temp/file",
+        "//utils/temp/env",
+        "//utils/random",
+    ],
 )

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -1,4 +1,7 @@
 
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/config/ConfigAndCredentialsCacheManager.h>
 #include <aws/core/http/Scheme.h>
 #include <aws/s3-crt/model/GetObjectRequest.h>
 #include <aws/s3-crt/model/ListObjectsV2Request.h>
@@ -92,6 +95,17 @@ S3ClientBase::S3ClientBase(const common::backend_api::ObjectClientConfig_t & con
             }
         }
     }
+
+    // Build explicit credentials when an access key was provided; otherwise leave
+    // _client_credentials null so the client falls back to the AWS default
+    // credential provider chain (environment, profile, SSO, IMDS, etc.)
+    if (_key.has_value() && _secret.has_value())
+    {
+        _client_credentials = std::make_unique<Aws::Auth::AWSCredentials>(
+            _key.value(),
+            _secret.value(),
+            _token.has_value() ? _token.value() : Aws::String(""));
+    }
 }
 
 bool S3ClientBase::verify_credentials_member(const std::optional<Aws::String>& member, const std::optional<Aws::String>& value, const char * name) const
@@ -169,7 +183,20 @@ S3Client::S3Client(const common::backend_api::ObjectClientConfig_t & config) :
         _client_config.config.region = _region.value();
     }
 
-    if (utils::try_getenv("AWS_CA_BUNDLE", _client_config.config.caFile))
+    // Resolve the TLS CA bundle: the AWS_CA_BUNDLE environment variable takes
+    // precedence; otherwise fall back to the "ca_bundle" setting in the shared
+    // AWS config profile (~/.aws/config), matching boto3/aws-cli behavior. The
+    // config file is already parsed and cached by Aws::InitAPI (see s3_init).
+    if (!utils::try_getenv("AWS_CA_BUNDLE", _client_config.config.caFile))
+    {
+        const auto ca_bundle = Aws::Config::GetCachedConfigValue(Aws::Auth::GetConfigProfileName(), "ca_bundle");
+        if (!ca_bundle.empty())
+        {
+            _client_config.config.caFile = ca_bundle;
+        }
+    }
+
+    if (!_client_config.config.caFile.empty())
     {
         LOG(DEBUG) << "Setting s3 configuration ca certificate file to " << _client_config.config.caFile;
 

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -1,6 +1,7 @@
 
 #include <aws/core/http/Scheme.h>
 #include <aws/s3-crt/model/GetObjectRequest.h>
+#include <aws/s3-crt/model/ListObjectsV2Request.h>
 
 #include <cstring>
 #include <algorithm>
@@ -307,6 +308,59 @@ void S3Client::stop()
     {
         _responder->stop();
     }
+}
+
+common::ResponseCode S3Client::list_files(
+    const char* prefix,
+    int is_recursive,
+    std::vector<std::pair<std::string, size_t>>& results)
+{
+    const auto uri = common::s3::StorageUri(prefix);
+
+    Aws::S3Crt::Model::ListObjectsV2Request request;
+    request.SetBucket(uri.bucket.c_str());
+    request.SetPrefix(uri.path.c_str());
+    if (!is_recursive)
+    {
+        request.SetDelimiter("/");
+    }
+
+    const std::string uri_prefix = uri.scheme + "://" + uri.bucket + "/";
+
+    bool done = false;
+    while (!done)
+    {
+        auto outcome = _client->ListObjectsV2(request);
+        if (!outcome.IsSuccess())
+        {
+            const auto& err = outcome.GetError();
+            LOG(ERROR) << "S3 ListObjectsV2 failed: " << err.GetExceptionName() << ": " << err.GetMessage();
+            return common::ResponseCode::FileAccessError;
+        }
+
+        const auto& result = outcome.GetResult();
+        for (const auto& obj : result.GetContents())
+        {
+            const auto& key = obj.GetKey();
+            // skip zero-byte directory marker objects (keys ending with "/")
+            if (!key.empty() && key.back() == '/')
+            {
+                continue;
+            }
+            results.emplace_back(uri_prefix + std::string(key), static_cast<size_t>(obj.GetSize()));
+        }
+
+        if (result.GetIsTruncated())
+        {
+            request.SetContinuationToken(result.GetNextContinuationToken());
+        }
+        else
+        {
+            done = true;
+        }
+    }
+
+    return common::ResponseCode::Success;
 }
 
 }; // namespace runai::llm::streamer::impl::s3

--- a/cpp/s3/client/client.h
+++ b/cpp/s3/client/client.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <string>
 #include <optional>
+#include <utility>
+#include <vector>
 
 #include <aws/core/http/Scheme.h>
 
@@ -58,6 +60,11 @@ struct S3Client : S3ClientBase
                                                    common::backend_api::ObjectRequestId_t request_id);
 
     common::backend_api::Response async_read_response();
+
+    // Synchronously lists all objects under prefix (full URI, e.g. "s3://bucket/models/").
+    // Appends (full_uri, size) pairs to results; handles S3 pagination internally.
+    common::ResponseCode list_files(const char* prefix, int is_recursive,
+                                    std::vector<std::pair<std::string, size_t>>& results);
 
     // Stop sending requests to the object store
     // Requests that were already sent cannot be cancelled, since the Aws S3CrtClient does not support aborting requests

--- a/cpp/s3/client/client_test.cc
+++ b/cpp/s3/client/client_test.cc
@@ -1,6 +1,22 @@
 #include "s3/client/client.h"
 
+#include <aws/core/config/ConfigAndCredentialsCacheManager.h>
+
 #include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "s3/s3_init/s3_init.h"
+#include "common/exception/exception.h"
+#include "common/response_code/response_code.h"
+#include "common/s3_credentials/s3_credentials.h"
+#include "common/backend_api/object_storage/object_storage.h"
+#include "utils/temp/file/file.h"
+#include "utils/temp/env/env.h"
+#include "utils/random/random.h"
 
 namespace runai::llm::streamer::impl::s3
 {
@@ -104,6 +120,71 @@ TEST(ParseEndpointScheme, PortWithoutHost)
     EXPECT_EQ(result.host, ":9000");
     ASSERT_TRUE(result.scheme.has_value());
     EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTP);
+}
+
+namespace
+{
+
+void write_config_with_ca_bundle(const std::string & path, const std::string & ca_bundle)
+{
+    std::ofstream out(path, std::ios::trunc);
+    out << "[default]\n";
+    out << "ca_bundle = " << ca_bundle << "\n";
+}
+
+common::backend_api::ObjectClientConfig_t make_config(std::vector<common::backend_api::ObjectConfigParam_t> & params)
+{
+    // provide a region so the underlying S3 client can be constructed
+    params.push_back(common::backend_api::ObjectConfigParam_t{common::s3::Credentials::REGION_KEY, "us-east-1"});
+
+    common::backend_api::ObjectClientConfig_t config{};
+    config.endpoint_url = nullptr;
+    config.default_storage_chunk_size = 8 * 1024 * 1024;
+    config.initial_params = params.data();
+    config.num_initial_params = static_cast<unsigned>(params.size());
+    return config;
+}
+
+} // namespace
+
+// Verifies that when AWS_CA_BUNDLE is not set, the S3 client resolves the CA
+// bundle from the "ca_bundle" setting in the shared AWS config profile.
+TEST(CaBundle, ResolvedFromConfigProfile)
+{
+    // ensure the environment variable does not shadow the profile setting
+    ::unsetenv("AWS_CA_BUNDLE");
+
+    utils::temp::Dir dir;
+    const std::string config_path = dir.path + "/aws_config";
+    const std::string missing_ca = dir.path + "/missing_ca.pem";
+    utils::temp::File valid_ca(dir.path, "ca.pem", utils::random::buffer(32));
+
+    // point the SDK at our temporary config file
+    utils::temp::Env config_file_env("AWS_CONFIG_FILE", config_path);
+
+    S3Init init;
+
+    std::vector<common::backend_api::ObjectConfigParam_t> params;
+    const auto config = make_config(params);
+
+    // 1) ca_bundle points to a non-existent file -> the client rejects it.
+    //    This only fires if the profile ca_bundle was actually read.
+    write_config_with_ca_bundle(config_path, missing_ca);
+    Aws::Config::ReloadCachedConfigFile();
+    try
+    {
+        S3Client client(config);
+        FAIL() << "expected CaFileNotFound for a missing ca_bundle from the config profile";
+    }
+    catch (const common::Exception & e)
+    {
+        EXPECT_EQ(e.error(), common::ResponseCode::CaFileNotFound);
+    }
+
+    // 2) ca_bundle points to an existing file -> accepted, client is created
+    write_config_with_ca_bundle(config_path, valid_ca.path);
+    Aws::Config::ReloadCachedConfigFile();
+    EXPECT_NO_THROW(S3Client client(config));
 }
 
 }; // namespace runai::llm::streamer::impl::s3

--- a/cpp/s3/client/client_test.cc
+++ b/cpp/s3/client/client_test.cc
@@ -152,7 +152,8 @@ common::backend_api::ObjectClientConfig_t make_config(std::vector<common::backen
 TEST(CaBundle, ResolvedFromConfigProfile)
 {
     // ensure the environment variable does not shadow the profile setting
-    ::unsetenv("AWS_CA_BUNDLE");
+    // (restored on scope exit to avoid cross-test pollution)
+    utils::temp::UnsetEnv ca_bundle_env("AWS_CA_BUNDLE");
 
     utils::temp::Dir dir;
     const std::string config_path = dir.path + "/aws_config";

--- a/cpp/s3/s3.cc
+++ b/cpp/s3/s3.cc
@@ -2,6 +2,7 @@
 #include "s3/s3_init/s3_init.h"
 #include "s3/client/client.h"
 
+#include "common/backend_api/object_storage/list_files_impl.h"
 #include "common/client_mgr/client_mgr.h"
 #include "common/exception/exception.h"
 #include "utils/env/env.h"
@@ -206,6 +207,24 @@ common::backend_api::ResponseCode_t obj_wait_for_completions(common::backend_api
         LOG(ERROR) << "Caught exception while sending async request";
     }
     return common::ResponseCode::UnknownError;
+}
+
+common::backend_api::ResponseCode_t obj_list_files(
+    common::backend_api::ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries)
+{
+    return common::backend_api::impl_obj_list_files<S3Client>(
+        client_handle, prefix, is_recursive, out_entries, out_num_entries);
+}
+
+void obj_free_file_list(
+    common::backend_api::ObjectFileEntry_t* entries,
+    unsigned num_entries)
+{
+    common::backend_api::impl_obj_free_file_list(entries, num_entries);
 }
 
 }; // namespace runai::llm::streamer::impl::s3

--- a/cpp/s3/s3.h
+++ b/cpp/s3/s3.h
@@ -71,4 +71,18 @@ extern "C" common::backend_api::ResponseCode_t obj_cancel_all_reads();
 // release clients
 extern "C" common::backend_api::ResponseCode_t obj_remove_all_clients();
 
+// list files
+extern "C" common::backend_api::ResponseCode_t obj_list_files(
+    common::backend_api::ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries
+);
+
+extern "C" void obj_free_file_list(
+    common::backend_api::ObjectFileEntry_t* entries,
+    unsigned num_entries
+);
+
 }; //namespace runai::llm::streamer::impl::s3

--- a/cpp/s3/s3.ldscript
+++ b/cpp/s3/s3.ldscript
@@ -9,5 +9,7 @@
         obj_cancel_all_reads;
         obj_remove_all_clients;
         obj_get_backend_shutdown_policy;
+        obj_list_files;
+        obj_free_file_list;
     local: *;
 };

--- a/cpp/s3/s3_mock/s3_mock.cc
+++ b/cpp/s3/s3_mock/s3_mock.cc
@@ -2,9 +2,14 @@
 
 #include <unistd.h>
 
+#include <cstdlib>
+#include <cstring>
 #include <map>
 #include <mutex>
 #include <set>
+#include <string>
+#include <utility>
+#include <vector>
 #include <atomic>
 
 #include "common/s3_credentials/s3_credentials.h"
@@ -24,6 +29,10 @@ std::mutex __mutex;
 std::atomic<bool> __stopped(false);
 std::atomic<bool> __opened(false);
 common::backend_api::ObjectShutdownPolicy_t __shutdown_policy = common::backend_api::OBJECT_SHUTDOWN_POLICY_ON_PROCESS_EXIT;
+
+std::vector<std::pair<std::string, size_t>> __mock_files;
+common::backend_api::ResponseCode_t __mock_list_files_response = common::ResponseCode::Success;
+int __mock_last_list_files_is_recursive = -1;
 
 void runai_s3_mock_set_backend_shutdown_policy(common::backend_api::ObjectShutdownPolicy_t policy)
 {
@@ -266,11 +275,90 @@ common::backend_api::ResponseCode_t obj_cancel_all_reads()
     return common::ResponseCode::Success;
 }
 
+void runai_mock_s3_set_files(const char** paths, const size_t* sizes, unsigned count)
+{
+    const auto guard = std::unique_lock<std::mutex>(__mutex);
+    __mock_files.clear();
+    for (unsigned i = 0; i < count; ++i)
+    {
+        __mock_files.emplace_back(paths[i], sizes[i]);
+    }
+}
+
+void runai_mock_s3_set_list_files_response(common::backend_api::ResponseCode_t response)
+{
+    const auto guard = std::unique_lock<std::mutex>(__mutex);
+    __mock_list_files_response = response;
+}
+
+int runai_mock_s3_last_list_files_is_recursive()
+{
+    const auto guard = std::unique_lock<std::mutex>(__mutex);
+    return __mock_last_list_files_is_recursive;
+}
+
+common::backend_api::ResponseCode_t obj_list_files(
+    common::backend_api::ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries)
+{
+    const auto guard = std::unique_lock<std::mutex>(__mutex);
+
+    __mock_last_list_files_is_recursive = is_recursive;
+
+    if (!__mock_clients.count(client_handle) || __mock_unused.count(client_handle))
+    {
+        LOG(ERROR) << "Mock client " << client_handle << " not found or unused";
+        return common::ResponseCode::UnknownError;
+    }
+
+    if (__mock_list_files_response != common::ResponseCode::Success)
+    {
+        return __mock_list_files_response; // out_entries left untouched on error
+    }
+
+    *out_num_entries = static_cast<unsigned>(__mock_files.size());
+    if (__mock_files.empty())
+    {
+        *out_entries = nullptr;
+        return common::ResponseCode::Success;
+    }
+
+    auto* entries = new common::backend_api::ObjectFileEntry_t[__mock_files.size()];
+    for (size_t i = 0; i < __mock_files.size(); ++i)
+    {
+        entries[i].path = ::strdup(__mock_files[i].first.c_str());
+        entries[i].size = __mock_files[i].second;
+    }
+    *out_entries = entries;
+    return common::ResponseCode::Success;
+}
+
+void obj_free_file_list(common::backend_api::ObjectFileEntry_t* entries, unsigned num_entries)
+{
+    if (entries == nullptr)
+    {
+        return;
+    }
+    for (unsigned i = 0; i < num_entries; ++i)
+    {
+        ::free(entries[i].path);
+    }
+    delete[] entries;
+}
+
 void runai_mock_s3_cleanup()
 {
     runai_mock_s3_set_response_time_ms(0);
     __stopped = false;
     runai_s3_mock_set_backend_shutdown_policy(common::backend_api::OBJECT_SHUTDOWN_POLICY_ON_PROCESS_EXIT);
+
+    const auto guard = std::unique_lock<std::mutex>(__mutex);
+    __mock_files.clear();
+    __mock_list_files_response = common::ResponseCode::Success;
+    __mock_last_list_files_is_recursive = -1;
 }
 
 bool runai_mock_s3_is_shutdown()

--- a/cpp/s3/s3_mock/s3_mock.h
+++ b/cpp/s3/s3_mock/s3_mock.h
@@ -45,6 +45,24 @@ extern "C" common::backend_api::ResponseCode_t obj_wait_for_completions(
 extern "C" common::backend_api::ResponseCode_t obj_cancel_all_reads();
 extern "C" common::backend_api::ResponseCode_t obj_remove_all_clients();
 
+extern "C" common::backend_api::ResponseCode_t obj_list_files(
+    common::backend_api::ObjectClientHandle_t client_handle,
+    const char* prefix,
+    int is_recursive,
+    common::backend_api::ObjectFileEntry_t** out_entries,
+    unsigned* out_num_entries
+);
+
+extern "C" void obj_free_file_list(common::backend_api::ObjectFileEntry_t* entries, unsigned num_entries);
+
+// Test hooks for obj_list_files:
+//   set the files that the next obj_list_files call returns
+extern "C" void runai_mock_s3_set_files(const char** paths, const size_t* sizes, unsigned count);
+//   force obj_list_files to return the given response code (Success restores normal behavior)
+extern "C" void runai_mock_s3_set_list_files_response(common::backend_api::ResponseCode_t response);
+//   the is_recursive argument observed by the last obj_list_files call (-1 if never called)
+extern "C" int runai_mock_s3_last_list_files_is_recursive();
+
 extern "C" void runai_mock_s3_set_response_time_ms(unsigned milliseconds);
 extern "C" void runai_s3_mock_set_backend_shutdown_policy(common::backend_api::ObjectShutdownPolicy_t policy);
 extern "C" int runai_mock_s3_clients();

--- a/cpp/s3/s3_mock/s3_mock.ldscript
+++ b/cpp/s3/s3_mock/s3_mock.ldscript
@@ -5,6 +5,11 @@
         runai_mock_s3_cleanup;
         runai_s3_mock_set_backend_shutdown_policy;
         runai_mock_s3_is_shutdown;
+        runai_mock_s3_set_files;
+        runai_mock_s3_set_list_files_response;
+        runai_mock_s3_last_list_files_is_recursive;
+        obj_list_files;
+        obj_free_file_list;
         obj_open_backend;
         obj_close_backend;
         obj_create_client;

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -1,6 +1,9 @@
 #include "streamer/impl/streamer/streamer.h"
 
+#include <fnmatch.h>
+
 #include <atomic>
+#include <filesystem>
 #include <memory>
 #include <numeric>
 #include <string>
@@ -204,7 +207,7 @@ void Streamer::verify_requests(std::vector<std::string> & paths, std::vector<siz
     }
 }
 
-common::s3::S3ClientWrapper::Params Streamer::handle_s3(unsigned file_index, const std::string & path, const common::s3::Credentials & credentials)
+std::shared_ptr<common::s3::StorageUri> Streamer::try_parse_uri(const std::string & path)
 {
     std::shared_ptr<common::s3::StorageUri> uri;
     try
@@ -214,6 +217,12 @@ common::s3::S3ClientWrapper::Params Streamer::handle_s3(unsigned file_index, con
     catch(const std::exception& e)
     {
     }
+    return uri;
+}
+
+common::s3::S3ClientWrapper::Params Streamer::handle_s3(unsigned file_index, const std::string & path, const common::s3::Credentials & credentials)
+{
+    auto uri = try_parse_uri(path);
 
     if (uri != nullptr && _s3 == nullptr)
     {
@@ -236,6 +245,100 @@ common::s3::S3ClientWrapper::Params Streamer::handle_s3(unsigned file_index, con
     }
 
     return common::s3::S3ClientWrapper::Params(uri, credentials, _config->s3_block_bytesize);
+}
+
+std::vector<std::pair<std::string, size_t>> Streamer::list_files(
+    const std::string & prefix,
+    bool is_recursive,
+    const std::vector<std::string> & allow_patterns,
+    const std::vector<std::string> & ignore_patterns,
+    const common::s3::Credentials & credentials)
+{
+    // fnmatch(3) filtering, matching the behavior of Python fnmatch.fnmatch(path, pattern)
+    auto keep = [&](const char * path) -> bool
+    {
+        if (!allow_patterns.empty())
+        {
+            bool matched = false;
+            for (const auto & p : allow_patterns)
+            {
+                if (fnmatch(p.c_str(), path, 0) == 0) { matched = true; break; }
+            }
+            if (!matched) return false;
+        }
+        for (const auto & p : ignore_patterns)
+        {
+            if (fnmatch(p.c_str(), path, 0) == 0) return false;
+        }
+        return true;
+    };
+
+    std::vector<std::pair<std::string, size_t>> results;
+
+    auto uri = try_parse_uri(prefix);
+
+    if (uri != nullptr)
+    {
+        // Any code path that uses the S3 plugin must release its clients and the
+        // backend handle when the streamer shuts down (~Streamer). stop() and the
+        // fd limit are streaming-only: listing is a single synchronous call with no
+        // in-flight async reads and no threadpool workers to unblock.
+        if (_s3 == nullptr)
+        {
+            _s3 = std::make_unique<S3Cleanup>();
+        }
+
+        common::s3::S3ClientWrapper::Params params(uri, credentials, _config->s3_block_bytesize);
+        common::s3::S3ClientWrapper wrapper(params);
+
+        common::backend_api::ObjectFileEntry_t * entries = nullptr;
+        unsigned num_entries = 0;
+        auto ret = wrapper.list_files(prefix.c_str(), is_recursive ? 1 : 0, &entries, &num_entries);
+        if (ret != common::ResponseCode::Success)
+        {
+            throw common::Exception(ret); // entries is not allocated on error
+        }
+
+        // free_file_list is a no-op for nullptr (empty listing); ScopeGuard is
+        // constructed only on the success path so it never fires on error.
+        utils::ScopeGuard guard([&]{ wrapper.free_file_list(entries, num_entries); });
+
+        for (unsigned i = 0; i < num_entries; ++i)
+        {
+            if (keep(entries[i].path))
+            {
+                results.emplace_back(entries[i].path, entries[i].size);
+            }
+        }
+    }
+    else
+    {
+        namespace fs = std::filesystem;
+        const fs::path root(prefix);
+        if (!fs::exists(root))
+        {
+            throw common::Exception(common::ResponseCode::FileAccessError);
+        }
+
+        auto process = [&](const fs::directory_entry & entry)
+        {
+            if (entry.is_regular_file() && keep(entry.path().c_str()))
+            {
+                results.emplace_back(entry.path().string(), static_cast<size_t>(entry.file_size()));
+            }
+        };
+
+        if (is_recursive)
+        {
+            for (const auto & e : fs::recursive_directory_iterator(root)) process(e);
+        }
+        else
+        {
+            for (const auto & e : fs::directory_iterator(root)) process(e);
+        }
+    }
+
+    return results;
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/streamer/streamer.h
+++ b/cpp/streamer/impl/streamer/streamer.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "utils/threadpool/threadpool.h"
@@ -61,7 +62,19 @@ struct Streamer
     // returns common::ResponseCode::Success if successful or error code
     common::ResponseCode async_read(const std::string & path, size_t offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes, const common::s3::Credentials & credentials);
 
+    // List files under prefix, which may be an object storage URI or a local filesystem path.
+    // Applies fnmatch allow/ignore filtering (empty vectors mean no filter) and returns
+    // (full path, size) pairs. Throws common::Exception on error.
+    std::vector<std::pair<std::string, size_t>> list_files(
+      const std::string & prefix,
+      bool is_recursive,
+      const std::vector<std::string> & allow_patterns,
+      const std::vector<std::string> & ignore_patterns,
+      const common::s3::Credentials & credentials);
+
  private:
+    // Try to parse path as an object storage URI; returns nullptr for a filesystem path
+    std::shared_ptr<common::s3::StorageUri> try_parse_uri(const std::string & path);
     common::s3::S3ClientWrapper::Params handle_s3(unsigned file_index, const std::string & path, const common::s3::Credentials & credentials);
     void verify_requests(std::vector<std::string> & paths, std::vector<size_t> & file_offsets, std::vector<size_t> & bytesizes, std::vector<unsigned> & num_sizes, std::vector<void *> & dsts);
 

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 #include <atomic>
+#include <string>
+#include <utility>
 #include <vector>
 #include <set>
 
@@ -455,6 +457,124 @@ TEST(AsyncRequest, InvalidScheme)
     std::vector<std::vector<size_t>> internal_sizes =  { sizes };
 
     EXPECT_THROW(streamer.async_request(paths, file_offsets, bytesizes, dsts, num_sizes, internal_sizes, credentials), runai::llm::streamer::common::Exception);
+}
+
+namespace
+{
+
+std::set<std::string> paths_of(const std::vector<std::pair<std::string, size_t>> & entries)
+{
+    std::set<std::string> result;
+    for (const auto & entry : entries)
+    {
+        result.insert(entry.first);
+    }
+    return result;
+}
+
+} // namespace
+
+TEST(ListFiles, FilesystemBasicListingAndSizes)
+{
+    Streamer streamer;
+    common::s3::Credentials credentials;
+
+    utils::temp::Dir dir;
+    const auto data_a = utils::random::buffer(utils::random::number(1, 1000));
+    const auto data_b = utils::random::buffer(utils::random::number(1, 1000));
+    utils::temp::File a(dir.path, "a.bin", data_a);
+    utils::temp::File b(dir.path, "b.bin", data_b);
+
+    const auto entries = streamer.list_files(dir.path, true, {}, {}, credentials);
+
+    EXPECT_EQ(entries.size(), 2u);
+    bool found_a = false;
+    bool found_b = false;
+    for (const auto & entry : entries)
+    {
+        if (entry.first == a.path) { EXPECT_EQ(entry.second, data_a.size()); found_a = true; }
+        if (entry.first == b.path) { EXPECT_EQ(entry.second, data_b.size()); found_b = true; }
+    }
+    EXPECT_TRUE(found_a);
+    EXPECT_TRUE(found_b);
+}
+
+TEST(ListFiles, FilesystemRecursive)
+{
+    Streamer streamer;
+    common::s3::Credentials credentials;
+
+    utils::temp::Dir dir;
+    utils::temp::File root_file(dir.path, "root.bin", utils::random::buffer(10));
+    utils::temp::Dir sub(dir.path, "subdir");
+    utils::temp::File nested(sub.path, "nested.bin", utils::random::buffer(10));
+
+    const auto recursive = paths_of(streamer.list_files(dir.path, true, {}, {}, credentials));
+    const auto non_recursive = paths_of(streamer.list_files(dir.path, false, {}, {}, credentials));
+
+    EXPECT_TRUE(recursive.count(root_file.path));
+    EXPECT_TRUE(recursive.count(nested.path));
+
+    EXPECT_TRUE(non_recursive.count(root_file.path));
+    EXPECT_FALSE(non_recursive.count(nested.path));
+}
+
+TEST(ListFiles, FilesystemAllowPattern)
+{
+    Streamer streamer;
+    common::s3::Credentials credentials;
+
+    utils::temp::Dir dir;
+    utils::temp::File st(dir.path, "model.safetensors", utils::random::buffer(10));
+    utils::temp::File js(dir.path, "config.json", utils::random::buffer(10));
+
+    const auto paths = paths_of(streamer.list_files(dir.path, true, {"*.safetensors"}, {}, credentials));
+
+    EXPECT_TRUE(paths.count(st.path));
+    EXPECT_FALSE(paths.count(js.path));
+}
+
+TEST(ListFiles, FilesystemIgnorePattern)
+{
+    Streamer streamer;
+    common::s3::Credentials credentials;
+
+    utils::temp::Dir dir;
+    utils::temp::File st(dir.path, "model.safetensors", utils::random::buffer(10));
+    utils::temp::File js(dir.path, "config.json", utils::random::buffer(10));
+
+    const auto paths = paths_of(streamer.list_files(dir.path, true, {}, {"*.json"}, credentials));
+
+    EXPECT_TRUE(paths.count(st.path));
+    EXPECT_FALSE(paths.count(js.path));
+}
+
+TEST(ListFiles, FilesystemNonExistentPathThrows)
+{
+    Streamer streamer;
+    common::s3::Credentials credentials;
+
+    const std::string missing = "./" + utils::random::string() + "/" + utils::random::string();
+    try
+    {
+        streamer.list_files(missing, true, {}, {}, credentials);
+        FAIL() << "expected an exception for a non-existent path";
+    }
+    catch (const common::Exception & e)
+    {
+        EXPECT_EQ(e.error(), common::ResponseCode::FileAccessError);
+    }
+}
+
+TEST(ListFiles, FilesystemEmptyDirectory)
+{
+    Streamer streamer;
+    common::s3::Credentials credentials;
+
+    utils::temp::Dir dir;
+
+    const auto entries = streamer.list_files(dir.path, true, {}, {}, credentials);
+    EXPECT_TRUE(entries.empty());
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/streamer.cc
+++ b/cpp/streamer/streamer.cc
@@ -1,16 +1,13 @@
 #include "streamer/streamer.h"
 
-#include <filesystem>
-#include <fnmatch.h>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "common/exception/exception.h"
 #include "common/response_code/response_code.h"
 #include "common/s3_credentials/s3_credentials.h"
-#include "common/s3_wrapper/s3_wrapper.h"
 #include "streamer/impl/streamer/streamer.h"
-#include "utils/scope_guard/scope_guard.h"
 
 namespace runai::llm::streamer
 {
@@ -186,79 +183,37 @@ _RUNAI_EXTERN_C int runai_list_files(
         if (!prefix || !callback)
             return static_cast<int>(common::ResponseCode::InvalidParameterError);
 
-        auto fire = [&](const char* path, size_t size)
+        const char *key = nullptr, *secret = nullptr, *token = nullptr,
+                   *region = nullptr, *endpoint = nullptr;
+        for (unsigned i = 0; i < num_params; ++i)
         {
-            if (num_allow_patterns > 0)
-            {
-                bool matched = false;
-                for (unsigned j = 0; j < num_allow_patterns; ++j)
-                    if (fnmatch(allow_patterns[j], path, 0) == 0) { matched = true; break; }
-                if (!matched) return;
-            }
-            for (unsigned j = 0; j < num_ignore_patterns; ++j)
-                if (fnmatch(ignore_patterns[j], path, 0) == 0) return;
-            callback(path, size, user_data);
-        };
-
-        // Try to parse as an object storage URI; nullptr means local filesystem path
-        std::shared_ptr<common::s3::StorageUri> uri;
-        try { uri = std::make_shared<common::s3::StorageUri>(prefix); }
-        catch (...) {}
-
-        if (uri != nullptr)
-        {
-            const char *key = nullptr, *secret = nullptr, *token = nullptr,
-                       *region = nullptr, *endpoint = nullptr;
-            for (unsigned i = 0; i < num_params; ++i)
-            {
-                if (!param_keys || !param_keys[i]) continue;
-                const std::string k(param_keys[i]);
-                if      (k == "key")      key      = param_values[i];
-                else if (k == "secret")   secret   = param_values[i];
-                else if (k == "token")    token    = param_values[i];
-                else if (k == "region")   region   = param_values[i];
-                else if (k == "endpoint") endpoint = param_values[i];
-            }
-
-            common::s3::Credentials credentials(key, secret, token, region, endpoint);
-            common::s3::S3ClientWrapper::Params params(uri, credentials, common::s3::S3ClientWrapper::default_chunk_bytesize);
-            common::s3::S3ClientWrapper wrapper(params);
-
-            common::backend_api::ObjectFileEntry_t* entries = nullptr;
-            unsigned num_entries = 0;
-            auto ret = wrapper.list_files(prefix, is_recursive, &entries, &num_entries);
-            if (ret != common::ResponseCode::Success)
-                return static_cast<int>(ret); // entries not allocated on error
-
-            // ScopeGuard is constructed only on the success path: entries is either
-            // nullptr (empty directory, delete[] nullptr is a no-op) or a valid allocation.
-            utils::ScopeGuard guard([&]{ wrapper.free_file_list(entries, num_entries); });
-
-            for (unsigned i = 0; i < num_entries; ++i)
-                fire(entries[i].path, entries[i].size);
+            if (!param_keys || !param_keys[i]) continue;
+            const std::string k(param_keys[i]);
+            const char* v = param_values ? param_values[i] : nullptr;
+            if      (k == "key")      key      = v;
+            else if (k == "secret")   secret   = v;
+            else if (k == "token")    token    = v;
+            else if (k == "region")   region   = v;
+            else if (k == "endpoint") endpoint = v;
         }
-        else
+        common::s3::Credentials credentials(key, secret, token, region, endpoint);
+
+        std::vector<std::string> allow, ignore;
+        for (unsigned i = 0; i < num_allow_patterns; ++i) allow.emplace_back(allow_patterns[i]);
+        for (unsigned i = 0; i < num_ignore_patterns; ++i) ignore.emplace_back(ignore_patterns[i]);
+
+        impl::Streamer streamer;
+        const auto files = streamer.list_files(prefix, is_recursive != 0, allow, ignore, credentials);
+        for (const auto & entry : files)
         {
-            namespace fs = std::filesystem;
-            const fs::path root(prefix);
-            if (!fs::exists(root))
-                return static_cast<int>(common::ResponseCode::FileAccessError);
-
-            auto process = [&](const fs::directory_entry& entry)
-            {
-                if (entry.is_regular_file())
-                    fire(entry.path().c_str(), static_cast<size_t>(entry.file_size()));
-            };
-
-            if (is_recursive)
-                for (const auto& e : fs::recursive_directory_iterator(root))
-                    process(e);
-            else
-                for (const auto& e : fs::directory_iterator(root))
-                    process(e);
+            callback(entry.first.c_str(), entry.second, user_data);
         }
 
         return static_cast<int>(common::ResponseCode::Success);
+    }
+    catch (const common::Exception & e)
+    {
+        return static_cast<int>(e.error());
     }
     catch (...)
     {

--- a/cpp/streamer/streamer.cc
+++ b/cpp/streamer/streamer.cc
@@ -1,11 +1,16 @@
 #include "streamer/streamer.h"
 
+#include <filesystem>
+#include <fnmatch.h>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "common/response_code/response_code.h"
+#include "common/s3_credentials/s3_credentials.h"
+#include "common/s3_wrapper/s3_wrapper.h"
 #include "streamer/impl/streamer/streamer.h"
+#include "utils/scope_guard/scope_guard.h"
 
 namespace runai::llm::streamer
 {
@@ -161,6 +166,104 @@ _RUNAI_EXTERN_C const char * runai_response_str(int response_code)
     }
 
     return unexpected_error;
+}
+
+_RUNAI_EXTERN_C int runai_list_files(
+    const char *          prefix,
+    int                   is_recursive,
+    const char **         allow_patterns,
+    unsigned              num_allow_patterns,
+    const char **         ignore_patterns,
+    unsigned              num_ignore_patterns,
+    RunaiFileListCallback callback,
+    void *                user_data,
+    const char **         param_keys,
+    const char **         param_values,
+    unsigned              num_params)
+{
+    try
+    {
+        if (!prefix || !callback)
+            return static_cast<int>(common::ResponseCode::InvalidParameterError);
+
+        auto fire = [&](const char* path, size_t size)
+        {
+            if (num_allow_patterns > 0)
+            {
+                bool matched = false;
+                for (unsigned j = 0; j < num_allow_patterns; ++j)
+                    if (fnmatch(allow_patterns[j], path, 0) == 0) { matched = true; break; }
+                if (!matched) return;
+            }
+            for (unsigned j = 0; j < num_ignore_patterns; ++j)
+                if (fnmatch(ignore_patterns[j], path, 0) == 0) return;
+            callback(path, size, user_data);
+        };
+
+        // Try to parse as an object storage URI; nullptr means local filesystem path
+        std::shared_ptr<common::s3::StorageUri> uri;
+        try { uri = std::make_shared<common::s3::StorageUri>(prefix); }
+        catch (...) {}
+
+        if (uri != nullptr)
+        {
+            const char *key = nullptr, *secret = nullptr, *token = nullptr,
+                       *region = nullptr, *endpoint = nullptr;
+            for (unsigned i = 0; i < num_params; ++i)
+            {
+                if (!param_keys || !param_keys[i]) continue;
+                const std::string k(param_keys[i]);
+                if      (k == "key")      key      = param_values[i];
+                else if (k == "secret")   secret   = param_values[i];
+                else if (k == "token")    token    = param_values[i];
+                else if (k == "region")   region   = param_values[i];
+                else if (k == "endpoint") endpoint = param_values[i];
+            }
+
+            common::s3::Credentials credentials(key, secret, token, region, endpoint);
+            common::s3::S3ClientWrapper::Params params(uri, credentials, common::s3::S3ClientWrapper::default_chunk_bytesize);
+            common::s3::S3ClientWrapper wrapper(params);
+
+            common::backend_api::ObjectFileEntry_t* entries = nullptr;
+            unsigned num_entries = 0;
+            auto ret = wrapper.list_files(prefix, is_recursive, &entries, &num_entries);
+            if (ret != common::ResponseCode::Success)
+                return static_cast<int>(ret); // entries not allocated on error
+
+            // ScopeGuard is constructed only on the success path: entries is either
+            // nullptr (empty directory, delete[] nullptr is a no-op) or a valid allocation.
+            utils::ScopeGuard guard([&]{ wrapper.free_file_list(entries, num_entries); });
+
+            for (unsigned i = 0; i < num_entries; ++i)
+                fire(entries[i].path, entries[i].size);
+        }
+        else
+        {
+            namespace fs = std::filesystem;
+            const fs::path root(prefix);
+            if (!fs::exists(root))
+                return static_cast<int>(common::ResponseCode::FileAccessError);
+
+            auto process = [&](const fs::directory_entry& entry)
+            {
+                if (entry.is_regular_file())
+                    fire(entry.path().c_str(), static_cast<size_t>(entry.file_size()));
+            };
+
+            if (is_recursive)
+                for (const auto& e : fs::recursive_directory_iterator(root))
+                    process(e);
+            else
+                for (const auto& e : fs::directory_iterator(root))
+                    process(e);
+        }
+
+        return static_cast<int>(common::ResponseCode::Success);
+    }
+    catch (...)
+    {
+    }
+    return static_cast<int>(common::ResponseCode::UnknownError);
 }
 
 } // namespace runai::llm::streamer

--- a/cpp/streamer/streamer.cc
+++ b/cpp/streamer/streamer.cc
@@ -199,8 +199,8 @@ _RUNAI_EXTERN_C int runai_list_files(
         common::s3::Credentials credentials(key, secret, token, region, endpoint);
 
         std::vector<std::string> allow, ignore;
-        for (unsigned i = 0; i < num_allow_patterns; ++i) allow.emplace_back(allow_patterns[i]);
-        for (unsigned i = 0; i < num_ignore_patterns; ++i) ignore.emplace_back(ignore_patterns[i]);
+        for (unsigned i = 0; allow_patterns && i < num_allow_patterns; ++i) allow.emplace_back(allow_patterns[i]);
+        for (unsigned i = 0; ignore_patterns && i < num_ignore_patterns; ++i) ignore.emplace_back(ignore_patterns[i]);
 
         impl::Streamer streamer;
         const auto files = streamer.list_files(prefix, is_recursive != 0, allow, ignore, credentials);

--- a/cpp/streamer/streamer.h
+++ b/cpp/streamer/streamer.h
@@ -11,6 +11,8 @@ namespace runai::llm::streamer
     #define _RUNAI_EXTERN_C
 #endif
 
+typedef void (*RunaiFileListCallback)(const char* path, size_t file_size, void* user_data);
+
 // Library for reading a large file concurrently to a given host memory buffer
 // Reads a single file at a time
 // NOT THREAD SAFE - caller must not send requests and responses in parallel
@@ -57,5 +59,39 @@ _RUNAI_EXTERN_C int runai_request(
 _RUNAI_EXTERN_C int runai_response(void * streamer, unsigned * file_index /* return parameter */, unsigned * index /* return parameter */);
 
 _RUNAI_EXTERN_C const char * runai_response_str(int response_code);
+
+// List files at the given object storage prefix.
+//
+// For each matching entry the callback is invoked as:
+//   callback(path, file_size, user_data)
+// where path is the full object URI and file_size is the size in bytes.
+// user_data is passed through to every callback invocation unchanged.
+//
+// Example:
+//   struct Result { std::vector<std::pair<std::string,size_t>> files; };
+//   Result result;
+//   runai_list_files("s3://my-bucket/models/", 1,
+//       nullptr, 0, nullptr, 0,
+//       [](const char* p, size_t sz, void* ud) {
+//           static_cast<Result*>(ud)->files.emplace_back(p, sz);
+//       }, &result,
+//       keys, vals, num_params);
+//
+// allow_patterns / ignore_patterns are fnmatch(3) patterns; NULL means no filter.
+// param_keys / param_values are parallel arrays of credential/config key-value pairs
+// (recognised keys: "key", "secret", "token", "region", "endpoint").
+_RUNAI_EXTERN_C int runai_list_files(
+    const char *             prefix,
+    int                      is_recursive,
+    const char **            allow_patterns,
+    unsigned                 num_allow_patterns,
+    const char **            ignore_patterns,
+    unsigned                 num_ignore_patterns,
+    RunaiFileListCallback    callback,
+    void *                   user_data,
+    const char **            param_keys,
+    const char **            param_values,
+    unsigned                 num_params
+);
 
 } // namespace runai::llm::streamer

--- a/cpp/streamer/streamer.ldscript
+++ b/cpp/streamer/streamer.ldscript
@@ -5,5 +5,6 @@
         runai_request;
         runai_response;
         runai_response_str;
+        runai_list_files;
     local: *;
 };

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -467,4 +467,107 @@ TEST_F(StreamerTest, Multiple_Files_Error)
     EXPECT_EQ(verify_mock(), 0);
 }
 
+namespace
+{
+
+// Collects the (path, size) pairs delivered to the runai_list_files callback
+struct ListFilesResult
+{
+    std::vector<std::pair<std::string, size_t>> files;
+};
+
+void list_files_collect(const char* path, size_t size, void* user_data)
+{
+    static_cast<ListFilesResult*>(user_data)->files.emplace_back(path, size);
+}
+
+} // namespace
+
+TEST_F(StreamerTest, ListFiles_S3_ReturnsEntriesAndCleansUp)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+    auto is_shutdown = dylib.dlsym<bool(*)()>("runai_mock_s3_is_shutdown");
+    auto set_files = dylib.dlsym<void(*)(const char**, const size_t*, unsigned)>("runai_mock_s3_set_files");
+    auto set_backend_shutdown_policy = dylib.dlsym<void(*)(common::backend_api::ObjectShutdownPolicy_t)>("runai_s3_mock_set_backend_shutdown_policy");
+    set_backend_shutdown_policy(common::backend_api::ObjectShutdownPolicy_t::OBJECT_SHUTDOWN_POLICY_ON_STREAMER_SHUTDOWN);
+
+    std::vector<const char*> paths = {"s3://bucket/models/a.safetensors", "s3://bucket/models/b.bin"};
+    const std::vector<size_t> sizes = {111, 222};
+    set_files(paths.data(), sizes.data(), paths.size());
+
+    ListFilesResult result;
+    auto res = runai_list_files("s3://bucket/models/", 1, nullptr, 0, nullptr, 0, list_files_collect, &result, nullptr, nullptr, 0);
+
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
+    ASSERT_EQ(result.files.size(), 2u);
+
+    std::map<std::string, size_t> by_path;
+    for (const auto& f : result.files)
+    {
+        by_path[f.first] = f.second;
+    }
+    EXPECT_EQ(by_path["s3://bucket/models/a.safetensors"], 111u);
+    EXPECT_EQ(by_path["s3://bucket/models/b.bin"], 222u);
+
+    // S3Cleanup ran on Streamer destruction: clients released and backend closed
+    EXPECT_EQ(verify_mock(), 0);
+    EXPECT_TRUE(is_shutdown());
+}
+
+TEST_F(StreamerTest, ListFiles_S3_AppliesPatternFilters)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto set_files = dylib.dlsym<void(*)(const char**, const size_t*, unsigned)>("runai_mock_s3_set_files");
+
+    std::vector<const char*> paths = {"s3://bucket/m/model.safetensors", "s3://bucket/m/config.json"};
+    const std::vector<size_t> sizes = {10, 20};
+    set_files(paths.data(), sizes.data(), paths.size());
+
+    std::vector<const char*> allow = {"*.safetensors"};
+
+    ListFilesResult result;
+    auto res = runai_list_files("s3://bucket/m/", 1, allow.data(), allow.size(), nullptr, 0, list_files_collect, &result, nullptr, nullptr, 0);
+
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
+    ASSERT_EQ(result.files.size(), 1u);
+    EXPECT_EQ(result.files[0].first, "s3://bucket/m/model.safetensors");
+}
+
+TEST_F(StreamerTest, ListFiles_S3_ForwardsIsRecursive)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto set_files = dylib.dlsym<void(*)(const char**, const size_t*, unsigned)>("runai_mock_s3_set_files");
+    auto last_is_recursive = dylib.dlsym<int(*)()>("runai_mock_s3_last_list_files_is_recursive");
+
+    std::vector<const char*> paths = {"s3://bucket/x/f.bin"};
+    const std::vector<size_t> sizes = {1};
+    set_files(paths.data(), sizes.data(), paths.size());
+
+    ListFilesResult result;
+    runai_list_files("s3://bucket/x/", 0, nullptr, 0, nullptr, 0, list_files_collect, &result, nullptr, nullptr, 0);
+    EXPECT_EQ(last_is_recursive(), 0);
+
+    runai_list_files("s3://bucket/x/", 1, nullptr, 0, nullptr, 0, list_files_collect, &result, nullptr, nullptr, 0);
+    EXPECT_EQ(last_is_recursive(), 1);
+}
+
+TEST_F(StreamerTest, ListFiles_S3_ErrorPropagates)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto set_files = dylib.dlsym<void(*)(const char**, const size_t*, unsigned)>("runai_mock_s3_set_files");
+    auto set_response = dylib.dlsym<void(*)(common::backend_api::ResponseCode_t)>("runai_mock_s3_set_list_files_response");
+
+    std::vector<const char*> paths = {"s3://bucket/x/f.bin"};
+    const std::vector<size_t> sizes = {1};
+    set_files(paths.data(), sizes.data(), paths.size());
+    set_response(common::ResponseCode::FileAccessError);
+
+    ListFilesResult result;
+    auto res = runai_list_files("s3://bucket/x/", 1, nullptr, 0, nullptr, 0, list_files_collect, &result, nullptr, nullptr, 0);
+
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::FileAccessError));
+    EXPECT_TRUE(result.files.empty());
+}
+
 }; // namespace runai::llm::streamer

--- a/cpp/utils/temp/env/env.cc
+++ b/cpp/utils/temp/env/env.cc
@@ -55,4 +55,34 @@ Env::~Env()
     }
 }
 
+UnsetEnv::UnsetEnv(const std::string & name) :
+    name(name)
+{
+    const char * previous = ::getenv(name.c_str());
+    if (previous != nullptr)
+    {
+        had_value = true;
+        previous_value = previous;
+    }
+    if (::unsetenv(name.c_str()) == -1)
+    {
+        LOG(ERROR) << "Failed unsetting environment variable '" << name << "'";
+    }
+}
+
+UnsetEnv::~UnsetEnv()
+{
+    if (had_value)
+    {
+        if (::setenv(name.c_str(), previous_value.c_str(), 1 /* overwrite */) == -1)
+        {
+            LOG(ERROR) << "Failed restoring environment variable '" << name << "'";
+        }
+    }
+    else if (::unsetenv(name.c_str()) == -1)
+    {
+        LOG(ERROR) << "Failed unsetting environment variable '" << name << "'";
+    }
+}
+
 } // namespace runai::llm::streamer::utils::temp

--- a/cpp/utils/temp/env/env.h
+++ b/cpp/utils/temp/env/env.h
@@ -47,4 +47,22 @@ struct Env
     std::string value;
 };
 
+// Unsets an environment variable for the lifetime of the object and restores its
+// previous value (or leaves it unset) on destruction
+struct UnsetEnv
+{
+    explicit UnsetEnv(const std::string & name);
+    ~UnsetEnv();
+
+    UnsetEnv(UnsetEnv &&) = delete;
+    UnsetEnv(const UnsetEnv &) = delete;
+
+    UnsetEnv & operator=(UnsetEnv &&) = delete;
+    UnsetEnv & operator=(const UnsetEnv &) = delete;
+
+    std::string name;
+    std::string previous_value;
+    bool had_value = false;
+};
+
 } // namespace runai::llm::streamer::utils::temp

--- a/cpp/utils/temp/file/file.cc
+++ b/cpp/utils/temp/file/file.cc
@@ -76,6 +76,9 @@ Dir::Dir(const std::string & dir, const std::string & name) :
     name(name),
     path(dir + (name.empty() ? "" : "/") + name)
 {
+    // An empty name collapses path to dir, which would make _delete() recursively
+    // remove the caller-supplied directory instead of an owned temp subdirectory
+    ASSERT(!name.empty()) << "Temporary directory name must not be empty";
     std::filesystem::create_directories(path);
 }
 

--- a/cpp/utils/temp/file/file.cc
+++ b/cpp/utils/temp/file/file.cc
@@ -4,6 +4,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <filesystem>
+#include <system_error>
 #include <utility>
 
 #include "utils/fd/fd.h"
@@ -68,6 +70,55 @@ void Path::_delete()
     ASSERT(!Path::is_directory(path)) << "Removing directory is not implemented";
 
     PASSERT(::unlink(path.c_str()) != -1) << "Failed removing file '" << path << "'";
+}
+
+Dir::Dir(const std::string & dir, const std::string & name) :
+    name(name),
+    path(dir + (name.empty() ? "" : "/") + name)
+{
+    std::filesystem::create_directories(path);
+}
+
+Dir::Dir(Dir && other)
+{
+    *this = std::move(other);
+}
+
+Dir & Dir::operator=(Dir && other)
+{
+    _delete();
+
+    name = other.name;
+    path = other.path;
+
+    other.path = other.name = "";
+
+    return *this;
+}
+
+Dir::~Dir()
+{
+    try
+    {
+        _delete();
+    }
+    catch (...)
+    {}
+}
+
+void Dir::_delete()
+{
+    if (path.empty())
+    {
+        return;
+    }
+
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+    if (ec)
+    {
+        LOG(ERROR) << "Failed removing directory '" << path << "': " << ec.message();
+    }
 }
 
 File::File(const std::string & dir, const std::string & name, const std::vector<uint8_t> & data) :

--- a/cpp/utils/temp/file/file.h
+++ b/cpp/utils/temp/file/file.h
@@ -31,6 +31,27 @@ struct Path
     void _delete();
 };
 
+// RAII temporary directory: created on construction and recursively removed on destruction
+struct Dir
+{
+    Dir(
+        const std::string & dir = ".",
+        const std::string & name = random::string());
+    ~Dir();
+
+    Dir(Dir &&);
+    Dir(const Dir &) = delete;
+
+    Dir & operator=(Dir &&);
+    Dir & operator=(const Dir &) = delete;
+
+    std::string name;
+    std::string path;
+
+ private:
+    void _delete();
+};
+
 struct File
 {
     File(

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -107,21 +107,11 @@ file_path = "s3://my-bucket/my/file/path.safetensors"
 
 #### S3 authentication
 
-By default, the streamer performs authentication via boto3 to obtain credentials, which are then passed to the S3 client in `libstreamers3.so`.
+###### Authentication via AWS CPP SDK (default)
 
-This is the recommended way to load tensors from AWS S3 storage
+By default, the S3 client in `libstreamers3.so` authenticates itself using the AWS C++ SDK's default credential provider chain. No boto3 session is created.
 
-###### HTTPS certificate
-
-Custom certificates file can be passed using `AWS_CA_BUNDLE=path/to/ca_file`
-
-The file path can also be configured in `~/.aws/config` file with `ca_bundle = /path/to/ca_file`, in case the authentication is via boto3 (`RUNAI_STREAMER_NO_BOTO3_SESSION=0` which is the default)
-
-###### Authentication via AWS CPP SDK 
-
-The boto3 authentication can be disabled by setting `RUNAI_STREAMER_NO_BOTO3_SESSION=1`.
-
-In this case credentials can be passed in one of the following ways:
+Credentials are resolved from any of the following:
 
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
 
@@ -136,6 +126,16 @@ e.g. `aws sts assume-role --role-arn arn:aws:iam::<account_name>:role/<role> --r
 The session token shoud be passed as an environment variable `AWS_SESSION_TOKEN`
 
 To check if IAM role assumption is needed run `aws s3 ls s3://your-bucket-name --region your-region`. If you get a `403 Forbidden` error, you might need an assumed role
+
+###### Authentication via boto3
+
+Setting `RUNAI_STREAMER_NO_BOTO3_SESSION=0` makes the streamer resolve credentials via a boto3 session in Python and pass the resolved credentials to the S3 client in `libstreamers3.so`. This is useful when credentials are only reachable through boto3 (for example an SSO or `credential_process` profile).
+
+###### HTTPS certificate
+
+Custom certificates file can be passed using `AWS_CA_BUNDLE=path/to/ca_file`
+
+The file path can also be configured in the `~/.aws/config` file with `ca_bundle = /path/to/ca_file`. This is honored in both authentication modes.
 
 ###### Unsigned requests (public buckets)
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -54,6 +54,13 @@ def homogeneous_paths(paths: List[str]) -> bool:
     return True
 
 class FileStreamer:
+    def __init__(self) -> None:
+        # Initialized here (not only in __enter__) so methods such as list_files
+        # can be used without entering the context manager
+        self.streamer = None
+        self.s3_session = None
+        self.s3_credentials = None
+
     def __enter__(self) -> "FileStreamer":
         self.streamer = runai_start()
         self.start_time = timer()
@@ -93,23 +100,24 @@ class FileStreamer:
         ignore_patterns: Optional[List[str]] = None,
         credentials: Optional[S3Credentials] = None,
     ) -> List[Tuple[str, int]]:
-        s3_credentials = None
-        if s3_credentials_module and is_s3_path(prefix):
-            _, s3_credentials = s3_credentials_module.get_credentials(credentials)
+        # Resolve credentials through the same path as streaming: this creates and
+        # retains the boto3 session (self.s3_session) and the resolved credentials
+        # (self.s3_credentials) for s3 paths
+        self.handle_object_store(prefix, credentials)
 
         params: Optional[Dict[str, str]] = None
-        if s3_credentials is not None:
+        if self.s3_credentials is not None:
             params = {}
-            if s3_credentials.access_key_id:
-                params["key"] = s3_credentials.access_key_id
-            if s3_credentials.secret_access_key:
-                params["secret"] = s3_credentials.secret_access_key
-            if s3_credentials.session_token:
-                params["token"] = s3_credentials.session_token
-            if s3_credentials.region_name:
-                params["region"] = s3_credentials.region_name
-            if s3_credentials.endpoint:
-                params["endpoint"] = s3_credentials.endpoint
+            if self.s3_credentials.access_key_id:
+                params["key"] = self.s3_credentials.access_key_id
+            if self.s3_credentials.secret_access_key:
+                params["secret"] = self.s3_credentials.secret_access_key
+            if self.s3_credentials.session_token:
+                params["token"] = self.s3_credentials.session_token
+            if self.s3_credentials.region_name:
+                params["region"] = self.s3_credentials.region_name
+            if self.s3_credentials.endpoint:
+                params["endpoint"] = self.s3_credentials.endpoint
 
         results: List[Tuple[str, int]] = []
         runai_list_files(

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -1,10 +1,11 @@
-from typing import List, Iterator, Optional
+from typing import Dict, List, Iterator, Optional, Tuple
 from timeit import default_timer as timer
 from runai_model_streamer.libstreamer.libstreamer import (
     runai_start,
     runai_end,
     runai_request,
-    runai_response
+    runai_response,
+    runai_list_files,
 )
 from runai_model_streamer.file_streamer.requests_iterator import (
     FilesRequestsIteratorWithBuffer,
@@ -83,6 +84,43 @@ class FileStreamer:
                 self.s3_session, self.s3_credentials = s3_credentials_module.get_credentials(credentials)
         return path
 
+
+    def list_files(
+        self,
+        prefix: str,
+        is_recursive: bool = True,
+        allow_patterns: Optional[List[str]] = None,
+        ignore_patterns: Optional[List[str]] = None,
+        credentials: Optional[S3Credentials] = None,
+    ) -> List[Tuple[str, int]]:
+        s3_credentials = None
+        if s3_credentials_module and is_s3_path(prefix):
+            _, s3_credentials = s3_credentials_module.get_credentials(credentials)
+
+        params: Optional[Dict[str, str]] = None
+        if s3_credentials is not None:
+            params = {}
+            if s3_credentials.access_key_id:
+                params["key"] = s3_credentials.access_key_id
+            if s3_credentials.secret_access_key:
+                params["secret"] = s3_credentials.secret_access_key
+            if s3_credentials.session_token:
+                params["token"] = s3_credentials.session_token
+            if s3_credentials.region_name:
+                params["region"] = s3_credentials.region_name
+            if s3_credentials.endpoint:
+                params["endpoint"] = s3_credentials.endpoint
+
+        results: List[Tuple[str, int]] = []
+        runai_list_files(
+            prefix,
+            lambda path, size: results.append((path, size)),
+            is_recursive=is_recursive,
+            allow_patterns=allow_patterns,
+            ignore_patterns=ignore_patterns,
+            params=params,
+        )
+        return results
 
     def stream_files(
             self,

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_list_files.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_list_files.py
@@ -1,0 +1,224 @@
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from runai_model_streamer.file_streamer.file_streamer import FileStreamer
+from runai_model_streamer.s3_utils.s3_utils import S3Credentials
+
+
+def _list_files_stub(entries):
+    """Returns a side_effect for mock runai_list_files that fires the callback with given (path, size) pairs."""
+    def stub(prefix, callback, is_recursive=True, allow_patterns=None, ignore_patterns=None, params=None):
+        for path, size in entries:
+            callback(path, size)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# Filesystem
+# ---------------------------------------------------------------------------
+
+class TestListFilesFilesystem(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def _write(self, rel_path, content=b"x"):
+        full = os.path.join(self.temp_dir, rel_path)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "wb") as f:
+            f.write(content)
+        return full
+
+    def test_basic_listing(self):
+        self._write("a.txt", b"hello")
+        self._write("b.safetensors", b"world!")
+        results = FileStreamer().list_files(self.temp_dir)
+        paths = {r[0] for r in results}
+        self.assertIn(os.path.join(self.temp_dir, "a.txt"), paths)
+        self.assertIn(os.path.join(self.temp_dir, "b.safetensors"), paths)
+
+    def test_returns_correct_sizes(self):
+        self._write("sized.bin", b"12345")
+        results = FileStreamer().list_files(self.temp_dir)
+        by_path = {r[0]: r[1] for r in results}
+        self.assertEqual(by_path[os.path.join(self.temp_dir, "sized.bin")], 5)
+
+    def test_recursive(self):
+        self._write("root.txt", b"r")
+        self._write("sub/nested.txt", b"n")
+        nested = os.path.join(self.temp_dir, "sub", "nested.txt")
+
+        recursive_paths = {r[0] for r in FileStreamer().list_files(self.temp_dir, is_recursive=True)}
+        non_recursive_paths = {r[0] for r in FileStreamer().list_files(self.temp_dir, is_recursive=False)}
+
+        self.assertIn(nested, recursive_paths)
+        self.assertNotIn(nested, non_recursive_paths)
+
+    def test_allow_pattern(self):
+        self._write("model.safetensors", b"m")
+        self._write("config.json", b"c")
+        results = FileStreamer().list_files(self.temp_dir, allow_patterns=["*.safetensors"])
+        paths = {r[0] for r in results}
+        self.assertTrue(all(p.endswith(".safetensors") for p in paths))
+        self.assertFalse(any(p.endswith(".json") for p in paths))
+
+    def test_ignore_pattern(self):
+        self._write("model.safetensors", b"m")
+        self._write("config.json", b"c")
+        results = FileStreamer().list_files(self.temp_dir, ignore_patterns=["*.json"])
+        paths = {r[0] for r in results}
+        self.assertFalse(any(p.endswith(".json") for p in paths))
+        self.assertTrue(any(p.endswith(".safetensors") for p in paths))
+
+    def test_empty_directory(self):
+        results = FileStreamer().list_files(self.temp_dir)
+        self.assertEqual(results, [])
+
+    def test_nonexistent_path_raises(self):
+        with self.assertRaises(ValueError):
+            FileStreamer().list_files(os.path.join(self.temp_dir, "does_not_exist"))
+
+
+# ---------------------------------------------------------------------------
+# S3
+# ---------------------------------------------------------------------------
+
+class TestListFilesS3(unittest.TestCase):
+    PREFIX = "s3://my-bucket/models/"
+    ENTRIES = [
+        ("s3://my-bucket/models/model.safetensors", 1024),
+        ("s3://my-bucket/models/config.json", 256),
+    ]
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_basic_listing(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub(self.ENTRIES)
+        results = FileStreamer().list_files(self.PREFIX)
+        self.assertEqual(sorted(results), sorted(self.ENTRIES))
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_is_recursive_passed(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX, is_recursive=False)
+        self.assertEqual(mock_rlf.call_args.kwargs["is_recursive"], False)
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_allow_patterns_passed(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX, allow_patterns=["*.safetensors"])
+        self.assertEqual(mock_rlf.call_args.kwargs["allow_patterns"], ["*.safetensors"])
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_ignore_patterns_passed(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX, ignore_patterns=["*.json"])
+        self.assertEqual(mock_rlf.call_args.kwargs["ignore_patterns"], ["*.json"])
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.s3_credentials_module")
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_credentials_mapped_to_params(self, mock_rlf, mock_s3_mod):
+        mock_rlf.side_effect = _list_files_stub([])
+        creds = S3Credentials(
+            access_key_id="AKID",
+            secret_access_key="SECRET",
+            session_token="TOKEN",
+            region_name="us-east-1",
+            endpoint="https://s3.example.com",
+        )
+        mock_s3_mod.get_credentials.return_value = (MagicMock(), creds)
+        FileStreamer().list_files(self.PREFIX, credentials=creds)
+        params = mock_rlf.call_args.kwargs["params"]
+        self.assertEqual(params["key"], "AKID")
+        self.assertEqual(params["secret"], "SECRET")
+        self.assertEqual(params["token"], "TOKEN")
+        self.assertEqual(params["region"], "us-east-1")
+        self.assertEqual(params["endpoint"], "https://s3.example.com")
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.s3_credentials_module", None)
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_no_params_when_no_credentials_module(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub(self.ENTRIES)
+        results = FileStreamer().list_files(self.PREFIX)
+        self.assertIsNone(mock_rlf.call_args.kwargs["params"])
+        self.assertEqual(sorted(results), sorted(self.ENTRIES))
+
+
+# ---------------------------------------------------------------------------
+# GCS
+# ---------------------------------------------------------------------------
+
+class TestListFilesGCS(unittest.TestCase):
+    PREFIX = "gs://my-bucket/models/"
+    ENTRIES = [
+        ("gs://my-bucket/models/model.safetensors", 2048),
+        ("gs://my-bucket/models/config.json", 512),
+    ]
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_basic_listing(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub(self.ENTRIES)
+        results = FileStreamer().list_files(self.PREFIX)
+        self.assertEqual(sorted(results), sorted(self.ENTRIES))
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_is_recursive_passed(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX, is_recursive=False)
+        self.assertEqual(mock_rlf.call_args.kwargs["is_recursive"], False)
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_allow_patterns_passed(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX, allow_patterns=["*.safetensors"])
+        self.assertEqual(mock_rlf.call_args.kwargs["allow_patterns"], ["*.safetensors"])
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_no_credentials_for_gcs(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX)
+        self.assertIsNone(mock_rlf.call_args.kwargs["params"])
+
+
+# ---------------------------------------------------------------------------
+# Azure
+# ---------------------------------------------------------------------------
+
+class TestListFilesAzure(unittest.TestCase):
+    PREFIX = "az://my-container/models/"
+    ENTRIES = [
+        ("az://my-container/models/model.safetensors", 4096),
+        ("az://my-container/models/config.json", 128),
+    ]
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_basic_listing(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub(self.ENTRIES)
+        results = FileStreamer().list_files(self.PREFIX)
+        self.assertEqual(sorted(results), sorted(self.ENTRIES))
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_is_recursive_passed(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX, is_recursive=False)
+        self.assertEqual(mock_rlf.call_args.kwargs["is_recursive"], False)
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_ignore_patterns_passed(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX, ignore_patterns=["*.json"])
+        self.assertEqual(mock_rlf.call_args.kwargs["ignore_patterns"], ["*.json"])
+
+    @patch("runai_model_streamer.file_streamer.file_streamer.runai_list_files")
+    def test_no_credentials_for_azure(self, mock_rlf):
+        mock_rlf.side_effect = _list_files_stub([])
+        FileStreamer().list_files(self.PREFIX)
+        self.assertIsNone(mock_rlf.call_args.kwargs["params"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_list_files.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_list_files.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from runai_model_streamer.file_streamer.file_streamer import FileStreamer
+from runai_model_streamer.libstreamer.libstreamer import runai_list_files
 from runai_model_streamer.s3_utils.s3_utils import S3Credentials
 
 
@@ -82,6 +83,20 @@ class TestListFilesFilesystem(unittest.TestCase):
     def test_nonexistent_path_raises(self):
         with self.assertRaises(ValueError):
             FileStreamer().list_files(os.path.join(self.temp_dir, "does_not_exist"))
+
+    def test_callback_exception_is_reraised(self):
+        # an exception raised inside the callback must propagate out of
+        # runai_list_files rather than be swallowed by the ctypes boundary
+        self._write("a.txt", b"hello")
+
+        class BoomError(Exception):
+            pass
+
+        def raising_callback(path, size):
+            raise BoomError("callback failed")
+
+        with self.assertRaises(BoomError):
+            runai_list_files(self.temp_dir, raising_callback, is_recursive=True)
 
 
 # ---------------------------------------------------------------------------

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
@@ -46,5 +46,29 @@ class LibstreamerDLLWrapper:
         self.fn_runai_response_str.argtypes = [ctypes.c_int]
         self.fn_runai_response_str.restype = ctypes.c_char_p
 
+        RunaiFileListCallback = ctypes.CFUNCTYPE(
+            None,                # return void
+            ctypes.c_char_p,     # path
+            ctypes.c_size_t,     # file_size
+            ctypes.c_void_p,     # user_data
+        )
+        self.RunaiFileListCallback = RunaiFileListCallback
+
+        self.fn_runai_list_files = self.lib.runai_list_files
+        self.fn_runai_list_files.argtypes = [
+            ctypes.c_char_p,                         # prefix
+            ctypes.c_int,                            # is_recursive
+            ctypes.POINTER(ctypes.c_char_p),         # allow_patterns
+            ctypes.c_uint,                           # num_allow_patterns
+            ctypes.POINTER(ctypes.c_char_p),         # ignore_patterns
+            ctypes.c_uint,                           # num_ignore_patterns
+            RunaiFileListCallback,                   # callback
+            ctypes.c_void_p,                         # user_data
+            ctypes.POINTER(ctypes.c_char_p),         # param_keys
+            ctypes.POINTER(ctypes.c_char_p),         # param_values
+            ctypes.c_uint,                           # num_params
+        ]
+        self.fn_runai_list_files.restype = ctypes.c_int
+
 
 dll = LibstreamerDLLWrapper(STREAMER_LIBRARY)

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -103,11 +103,19 @@ def runai_list_files(
     ignore_patterns: Optional[List[str]] = None,
     params: Optional[Dict[str, str]] = None,
 ) -> None:
-    results_holder = []
+    # Exceptions raised inside a ctypes callback do not propagate through the C
+    # call (they are routed to sys.unraisablehook). Capture the first one and
+    # re-raise it after runai_list_files returns so callers can detect failures.
+    callback_error: List[Exception] = []
 
     @dll.RunaiFileListCallback
     def _cb(path: bytes, size: int, _user_data: None) -> None:
-        callback(path.decode("utf-8"), size)
+        if callback_error:
+            return
+        try:
+            callback(path.decode("utf-8"), size)
+        except Exception as exc:
+            callback_error.append(exc)
 
     def make_pattern_array(patterns):
         if not patterns:
@@ -137,6 +145,9 @@ def runai_list_files(
         _cb, None,
         keys_arr, values_arr, num_params,
     )
+    # a callback failure is the root cause, so surface it before the error code
+    if callback_error:
+        raise callback_error[0]
     if error_code != SUCCESS_ERROR_CODE:
         raise ValueError(
             f"runai_list_files failed: {runai_response_str(error_code)}"

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -1,5 +1,5 @@
 from runai_model_streamer.libstreamer import dll, t_streamer
-from typing import List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 import ctypes
 
 from runai_model_streamer.s3_utils.s3_utils import (
@@ -93,3 +93,51 @@ def runai_response(streamer: t_streamer) -> Optional[Tuple[int, int]]:
 
 def runai_response_str(response_code: int) -> str:
     return dll.fn_runai_response_str(response_code)
+
+
+def runai_list_files(
+    prefix: str,
+    callback: Callable[[str, int], None],
+    is_recursive: bool = True,
+    allow_patterns: Optional[List[str]] = None,
+    ignore_patterns: Optional[List[str]] = None,
+    params: Optional[Dict[str, str]] = None,
+) -> None:
+    results_holder = []
+
+    @dll.RunaiFileListCallback
+    def _cb(path: bytes, size: int, _user_data: None) -> None:
+        callback(path.decode("utf-8"), size)
+
+    def make_pattern_array(patterns):
+        if not patterns:
+            return None, 0
+        arr = (ctypes.c_char_p * len(patterns))(
+            *[p.encode("utf-8") for p in patterns]
+        )
+        return arr, len(patterns)
+
+    allow_arr, num_allow = make_pattern_array(allow_patterns)
+    ignore_arr, num_ignore = make_pattern_array(ignore_patterns)
+
+    param_items = list((params or {}).items())
+    if param_items:
+        keys_arr   = (ctypes.c_char_p * len(param_items))(*[k.encode("utf-8") for k, _ in param_items])
+        values_arr = (ctypes.c_char_p * len(param_items))(*[v.encode("utf-8") for _, v in param_items])
+        num_params = len(param_items)
+    else:
+        keys_arr = values_arr = None
+        num_params = 0
+
+    error_code = dll.fn_runai_list_files(
+        prefix.encode("utf-8"),
+        int(is_recursive),
+        allow_arr, num_allow,
+        ignore_arr, num_ignore,
+        _cb, None,
+        keys_arr, values_arr, num_params,
+    )
+    if error_code != SUCCESS_ERROR_CODE:
+        raise ValueError(
+            f"runai_list_files failed: {runai_response_str(error_code)}"
+        )

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/credentials/credentials.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/credentials/credentials.py
@@ -5,6 +5,7 @@ import boto3
 
 AWS_CA_BUNDLE_ENV = "AWS_CA_BUNDLE"
 RUNAI_STREAMER_S3_UNSIGNED_ENV_VAR = "RUNAI_STREAMER_S3_UNSIGNED"
+RUNAI_STREAMER_NO_BOTO3_SESSION_ENV_VAR = "RUNAI_STREAMER_NO_BOTO3_SESSION"
 
 class S3Credentials:
     def __init__(
@@ -23,23 +24,27 @@ class S3Credentials:
 
 def get_credentials(credentials: Optional[S3Credentials] = None) -> Tuple[Optional[boto3.Session], S3Credentials]:
     """
-    Creates a boto3 session only if the environment variable RUNAI_STREAMER_NO_BOTO3_SESSION is set.
-    If the variable is not set, returns None and the original credentials.
+    Resolves S3 credentials, optionally via a boto3 session.
+
+    By default (RUNAI_STREAMER_NO_BOTO3_SESSION=1) no boto3 session is created:
+    the credentials are returned as provided and the C++ layer authenticates using
+    the AWS default credential provider chain (environment, profile, SSO, IMDS, etc.),
+    or the explicitly provided credentials. Set RUNAI_STREAMER_NO_BOTO3_SESSION=0 to
+    resolve credentials through a boto3 session in Python and pass the resolved
+    (frozen) credentials to the C++ layer.
 
     Returns:
-        - boto3.Session object (or None if RUNAI_STREAMER_NO_BOTO3_SESSION is set)
-        - S3Credentials object with the resolved credentials (or original if session not created)
+        - boto3.Session object (or None when no session is created)
+        - S3Credentials object with the resolved credentials (or the provided ones)
     """
 
+    # CA bundle resolution (AWS_CA_BUNDLE env or the profile "ca_bundle" setting)
+    # is handled by the C++ layer, so no boto3 session is needed for unsigned or
+    # no-session modes.
     if os.getenv(RUNAI_STREAMER_S3_UNSIGNED_ENV_VAR, "0") == "1":
-        if AWS_CA_BUNDLE_ENV not in os.environ:
-            session = boto3.Session()
-            ca_bundle = session._session.get_config_variable("ca_bundle")
-            if ca_bundle is not None:
-                os.environ.setdefault(AWS_CA_BUNDLE_ENV, ca_bundle)
         return None, credentials if credentials else S3Credentials()
 
-    if "RUNAI_STREAMER_NO_BOTO3_SESSION" in os.environ:
+    if os.getenv(RUNAI_STREAMER_NO_BOTO3_SESSION_ENV_VAR, "1") == "1":
         return None, credentials if credentials else S3Credentials()
 
     session = boto3.Session(
@@ -59,13 +64,7 @@ def get_credentials(credentials: Optional[S3Credentials] = None) -> Tuple[Option
         secret_access_key=frozen_creds.secret_key if frozen_creds else None,
         session_token=frozen_creds.token if frozen_creds else None,
         region_name=session.region_name,
-        endpoint=credentials.endpoint if credentials else None, 
+        endpoint=credentials.endpoint if credentials else None,
     )
 
-    # set ca_bundle if exists and AWS_CA_BUNDLE is undefined
-    if AWS_CA_BUNDLE_ENV not in os.environ:
-        ca_bundle = session._session.get_config_variable("ca_bundle")
-        if ca_bundle is not None:
-            os.environ.setdefault(AWS_CA_BUNDLE_ENV, ca_bundle)
- 
     return session, new_credentials

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/credentials/tests/test_credentials.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/credentials/tests/test_credentials.py
@@ -6,6 +6,7 @@ from runai_model_streamer_s3.credentials.credentials import (
     get_credentials,
     AWS_CA_BUNDLE_ENV,
     RUNAI_STREAMER_S3_UNSIGNED_ENV_VAR,
+    RUNAI_STREAMER_NO_BOTO3_SESSION_ENV_VAR,
 )
 
 
@@ -13,7 +14,7 @@ def _env_without_unsigned():
     env = os.environ.copy()
     env.pop(RUNAI_STREAMER_S3_UNSIGNED_ENV_VAR, None)
     env.pop(AWS_CA_BUNDLE_ENV, None)
-    env.pop("RUNAI_STREAMER_NO_BOTO3_SESSION", None)
+    env.pop(RUNAI_STREAMER_NO_BOTO3_SESSION_ENV_VAR, None)
     return env
 
 
@@ -26,35 +27,57 @@ class TestGetCredentialsUnsigned(unittest.TestCase):
         self.assertIsNone(session)
 
     @patch("runai_model_streamer_s3.credentials.credentials.boto3")
-    def test_unsigned_sets_ca_bundle(self, mock_boto3):
-        mock_boto3.Session.return_value._session.get_config_variable.return_value = "/etc/ssl/custom.pem"
+    def test_unsigned_creates_no_session(self, mock_boto3):
+        # CA bundle resolution now lives in the C++ layer; unsigned mode simply
+        # creates no boto3 session (and no longer touches AWS_CA_BUNDLE)
         env = _env_without_unsigned()
         env[RUNAI_STREAMER_S3_UNSIGNED_ENV_VAR] = "1"
         with patch.dict(os.environ, env, clear=True):
-            get_credentials(None)
-        self.assertEqual(os.environ.get(AWS_CA_BUNDLE_ENV), "/etc/ssl/custom.pem")
+            session, _ = get_credentials(None)
+        self.assertIsNone(session)
+        mock_boto3.Session.assert_not_called()
 
     @patch("runai_model_streamer_s3.credentials.credentials.boto3")
-    def test_unsigned_disabled_resolves_credentials(self, mock_boto3):
+    def test_no_boto3_session_disabled_resolves_credentials(self, mock_boto3):
+        # RUNAI_STREAMER_NO_BOTO3_SESSION=0 opts back into boto3 resolution
         mock_session = MagicMock()
         mock_session.get_credentials.return_value = None
         mock_session._session.get_config_variable.return_value = None
         mock_boto3.Session.return_value = mock_session
-        with patch.dict(os.environ, {RUNAI_STREAMER_S3_UNSIGNED_ENV_VAR: "0"}, clear=False):
+        env = _env_without_unsigned()
+        env[RUNAI_STREAMER_NO_BOTO3_SESSION_ENV_VAR] = "0"
+        with patch.dict(os.environ, env, clear=True):
             session, _ = get_credentials(None)
         mock_session.get_credentials.assert_called_once()
         self.assertIsNotNone(session)
 
     @patch("runai_model_streamer_s3.credentials.credentials.boto3")
-    def test_unsigned_absent_resolves_credentials(self, mock_boto3):
-        mock_session = MagicMock()
-        mock_session.get_credentials.return_value = None
-        mock_session._session.get_config_variable.return_value = None
-        mock_boto3.Session.return_value = mock_session
+    def test_no_boto3_session_default_returns_no_session(self, mock_boto3):
+        # Default: no boto3 session is created; the C++ layer self-authenticates
         with patch.dict(os.environ, _env_without_unsigned(), clear=True):
+            session, creds = get_credentials(None)
+        self.assertIsNone(session)
+        mock_boto3.Session.assert_not_called()
+        self.assertIsNotNone(creds)
+
+    @patch("runai_model_streamer_s3.credentials.credentials.boto3")
+    def test_no_boto3_session_enabled_returns_no_session(self, mock_boto3):
+        env = _env_without_unsigned()
+        env[RUNAI_STREAMER_NO_BOTO3_SESSION_ENV_VAR] = "1"
+        with patch.dict(os.environ, env, clear=True):
             session, _ = get_credentials(None)
-        mock_session.get_credentials.assert_called_once()
-        self.assertIsNotNone(session)
+        self.assertIsNone(session)
+        mock_boto3.Session.assert_not_called()
+
+    @patch("runai_model_streamer_s3.credentials.credentials.boto3")
+    def test_default_returns_provided_credentials_unchanged(self, mock_boto3):
+        from runai_model_streamer_s3.credentials.credentials import S3Credentials
+        provided = S3Credentials(access_key_id="AKID", secret_access_key="SECRET")
+        with patch.dict(os.environ, _env_without_unsigned(), clear=True):
+            session, creds = get_credentials(provided)
+        self.assertIsNone(session)
+        self.assertIs(creds, provided)
+        mock_boto3.Session.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/azure/test_azure.py
+++ b/tests/azure/test_azure.py
@@ -6,7 +6,7 @@ from azure.storage.blob import BlobServiceClient
 from azure.core.exceptions import ServiceRequestError, ResourceNotFoundError
 
 from tests.cases.interface import ObjectStoreBackend
-from tests.cases.testcases import compatibility_test_cases
+from tests.cases.testcases import compatibility_test_cases, list_files_test_cases
 
 
 class AzuriteServer(ObjectStoreBackend):
@@ -50,6 +50,12 @@ class AzuriteServer(ObjectStoreBackend):
 
 
 TestAzureCompatibility = compatibility_test_cases(
+    backend_class=AzuriteServer,
+    scheme="az",
+    bucket_name=os.getenv("AZURE_CONTAINER")
+)
+
+TestAzureListFiles = list_files_test_cases(
     backend_class=AzuriteServer,
     scheme="az",
     bucket_name=os.getenv("AZURE_CONTAINER")

--- a/tests/cases/testcases.py
+++ b/tests/cases/testcases.py
@@ -12,6 +12,7 @@ from runai_model_streamer.safetensors_streamer.safetensors_streamer import (
     list_safetensors,
     pull_files
 )
+from runai_model_streamer.file_streamer.file_streamer import FileStreamer
 
 METADATA_SUFFIX = ['safetensors', 'json', 'config', 'xml', 'pt', 'bin']
 FILE_COUNT = 5
@@ -194,3 +195,95 @@ def compatibility_test_cases(backend_class, scheme, bucket_name):
             shutil.rmtree(self.temp_dir)
 
     return TestObjectStorageCompatibility
+
+
+def list_files_test_cases(backend_class, scheme, bucket_name):
+    class TestListFilesCompatibility(unittest.TestCase):
+        @classmethod
+        def setUpClass(cls):
+            cls.server = backend_class()
+            cls.server.wait_for_startup()
+            cls.bucket_name = bucket_name
+            cls.scheme = scheme
+
+        def setUp(self):
+            self.temp_dir = tempfile.mkdtemp()
+            self.directory = random_letters(10)
+
+        def tearDown(self):
+            shutil.rmtree(self.temp_dir)
+
+        def _upload(self, directory, file_paths):
+            for fp in file_paths:
+                self.server.upload_file(self.bucket_name, directory, fp)
+
+        def _write(self, filename, content=b"x"):
+            path = os.path.join(self.temp_dir, filename)
+            with open(path, "wb") as f:
+                f.write(content)
+            return path
+
+        def _prefix(self, subdir=""):
+            base = f"{self.scheme}://{self.bucket_name}/{self.directory}"
+            return f"{base}/{subdir}" if subdir else f"{base}/"
+
+        def test_basic_listing(self):
+            files = [create_random_files(self.temp_dir) for _ in range(3)]
+            self._upload(self.directory, files)
+
+            results = FileStreamer().list_files(self._prefix())
+            result_paths = {r[0] for r in results}
+
+            for fp in files:
+                expected = f"{self.scheme}://{self.bucket_name}/{self.directory}/{os.path.basename(fp)}"
+                self.assertIn(expected, result_paths)
+
+        def test_returns_correct_sizes(self):
+            content = b"known content 123"
+            fp = self._write("known.bin", content)
+            self._upload(self.directory, [fp])
+
+            results = FileStreamer().list_files(self._prefix())
+            by_path = {r[0]: r[1] for r in results}
+            expected_path = f"{self.scheme}://{self.bucket_name}/{self.directory}/known.bin"
+            self.assertEqual(by_path[expected_path], len(content))
+
+        def test_recursive(self):
+            root_file = create_random_files(self.temp_dir)
+            nested_file = create_random_files(self.temp_dir)
+            self._upload(self.directory, [root_file])
+            self._upload(f"{self.directory}/subdir", [nested_file])
+
+            nested_path = f"{self.scheme}://{self.bucket_name}/{self.directory}/subdir/{os.path.basename(nested_file)}"
+
+            recursive_paths = {r[0] for r in FileStreamer().list_files(self._prefix(), is_recursive=True)}
+            non_recursive_paths = {r[0] for r in FileStreamer().list_files(self._prefix(), is_recursive=False)}
+
+            self.assertIn(nested_path, recursive_paths)
+            self.assertNotIn(nested_path, non_recursive_paths)
+
+        def test_allow_pattern(self):
+            fp_st = self._write("model.safetensors", b"model data")
+            fp_js = self._write("config.json", b"config data")
+            self._upload(self.directory, [fp_st, fp_js])
+
+            results = FileStreamer().list_files(self._prefix(), allow_patterns=["*.safetensors"])
+            paths = {r[0] for r in results}
+            self.assertTrue(all(p.endswith(".safetensors") for p in paths))
+            self.assertFalse(any(p.endswith(".json") for p in paths))
+
+        def test_ignore_pattern(self):
+            fp_st = self._write("model.safetensors", b"model data")
+            fp_js = self._write("config.json", b"config data")
+            self._upload(self.directory, [fp_st, fp_js])
+
+            results = FileStreamer().list_files(self._prefix(), ignore_patterns=["*.json"])
+            paths = {r[0] for r in results}
+            self.assertFalse(any(p.endswith(".json") for p in paths))
+            self.assertTrue(any(p.endswith(".safetensors") for p in paths))
+
+        def test_empty_prefix(self):
+            results = FileStreamer().list_files(self._prefix())
+            self.assertEqual(results, [])
+
+    return TestListFilesCompatibility

--- a/tests/gcs/test_gcs.py
+++ b/tests/gcs/test_gcs.py
@@ -7,7 +7,7 @@ from google.auth.credentials import AnonymousCredentials
 from google.api_core import exceptions as gcs_exceptions
 
 from tests.cases.interface import ObjectStoreBackend
-from tests.cases.testcases import compatibility_test_cases
+from tests.cases.testcases import compatibility_test_cases, list_files_test_cases
 
 class FakeGCSServer(ObjectStoreBackend):
     """A helper class to interact with a GCS-compatible test server."""
@@ -44,6 +44,12 @@ class FakeGCSServer(ObjectStoreBackend):
 
 
 TestGCSCompatibility = compatibility_test_cases(
+    backend_class = FakeGCSServer,
+    scheme = "gs",
+    bucket_name = os.getenv("GCS_BUCKET")
+)
+
+TestGCSListFiles = list_files_test_cases(
     backend_class = FakeGCSServer,
     scheme = "gs",
     bucket_name = os.getenv("GCS_BUCKET")

--- a/tests/s3/test_s3.py
+++ b/tests/s3/test_s3.py
@@ -11,7 +11,7 @@ from botocore.exceptions import NoCredentialsError, ClientError
 from safetensors.torch import safe_open
 
 from tests.cases.interface import ObjectStoreBackend
-from tests.cases.testcases import compatibility_test_cases
+from tests.cases.testcases import compatibility_test_cases, list_files_test_cases
 from tests.safetensors.generator import create_random_safetensors
 from tests.safetensors.comparison import tensor_maps_are_equal
 from runai_model_streamer.safetensors_streamer.safetensors_streamer import (
@@ -56,6 +56,12 @@ class MinioServer(ObjectStoreBackend):
         s3_client.upload_file(file, bucket, os.path.join(directory, os.path.basename(file)))
 
 TestS3ompatibility = compatibility_test_cases(
+    backend_class = MinioServer,
+    scheme = "s3",
+    bucket_name = os.getenv("AWS_BUCKET")
+)
+
+TestS3ListFiles = list_files_test_cases(
     backend_class = MinioServer,
     scheme = "s3",
     bucket_name = os.getenv("AWS_BUCKET")


### PR DESCRIPTION
**List objects/files paths and sizes across backends and implemented in the cpp layer**

- New public C API runai_list_files(...) in libstreamer.so: lists a URI prefix (s3://, gs://, az://) or a local filesystem path, with `is_recursive` and `fnmatch` allow/ignore pattern filtering, delivering results through a C callback.
- Implementation lives in `impl::Streamer::list_files`: detects object-storage URI vs. filesystem, applies filtering, and returns (path, size) pairs.
- Per-backend `obj_list_files` / `obj_free_file_list` for S3, GCS, and Azure, sharing a common `list_files_impl.h` (single-allocation entry packing; nothing allocated on error).
- Object-storage listing reuses the existing client lifecycle
- Python: `FileStreamer.list_files(...)` over the C callback, returning `List[Tuple[str, int]]`.
- Tests: filesystem branch (`Streamer::list_files`), list_files_impl packing + error invariants, S3 path + cleanup via the S3 mock, and end-to-end coverage against MinIO / fake-GCS / Azurite. Added a reusable utils::temp::Dir RAII helper.

Later on, the new API is planned to replace the python implementation in `list_safetensors` 

**Fix S3 credentials handling — self-authenticate in C++**

- Restored building the S3 client's credentials from the passed key/secret/token (this wiring was dropped in the object-storage API refactor, so provided credentials were silently ignored). When none are provided, the client falls back to the AWS default credential provider chain (env / profile / STS / IAM / IMDS).
- Flipped the default of `RUNAI_STREAMER_NO_BOTO3_SESSION` to 1: by default no boto3 session is created and the C++ layer authenticates itself; set =0 to resolve credentials through boto3 in Python (e.g. SSO / credential_process profiles).
- `FileStreamer.list_files` resolves credentials through the same `handle_object_store` path as streaming.

**CA bundle (ca_bundle) — resolved in C++**

- The S3 client resolves the TLS CA bundle itself: `AWS_CA_BUNDLE` takes precedence, otherwise it falls back to the ca_bundle setting in the shared AWS config profile (~/.aws/config), matching boto3/aws-cli.
- Removed the corresponding CA-bundle handling from the Python credentials module — CA resolution is now owned by C++ and works in both authentication modes.
- Added a C++ test verifying `ca_bundle` is read from the config profile.

**Docs**

- docs/src/usage.md updated: AWS C++ SDK authentication is now documented as the default, boto3 as the opt-in (RUNAI_STREAMER_NO_BOTO3_SESSION=0), and ca_bundle noted as honored in both modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added file-listing support across local, S3, GCS, and Azure storage paths.
  * Added optional recursive listing and allow/ignore pattern filtering.
  * Exposed a Python `FileStreamer.list_files()` API that returns discovered paths and sizes.

* **Bug Fixes**
  * Improved S3 credential and TLS CA-bundle resolution behavior.
  * Updated credential/session handling for the Python-side S3 integration.

* **Tests**
  * Added unit + integration coverage for list-files behavior, recursion, filtering, and callback error propagation.
  * Added S3 CA-bundle resolution tests.  

* **Documentation**
  * Updated S3 authentication guidance and CA-bundle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->