### PR TITLE
Per-range destinations: a general scatter-gather read APIestination per range

### DIFF
--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -134,11 +134,10 @@ extern "C" int runai_request(
     SubmissionId * out_submission_id,
     unsigned num_files,
     const char ** paths,
-    size_t * file_offsets,
-    size_t * bytesizes,
-    void ** dsts,
-    unsigned * num_sizes,
-    size_t ** internal_sizes
+    unsigned * num_ranges,
+    size_t * range_offsets,
+    size_t * range_sizes,
+    void ** range_dsts
 )
 {
     __multi_state.clear();
@@ -147,13 +146,33 @@ extern "C" int runai_request(
     __response_total = 0;
     __response_given = 0;
 
-    int buffer_start = 0;
+    // The range arrays are flat and grouped by file in the order of paths; base walks that grouping.
+    //
+    // The mock reads each file as ONE contiguous span, starting at its first range's offset and
+    // destination. That matches every caller today - a file's ranges are laid out consecutively in both
+    // the file and the destination - but a genuinely scattered request would need a seek per range here.
+    size_t base = 0;
     for (unsigned i = 0; i < num_files; ++i) {
+        const unsigned n = num_ranges[i];
+
+        size_t bytesize = 0;
+        for (unsigned j = 0; j < n; ++j) {
+            bytesize += range_sizes[base + j];
+        }
+
         State state;
-        request(streamer, paths[i], file_offsets[i], bytesizes[i], reinterpret_cast<char*>(dsts[0]) + buffer_start, num_sizes[i], internal_sizes[i], &state);
-        buffer_start = buffer_start + bytesizes[i];
-        __response_total += num_sizes[i];
+        request(streamer,
+                paths[i],
+                n > 0 ? range_offsets[base] : 0,
+                bytesize,
+                n > 0 ? reinterpret_cast<char*>(range_dsts[base]) : nullptr,
+                n,
+                range_sizes + base,
+                &state);
+
+        __response_total += n;
         __multi_state.push_back(std::move(state));
+        base += n;
     }
 
     __submission_id += 1;

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -26,6 +26,11 @@ struct State {
     std::vector<MockRange> ranges;
     unsigned total_items = 0;
     unsigned current_item = 0;
+
+    // Set when the file could not be opened. Every range still gets a response, carrying this code -
+    // the real streamer fails a file's ranges individually rather than dropping them, and a dropped
+    // response would hang the caller (runai_response blocks).
+    int error = 0;
 };
 
 State __state;
@@ -43,18 +48,31 @@ unsigned __response_given = 0;   // responses handed out so far
 // when it is served, since ranges need not be ordered or adjacent.
 int request(void * streamer, const char * path, unsigned num_ranges, const size_t * range_offsets, const size_t * range_sizes, void ** range_dsts, State * state)
 {
+    // Record the ranges BEFORE touching the file. The submission owes exactly one response per range
+    // whatever happens below, and runai_request does not consult this function's result - so returning
+    // early would leave total_items at 0 while the response counter had already been raised by num_ranges,
+    // and those responses would never be produced. The caller would then block forever in runai_response.
+    state->ranges.reserve(num_ranges);
+    bool needs_file = false;
+    for (unsigned j = 0; j < num_ranges; ++j) {
+        state->ranges.push_back(MockRange{ range_offsets[j], range_sizes[j], reinterpret_cast<char*>(range_dsts[j]) });
+        needs_file = needs_file || range_sizes[j] != 0;
+    }
+    state->total_items = num_ranges;
+
+    // A zero-sized range never reaches storage in the real streamer, so a file whose ranges are all
+    // zero-sized (or which has no ranges at all) is answered without being opened.
+    if (!needs_file) {
+        return 0;
+    }
+
     state->file = utils::Fd(::open(path, O_RDONLY));
     if (state->file.fd() == -1) {
         LOG(ERROR) << "Error opening file: " << path;
+        state->error = 2;   // common::ResponseCode::FileAccessError, reported once per range
         return -1;
     }
 
-    state->ranges.reserve(num_ranges);
-    for (unsigned j = 0; j < num_ranges; ++j) {
-        state->ranges.push_back(MockRange{ range_offsets[j], range_sizes[j], reinterpret_cast<char*>(range_dsts[j]) });
-    }
-
-    state->total_items = num_ranges;
     return 0;
 }
 
@@ -66,6 +84,24 @@ int response(void * streamer, unsigned * index, State * state)
 {
     size_t result = 0;
     const auto & range = state->ranges[state->current_item];
+
+    // Consume the item up front, so every exit below produces exactly one response for this range.
+    *index = state->current_item;
+    state->current_item++;
+
+    // A zero-sized range is completed without touching the file - it reaches no storage in the real
+    // streamer, so it must succeed even when the file could not be opened.
+    if (range.size == 0)
+    {
+        return 0;
+    }
+
+    // The file could not be opened: report the error for this range rather than dropping its response.
+    if (state->error != 0)
+    {
+        return state->error;
+    }
+
     int ret = 0;
     try
     {
@@ -85,8 +121,6 @@ int response(void * streamer, unsigned * index, State * state)
         ret = 3;   // common::ResponseCode::EofError
     }
 
-    *index = state->current_item;
-    state->current_item++;
     return ret;
 }
 

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -53,16 +53,15 @@ int request(void * streamer, const char * path, unsigned num_ranges, const size_
     // early would leave total_items at 0 while the response counter had already been raised by num_ranges,
     // and those responses would never be produced. The caller would then block forever in runai_response.
     state->ranges.reserve(num_ranges);
-    bool needs_file = false;
     for (unsigned j = 0; j < num_ranges; ++j) {
         state->ranges.push_back(MockRange{ range_offsets[j], range_sizes[j], reinterpret_cast<char*>(range_dsts[j]) });
-        needs_file = needs_file || range_sizes[j] != 0;
     }
     state->total_items = num_ranges;
 
-    // A zero-sized range never reaches storage in the real streamer, so a file whose ranges are all
-    // zero-sized (or which has no ranges at all) is answered without being opened.
-    if (!needs_file) {
+    // A file with NO ranges yields no transfer and no batch in the real streamer, so it is never opened.
+    // All-zero-sized ranges are different: they do yield a batch, and Batch::execute opens the file before
+    // looking at any size - so an unopenable file fails them (verified: it returns FileAccessError).
+    if (num_ranges == 0) {
         return 0;
     }
 
@@ -89,17 +88,17 @@ int response(void * streamer, unsigned * index, State * state)
     *index = state->current_item;
     state->current_item++;
 
-    // A zero-sized range is completed without touching the file - it reaches no storage in the real
-    // streamer, so it must succeed even when the file could not be opened.
-    if (range.size == 0)
-    {
-        return 0;
-    }
-
-    // The file could not be opened: report the error for this range rather than dropping its response.
+    // The file could not be opened: report the error rather than dropping the response. Checked BEFORE the
+    // zero-sized shortcut, because the real streamer opens the file regardless of range size.
     if (state->error != 0)
     {
         return state->error;
+    }
+
+    // A zero-sized range reads nothing, so it is completed without touching the (successfully opened) file.
+    if (range.size == 0)
+    {
+        return 0;
     }
 
     int ret = 0;

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -12,13 +12,20 @@
 
 namespace runai::llm::streamer
 {
+// One range of a submission, exactly as the caller described it: its own source offset, size and
+// destination. The mock keeps all three per range rather than a file offset plus a running destination
+// cursor, so a submission whose ranges are non-contiguous in the file or in memory is served correctly.
+struct MockRange {
+    size_t offset;
+    size_t size;
+    char * dst;
+};
+
 struct State {
     utils::Fd file;
-    std::vector<size_t> read_item_sizes;
+    std::vector<MockRange> ranges;
     unsigned total_items = 0;
     unsigned current_item = 0;
-    char* destination = nullptr;
-    unsigned current_dst_offset = 0;
 };
 
 State __state;
@@ -32,7 +39,9 @@ unsigned __response_total = 0;   // total sub-range responses expected for the c
 unsigned __response_given = 0;   // responses handed out so far
 
 
-int request(void * streamer, const char * path, size_t file_offset, size_t bytesize, char * dst, unsigned num_sizes, size_t * internal_sizes, State * state)
+// Record one file's ranges. The seek is deliberately NOT done here: each range seeks to its own offset
+// when it is served, since ranges need not be ordered or adjacent.
+int request(void * streamer, const char * path, unsigned num_ranges, const size_t * range_offsets, const size_t * range_sizes, void ** range_dsts, State * state)
 {
     state->file = utils::Fd(::open(path, O_RDONLY));
     if (state->file.fd() == -1) {
@@ -40,21 +49,12 @@ int request(void * streamer, const char * path, size_t file_offset, size_t bytes
         return -1;
     }
 
-    try
-    {
-        state->file.seek(file_offset);
-    }
-    catch(const std::exception& e)
-    {
-        LOG(ERROR) << "Error seek in file: " << path << " to: " << file_offset;
-        return -1;
+    state->ranges.reserve(num_ranges);
+    for (unsigned j = 0; j < num_ranges; ++j) {
+        state->ranges.push_back(MockRange{ range_offsets[j], range_sizes[j], reinterpret_cast<char*>(range_dsts[j]) });
     }
 
-    state->read_item_sizes.resize(num_sizes);
-    std::memcpy(state->read_item_sizes.data(), internal_sizes, num_sizes * sizeof(size_t));
-
-    state->total_items = num_sizes;
-    state->destination = dst;
+    state->total_items = num_ranges;
     return 0;
 }
 
@@ -65,26 +65,26 @@ int request(void * streamer, const char * path, size_t file_offset, size_t bytes
 int response(void * streamer, unsigned * index, State * state)
 {
     size_t result = 0;
-    auto to_read = state->read_item_sizes[state->current_item];
-    auto to_dst = state->destination + state->current_dst_offset;
+    const auto & range = state->ranges[state->current_item];
     int ret = 0;
     try
     {
-        result = state->file.read(to_read, to_dst, utils::Fd::Read::Eof);
+        // seek per range: the previous range may have been elsewhere in the file, or later in it
+        state->file.seek(range.offset);
+        result = state->file.read(range.size, range.dst, utils::Fd::Read::Eof);
     }
     catch(const std::exception& e)
     {
-        LOG(ERROR) << "Failed to read from file";
+        LOG(ERROR) << "Failed to read from file at offset " << range.offset;
         ret = 2;   // common::ResponseCode::FileAccessError
     }
 
-    if (ret == 0 && result != to_read)
+    if (ret == 0 && result != range.size)
     {
         LOG(ERROR) << "Reached EOF";
         ret = 3;   // common::ResponseCode::EofError
     }
 
-    state->current_dst_offset += result;
     *index = state->current_item;
     state->current_item++;
     return ret;
@@ -147,27 +147,20 @@ extern "C" int runai_request(
     __response_given = 0;
 
     // The range arrays are flat and grouped by file in the order of paths; base walks that grouping.
-    //
-    // The mock reads each file as ONE contiguous span, starting at its first range's offset and
-    // destination. That matches every caller today - a file's ranges are laid out consecutively in both
-    // the file and the destination - but a genuinely scattered request would need a seek per range here.
+    // Each file's ranges are handed over as they were submitted - every range keeps its own offset,
+    // size and destination, so scattered submissions are served correctly rather than collapsed into
+    // one contiguous span per file.
     size_t base = 0;
     for (unsigned i = 0; i < num_files; ++i) {
         const unsigned n = num_ranges[i];
 
-        size_t bytesize = 0;
-        for (unsigned j = 0; j < n; ++j) {
-            bytesize += range_sizes[base + j];
-        }
-
         State state;
         request(streamer,
                 paths[i],
-                n > 0 ? range_offsets[base] : 0,
-                bytesize,
-                n > 0 ? reinterpret_cast<char*>(range_dsts[base]) : nullptr,
                 n,
+                range_offsets + base,
                 range_sizes + base,
+                range_dsts + base,
                 &state);
 
         __response_total += n;

--- a/cpp/s3/s3_mock/s3_mock.cc
+++ b/cpp/s3/s3_mock/s3_mock.cc
@@ -88,12 +88,11 @@ common::backend_api::ResponseCode_t obj_close_backend(common::backend_api::Objec
 {
     const auto guard = std::unique_lock<std::mutex>(__mutex);
 
-    auto response_code = common::response_code_from(utils::getenv<int>("RUNAI_STREAMER_S3_MOCK_RESPONSE_CODE", static_cast<int>(common::ResponseCode::Success)));
-    if (response_code != common::ResponseCode::Success)
-    {
-        LOG(ERROR) << "S3 mock backend not closed";
-        return response_code;
-    }
+    // RUNAI_STREAMER_S3_MOCK_RESPONSE_CODE deliberately does NOT apply here. It exists to inject read
+    // failures, and a test that sets it for the duration of a read is very likely to still have it set when
+    // the streamer is destroyed - which used to make the streamer's own teardown fail to close the backend,
+    // leaving the mock open while the wrapper believed it closed. Every later obj_open_backend then failed
+    // with "already opened" for the rest of the process. Failure injection must not break the lifecycle.
 
     if (!__opened)
     {
@@ -102,7 +101,7 @@ common::backend_api::ResponseCode_t obj_close_backend(common::backend_api::Objec
     }
 
     __opened = false;
-    return response_code;
+    return common::ResponseCode::Success;
 }
 
 common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy()

--- a/cpp/streamer/BUILD
+++ b/cpp/streamer/BUILD
@@ -37,6 +37,7 @@ runai_cc_test(
             "//common/backend_api/object_storage",
            "//utils/random",
             "//utils/temp/env",
+            "//utils/temp/file",
             "//utils/dylib",
             "//utils/logging",
             "//utils/fdlimit",

--- a/cpp/streamer/impl/assigner/BUILD
+++ b/cpp/streamer/impl/assigner/BUILD
@@ -4,7 +4,7 @@ runai_cc_auto_library(
     name = "assigner",
     deps = [
         "//streamer/impl/assigner/file_read_task",
-        "//streamer/impl/batches",
+        "//streamer/impl/request",
         "//common/exception",
         "//common/storage_uri",
         "//streamer/impl/config",

--- a/cpp/streamer/impl/assigner/assigner.cc
+++ b/cpp/streamer/impl/assigner/assigner.cc
@@ -1,15 +1,10 @@
 #include "streamer/impl/assigner/assigner.h"
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
-#include <numeric> // For std::accumulate
-#include <cmath>   // For std::ceil
-#include <stdexcept> // For exceptions
-#include <limits>  // For numeric_limits
-#include <map>
-#include <utility>
 
 #include "common/exception/exception.h"
 #include "common/storage_uri/storage_uri.h"
@@ -19,41 +14,26 @@
 namespace runai::llm::streamer::impl
 {
 
-Assigner::Assigner(
-        const std::vector<std::string> & paths,
-        const std::vector<size_t> & file_offsets,
-        const std::vector<size_t>&  bytesizes,
-        const std::vector<void*> & dsts,
-        std::shared_ptr<const Config> config) :
+Assigner::Assigner(const std::vector<FileRanges> & request, std::shared_ptr<const Config> config) :
 _config(config),
-_is_object_storage(check_object_storage(paths)),
-_num_workers(_is_object_storage ? _config->s3_concurrency : _config->concurrency)
+_is_object_storage(check_object_storage(request)),
+_num_workers(_is_object_storage ? _config->s3_concurrency : _config->concurrency),
+_num_workloads(0)
 {
-    LOG(DEBUG) << "Assigning " << paths.size() << " files to " << _num_workers << " workers";
-    const size_t num_files = paths.size();
-    if (num_files == 0)
+    LOG(DEBUG) << "Assigning " << request.size() << " files to " << _num_workers << " workers";
+
+    if (request.empty())
     {
         LOG(WARNING) << "Assigner: No files provided.";
         return; // Nothing to assign
     }
 
-    if (!(num_files == file_offsets.size() && num_files == bytesizes.size() && (num_files == dsts.size() || dsts.size() == 1)))
-    {
-        LOG(ERROR) <<  "Input vector sizes mismatch " << num_files << " " << file_offsets.size() << " " << bytesizes.size() << " " << dsts.size();
-        throw common::Exception(common::ResponseCode::InvalidParameterError);
-    }
+    const size_t total_bytes_to_read = coalesce(request);
 
-    // Calculate Total Workload
-    size_t total_bytes_to_read = 0;
-    for (size_t size : bytesizes)
+    if (_transfers.empty())
     {
-        // Check for potential overflow if sizes are huge
-        if (total_bytes_to_read > std::numeric_limits<size_t>::max() - size)
-        {
-            LOG(ERROR) << "Total byte size calculation overflow";
-            throw common::Exception(common::ResponseCode::InvalidParameterError);
-        }
-        total_bytes_to_read += size;
+        LOG(WARNING) << "Assigner: no ranges to read.";
+        return;
     }
 
     if (total_bytes_to_read == 0)
@@ -61,98 +41,142 @@ _num_workers(_is_object_storage ? _config->s3_concurrency : _config->concurrency
         LOG(WARNING) << "Total bytes to read is zero.";
     }
 
-    // Determine Workload per Worker
-    size_t base_bytes_remainder;
-    size_t base_bytes_per_worker = bytes_per_worker(total_bytes_to_read, base_bytes_remainder);
-    LOG(DEBUG) << "base_bytes_per_worker: " << base_bytes_per_worker << " base_bytes_remainder: " << base_bytes_remainder;
+    assign(total_bytes_to_read);
+}
+
+// Merge each file's ranges into ContiguousTransfers. Single pass over the ranges, which also
+// accumulates the byte total and detects unordered input - none of these needs its own scan.
+size_t Assigner::coalesce(const std::vector<FileRanges> & request)
+{
+    size_t total_bytes = 0;
+
+    // The best case is one transfer per file. Growing past that is cheap: ContiguousTransfer's move is
+    // noexcept (two vector moves plus PODs), so reallocation moves the range vectors rather than
+    // copying them.
+    _transfers.reserve(request.size());
+
+    for (unsigned file_index = 0; file_index < request.size(); ++file_index)
+    {
+        const auto & ranges = request[file_index].ranges;
+
+        // Index of the transfer currently open for extension; _transfers.size() means "none open".
+        // Reset per file, which is also what stops a transfer from ever spanning two files.
+        size_t open = _transfers.size();
+        bool ordered = true;
+
+        for (unsigned i = 0; i < ranges.size(); ++i)
+        {
+            const auto & range = ranges[i];
+            char * const destination = static_cast<char *>(range.dst);
+
+            if (total_bytes > std::numeric_limits<size_t>::max() - range.size)
+            {
+                LOG(ERROR) << "Total byte size calculation overflow";
+                throw common::Exception(common::ResponseCode::InvalidParameterError);
+            }
+            total_bytes += range.size;
+
+            if (open < _transfers.size())
+            {
+                auto & current = _transfers[open];
+
+                // Extend only when adjacent in BOTH the file and the destination: a single read fills a
+                // single contiguous buffer, so either gap alone breaks the merge.
+                if (current.offset + current.size == range.offset &&
+                    current.destination + current.size == destination)
+                {
+                    current.size += range.size;
+                    current.range_sizes.push_back(range.size);
+                    continue;
+                }
+
+                // Noticed here for free rather than in a separate ordering pass
+                ordered = ordered && range.offset >= current.offset;
+            }
+
+            // NOTE: never hold a reference into _transfers across this push - it may reallocate.
+            // The open transfer is tracked by index for exactly that reason.
+            open = _transfers.size();
+            _transfers.emplace_back();
+
+            auto & opened = _transfers.back();
+            opened.file_index = file_index;
+            opened.offset = range.offset;
+            opened.size = range.size;
+            opened.destination = destination;
+            opened.first_range_index = i;
+            opened.range_sizes.push_back(range.size);
+        }
+
+        if (!ordered)
+        {
+            LOG(DEBUG) << "Ranges of " << request[file_index].path << " are not ordered by ascending"
+                       << " offset; coalescing is limited to ranges adjacent in the order given";
+        }
+    }
+
+    LOG(DEBUG) << "Coalesced the request into " << _transfers.size() << " contiguous transfers";
+
+    return total_bytes;
+}
+
+// Divide the transfers between the workers by total bytes. A transfer larger than a worker's remaining
+// target is split, with offset and destination advancing together so every slice stays contiguous.
+void Assigner::assign(size_t total_bytes_to_read)
+{
+    size_t base_bytes_remainder = 0;
+    const size_t base_bytes_per_worker = bytes_per_worker(total_bytes_to_read, base_bytes_remainder);
 
     _worker_assignments.resize(_num_workers);
 
-    // ASSUMES dsts[0] is base of one large buffer
-    char * global_dst_buffer = static_cast<char *>(dsts[0]);
+    size_t index = 0;     // the transfer being assigned
+    size_t consumed = 0;  // how many of its bytes are already assigned
 
-    size_t current_global_dst_offset = 0; // Tracks position in the conceptual global buffer
-    size_t current_file_index = 0;
-    size_t current_offset_within_file = file_offsets[0]; // Start at the beginning of the first file's range
-
-    for (unsigned workload_idx = 0; workload_idx < _num_workers && current_file_index < num_files; ++workload_idx)
+    for (unsigned workload_idx = 0; workload_idx < _num_workers && index < _transfers.size(); ++workload_idx)
     {
-        size_t target_bytes_for_this_worker = (workload_idx == 0 ? base_bytes_per_worker + base_bytes_remainder : base_bytes_per_worker);
+        const size_t target = (workload_idx == 0 ? base_bytes_per_worker + base_bytes_remainder : base_bytes_per_worker);
+        size_t assigned = 0;
 
-        size_t bytes_assigned_to_this_worker = 0;
+        LOG(DEBUG) << "Assigning work to worker " << workload_idx << ", target bytes: " << target;
 
-        LOG(DEBUG) << "Assigning work to worker " << workload_idx << ", target bytes: " << target_bytes_for_this_worker;
-
-        while (current_file_index < num_files)
+        while (index < _transfers.size())
         {
-            const std::string& file_path = paths[current_file_index];
-            const size_t file_start_offset = file_offsets[current_file_index];
-            const size_t file_total_requested_size = bytesizes[current_file_index];
-            char* current_global_dst_ptr = global_dst_buffer + current_global_dst_offset;
+            auto & transfer = _transfers[index];
 
-            if (file_total_requested_size > 0 && bytes_assigned_to_this_worker >= target_bytes_for_this_worker)
+            // A zero sized transfer is still given a task: its ranges are zero sized, and every range
+            // owes exactly one response whatever its size.
+            if (transfer.size > 0 && assigned >= target)
             {
                 break;
             }
 
-            // Sanity check: current offset should be within the requested range for the file
-            if (file_total_requested_size && (current_offset_within_file < file_start_offset || current_offset_within_file >= file_start_offset + file_total_requested_size))
+            const size_t remaining = transfer.size - consumed;
+            const size_t to_assign = std::min(remaining, target - assigned);
+
+            transfer.tasks.emplace_back(workload_idx,
+                                        transfer.file_index,
+                                        transfer.offset + consumed,
+                                        to_assign,
+                                        transfer.destination + consumed);
+
+            LOG(SPAM) << "  Worker " << workload_idx << ": file " << transfer.file_index
+                      << " offset " << transfer.offset + consumed << " size " << to_assign;
+
+            assigned += to_assign;
+            consumed += to_assign;
+            _worker_assignments[workload_idx].total_bytes += to_assign;
+
+            if (consumed == transfer.size)
             {
-                LOG(ERROR) << "Logic error: current_offset_within_file (" << current_offset_within_file
-                        << ") is outside the requested range [" << file_start_offset << ", "
-                        << file_start_offset + file_total_requested_size << ") for file " << current_file_index;
-                throw std::logic_error("Internal error during workload assignment: Invalid file offset.");
+                ++index;
+                consumed = 0;
             }
+        }
 
-            const size_t bytes_remaining_in_current_file = (file_start_offset + file_total_requested_size) - current_offset_within_file;
-            const size_t bytes_still_needed_by_worker = target_bytes_for_this_worker - bytes_assigned_to_this_worker;
+        LOG(DEBUG) << "Finished assignment for worker " << workload_idx << ", total bytes assigned: " << assigned;
+    }
 
-            const size_t bytes_to_assign_now = std::min(bytes_remaining_in_current_file, bytes_still_needed_by_worker);
-
-            LOG(DEBUG) << "bytes_to_assign_now: " << bytes_to_assign_now;
-
-            if (file_total_requested_size == 0 || bytes_to_assign_now > 0)
-            {
-                 // Create Task
-
-                 LOG(DEBUG) << "Assigned read file task to worker " << workload_idx << " file index: " << current_file_index << " file offset: " << current_offset_within_file << " bytesize: " << bytes_to_assign_now << " destination " << static_cast<void *>(current_global_dst_ptr);
-                _worker_assignments[workload_idx].tasks.emplace_back(
-                    workload_idx,
-                    current_file_index,
-                    file_path,
-                    current_offset_within_file,
-                    bytes_to_assign_now,
-                    current_global_dst_ptr);
-
-                // --- Update State ---
-                bytes_assigned_to_this_worker += bytes_to_assign_now;
-                _worker_assignments[workload_idx].total_bytes += bytes_to_assign_now;
-                current_offset_within_file += bytes_to_assign_now;
-                current_global_dst_offset += bytes_to_assign_now; // Advance global destination offset
-
-                LOG(SPAM) << "  Worker " << workload_idx << ": Assigned task - File " << current_file_index
-                            << " ('" << file_path << "'), Offset " << current_offset_within_file - bytes_to_assign_now
-                            << ", Size " << bytes_to_assign_now;
-            }
-
-            // Check if we finished the current file
-            LOG(DEBUG) << "file_start_offset " << file_start_offset << " file_total_requested_size: " << file_total_requested_size << " current_offset_within_file: " << current_offset_within_file << " file_start_offset + file_total_requested_size: " << file_start_offset + file_total_requested_size;
-            if (current_offset_within_file == file_start_offset + file_total_requested_size)
-            {
-                LOG(DEBUG) << "Finished current file " << current_file_index;
-                current_file_index++;
-                if (current_file_index < num_files)
-                {
-                    // Reset offset for the new file to its starting requested offset
-                    current_offset_within_file = file_offsets[current_file_index];
-                }
-            }
-        } // End while loop for assigning work to current worker
-
-        LOG(DEBUG) << "Finished assignment for worker " << workload_idx << ", total bytes assigned: " << bytes_assigned_to_this_worker;
-    } // End for loop iterating through workers
-
-    // Verification
+    // Verification - every byte assigned exactly once, and every transfer fully covered by its tasks
     size_t assigned_total = 0;
     for (const auto & assignment : _worker_assignments)
     {
@@ -162,42 +186,30 @@ _num_workers(_is_object_storage ? _config->s3_concurrency : _config->concurrency
     ASSERT(assigned_total == total_bytes_to_read) << "Verification failed: Total bytes assigned (" << assigned_total
         << ") does not match total bytes requested (" << total_bytes_to_read << ")";
 
+    for (size_t i = 0; i < _transfers.size(); ++i)
+    {
+        size_t transfer_total = 0;
+        for (const auto & task : _transfers[i].tasks)
+        {
+            transfer_total += task.size;
+        }
+        ASSERT(transfer_total == _transfers[i].size) << "Transfer " << i << " of file " << _transfers[i].file_index
+            << " assigned " << transfer_total << " bytes but covers " << _transfers[i].size;
+    }
+
     LOG(DEBUG) << "Workload assignment verification successful. Total bytes assigned: " << assigned_total;
-
-    unsigned i = 0;
-    for (auto & worker : _worker_assignments)
-    {
-        for (auto & read_task : worker.tasks)
-        {
-            const auto file_index = read_task.original_file_index;
-            _assignments[file_index].push_back(std::move(read_task));
-        }
-        ++i;
-    }
-
-    // Verification
-    for (unsigned i = 0; i < paths.size(); ++i)
-    {
-        size_t file_assigned_total = 0;
-        for (auto & task : _assignments[i])
-        {
-            file_assigned_total += task.size;
-        }
-        ASSERT(file_assigned_total == bytesizes[i]) << "File index " << i << " total assigned " << file_assigned_total << " not equal to file size " << bytesizes[i];
-    }
 }
 
-bool Assigner::check_object_storage(const std::vector<std::string> & paths) const
+bool Assigner::check_object_storage(const std::vector<FileRanges> & request) const
 {
-    if (paths.size() == 0)
+    if (request.empty())
     {
         return false;
     }
 
-    std::shared_ptr<common::s3::StorageUri> uri;
     try
     {
-        uri = std::make_shared<common::s3::StorageUri>(paths[0]);
+        common::s3::StorageUri uri(request[0].path);
         return true;
     }
     catch(const std::exception& e)
@@ -207,11 +219,9 @@ bool Assigner::check_object_storage(const std::vector<std::string> & paths) cons
     return false;
 }
 
-// Access the assignments of a given file by the original file index
-const std::vector<FileReadTask> & Assigner::file_assignments(unsigned file_index) const
+const std::vector<ContiguousTransfer> & Assigner::transfers() const
 {
-    ASSERT(file_index < _assignments.size()) << "file index " << file_index << " overflow";
-    return _assignments.at(file_index);
+    return _transfers;
 }
 
 unsigned Assigner::get_num_workers() const

--- a/cpp/streamer/impl/assigner/assigner.cc
+++ b/cpp/streamer/impl/assigner/assigner.cc
@@ -207,18 +207,27 @@ void Assigner::assign(size_t total_bytes_to_read)
 // workload is homogeneous for BackendPools::push to route.
 bool Assigner::check_object_storage(const std::vector<FileRanges> & request) const
 {
-    if (request.empty())
+    // The first file WITH RANGES decides. A file with no ranges yields no transfer and reaches no storage,
+    // so it must not select the backend - otherwise an empty "s3://..." entry alongside real filesystem
+    // files would pick the object-storage worker count and block size for a submission that only ever
+    // touches the filesystem. lock_object_plugin skips those entries for the same reason.
+    for (const auto & file : request)
     {
-        return false;
-    }
+        if (file.ranges.empty())
+        {
+            continue;
+        }
 
-    try
-    {
-        common::s3::StorageUri uri(request[0].path);
-        return true;
-    }
-    catch(const std::exception& e)
-    {
+        try
+        {
+            common::s3::StorageUri uri(file.path);
+            return true;
+        }
+        catch(const std::exception& e)
+        {
+        }
+
+        return false;
     }
 
     return false;

--- a/cpp/streamer/impl/assigner/assigner.cc
+++ b/cpp/streamer/impl/assigner/assigner.cc
@@ -200,6 +200,11 @@ void Assigner::assign(size_t total_bytes_to_read)
     LOG(DEBUG) << "Workload assignment verification successful. Total bytes assigned: " << assigned_total;
 }
 
+// The submission's backend kind. Reading it from the first file alone is sound because a submission is
+// homogeneous by then: Streamer::lock_object_plugin rejects one that mixes filesystem with object storage
+// (or two object-storage plugins) with UnsupportedBackendMix, before an Assigner is ever constructed. That
+// is what lets one worker count and one block size cover the whole submission, and what guarantees every
+// workload is homogeneous for BackendPools::push to route.
 bool Assigner::check_object_storage(const std::vector<FileRanges> & request) const
 {
     if (request.empty())

--- a/cpp/streamer/impl/assigner/assigner.h
+++ b/cpp/streamer/impl/assigner/assigner.h
@@ -3,18 +3,54 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <map>
 
 #include "streamer/impl/assigner/file_read_task/file_read_task.h"
 #include "streamer/impl/config/config.h"
 #include "streamer/impl/batches/batches.h"
+#include "streamer/impl/request/request.h"
 
-// Split reading from several files into several read assignments
-// Each read assignment is destined to a worker, represented as FileReadTask
-// FileReadTask will be later transformed to a Batch object
+// Turn a multi-file read request into read assignments:
+//   1. coalesce each file's ranges into ContiguousTransfers
+//   2. divide the transfers between workers, each slice represented as a FileReadTask
+// A FileReadTask is later transformed into a Batch object
 
 namespace runai::llm::streamer::impl
 {
+
+// ContiguousTransfer - a maximal group of the caller's ranges that are adjacent in BOTH the file and
+// the destination buffer, so the whole group can be served by one sequential read. A transfer never
+// spans two files.
+//
+// Coalescing happens BEFORE any work is divided between workers, so a single-worker streamer still
+// reads a coalesced group with one read rather than one read per range.
+//
+// Ranges are coalesced in the order the caller supplied them: a caller that lists a file's ranges by
+// ascending offset gets maximal coalescing (the .cc logs at DEBUG when they arrive unordered, so the
+// lost coalescing is visible rather than silent).
+//
+// The transfer is also the unit that O_DIRECT alignment is priced per - each one needs its own
+// block-aligned destination region - so coalescing bounds alignment overhead as well as seeks.
+
+struct ContiguousTransfer
+{
+    unsigned file_index = 0;
+
+    size_t offset = 0;             // start offset in the file
+    size_t size = 0;               // total bytes of all the ranges it covers
+    char * destination = nullptr;  // destination of its first range
+
+    // Index of its first range within the file. The ranges it covers are
+    // [first_range_index, first_range_index + range_sizes.size()), which is what makes the response
+    // index computable: the j-th range of this transfer is request index first_range_index + j.
+    unsigned first_range_index = 0;
+
+    // Sizes of the ranges it covers, in order. Batches turns these into Request objects - one
+    // response each, whatever the size.
+    std::vector<size_t> range_sizes;
+
+    // This transfer's slices, one per worker it was divided between (usually one)
+    std::vector<FileReadTask> tasks;
+};
 
 // Holds all tasks assigned to a single worker
 
@@ -28,16 +64,12 @@ struct WorkerTasks
 
 struct Assigner
 {
-    Assigner(
-        // Input file descriptions
-        const std::vector<std::string>& paths,
-        const std::vector<size_t>& file_offsets,
-        const std::vector<size_t>& bytesizes,
-        const std::vector<void*>& dsts,
-        std::shared_ptr<const Config> config);
+    Assigner(const std::vector<FileRanges> & request, std::shared_ptr<const Config> config);
 
-    // Access the assignments for each worker
-    const std::vector<FileReadTask> & file_assignments(unsigned file_index) const;
+    // The coalesced transfers, each carrying the worker slices it was divided into. Batches is built
+    // per transfer: within a transfer the ranges tile one contiguous span of file and buffer, which is
+    // the assumption Batch is built on.
+    const std::vector<ContiguousTransfer> & transfers() const;
 
     unsigned get_num_workers() const;
 
@@ -45,13 +77,23 @@ struct Assigner
 
  private:
     size_t bytes_per_worker(size_t total_bytes_to_read, size_t & remainder_bytesize);
-    bool check_object_storage(const std::vector<std::string> & paths) const;
+    bool check_object_storage(const std::vector<FileRanges> & request) const;
+
+    // Step 1 - merge each file's ranges that are adjacent in both file and destination. Independent of
+    // the worker count, and of how the work is later divided. Returns the total bytes of the request,
+    // accumulated during the same pass so the ranges are walked only once.
+    size_t coalesce(const std::vector<FileRanges> & request);
+
+    // Step 2 - divide _transfers between the workers by total bytes, splitting a transfer that is
+    // larger than a worker's remaining target. Offset and destination advance together across a split,
+    // so each slice stays contiguous.
+    void assign(size_t total_bytes_to_read);
 
  private:
     std::shared_ptr<const Config> _config;
     bool _is_object_storage;
     unsigned _num_workers;
-    std::map<unsigned, std::vector<FileReadTask>> _assignments; // assigned work for each file (key is the file index)
+    std::vector<ContiguousTransfer> _transfers;
     std::vector<WorkerTasks> _worker_assignments; // ordered by worker index
     unsigned _num_workloads;
 };

--- a/cpp/streamer/impl/assigner/assigner.h
+++ b/cpp/streamer/impl/assigner/assigner.h
@@ -6,7 +6,6 @@
 
 #include "streamer/impl/assigner/file_read_task/file_read_task.h"
 #include "streamer/impl/config/config.h"
-#include "streamer/impl/batches/batches.h"
 #include "streamer/impl/request/request.h"
 
 // Turn a multi-file read request into read assignments:

--- a/cpp/streamer/impl/assigner/assigner_test.cc
+++ b/cpp/streamer/impl/assigner/assigner_test.cc
@@ -24,66 +24,291 @@ struct AssignerTest : public ::testing::Test
         config->s3_concurrency = utils::random::number(1, 20);
     }
 
+    // A file whose ranges tile [offset, offset + sum(sizes)) and are packed consecutively from dst -
+    // the layout the previous single-destination API implied. Coalesces to exactly one transfer.
+    static FileRanges contiguous_file(const std::string & path, size_t offset, const std::vector<size_t> & sizes, char * dst)
+    {
+        FileRanges file;
+        file.path = path;
+        file.ranges.reserve(sizes.size());
+
+        size_t o = offset;
+        char * d = dst;
+        for (const auto size : sizes)
+        {
+            file.ranges.push_back(ReadRange{ o, size, d });
+            o += size;
+            d += size;
+        }
+        return file;
+    }
+
+    static FileRanges file_with(const std::string & path, const std::vector<ReadRange> & ranges)
+    {
+        FileRanges file;
+        file.path = path;
+        file.ranges = ranges;
+        return file;
+    }
+
+    // The Assigner never dereferences a destination - it only does pointer arithmetic and comparison -
+    // so tests that care only about layout can use a fabricated base.
+    static char * fake_base()
+    {
+        return reinterpret_cast<char *>(static_cast<uintptr_t>(utils::random::number(1, 1000)) * 4096);
+    }
+
     std::shared_ptr<Config> config;
 };
 
 TEST_F(AssignerTest, Empty_Inputs)
 {
-    std::vector<std::string> paths;
-    std::vector<size_t> offsets;
-    std::vector<size_t> sizes;
-    std::vector<void*> dsts;
+    const std::vector<FileRanges> request;
 
-    // Empty input should not throw, just create empty assignments
-    EXPECT_NO_THROW(Assigner(paths, offsets, sizes, dsts, config));
+    // Empty input should not throw, just produce no transfers
+    EXPECT_NO_THROW(Assigner(request, config));
 
-    Assigner assigner(paths, offsets, sizes, dsts, config);
-    EXPECT_THROW(assigner.file_assignments(0), std::exception);
+    const Assigner assigner(request, config);
+    EXPECT_TRUE(assigner.transfers().empty());
+    EXPECT_EQ(assigner.num_workloads(), 0);
 }
 
-TEST_F(AssignerTest, Mismatched_Input_Sizes)
+TEST_F(AssignerTest, File_Without_Ranges)
 {
-    std::vector<std::string> paths = {utils::random::string()};
-    std::vector<size_t> offsets = {0};
-    std::vector<size_t> sizes = {utils::random::number(100, 1000)};
-    std::vector<void*> dsts;  // Empty dsts
+    // A file carrying no ranges is legal: it owes no responses and contributes no transfer
+    std::vector<FileRanges> request(1);
+    request[0].path = utils::random::string();
 
-    EXPECT_THROW(Assigner(paths, offsets, sizes, dsts, config), runai::llm::streamer::common::Exception);
+    const Assigner assigner(request, config);
+    EXPECT_TRUE(assigner.transfers().empty());
 }
+
+// ---------------------------------------------------------------------------------------------
+// Coalescing - runs before any work is divided between workers
+// ---------------------------------------------------------------------------------------------
+
+TEST_F(AssignerTest, Coalesce_Adjacent_Ranges)
+{
+    char * const base = fake_base();
+    const std::vector<size_t> sizes = { 100, 200, 300, 400 };
+
+    std::vector<FileRanges> request;
+    request.push_back(contiguous_file(utils::random::string(), 4096, sizes, base));
+
+    const Assigner assigner(request, config);
+
+    ASSERT_EQ(assigner.transfers().size(), 1);
+
+    const auto & transfer = assigner.transfers()[0];
+    EXPECT_EQ(transfer.file_index, 0);
+    EXPECT_EQ(transfer.offset, 4096);
+    EXPECT_EQ(transfer.size, 1000);
+    EXPECT_EQ(transfer.destination, base);
+    EXPECT_EQ(transfer.first_range_index, 0);
+    EXPECT_EQ(transfer.range_sizes, sizes);
+}
+
+TEST_F(AssignerTest, Coalesce_Broken_By_File_Gap)
+{
+    char * const base = fake_base();
+
+    // adjacent in the destination, but a hole in the file
+    std::vector<FileRanges> request;
+    request.push_back(file_with(utils::random::string(), {
+        ReadRange{ 0,    100, base },
+        ReadRange{ 500,  100, base + 100 },   // file gap: 100 != 500
+    }));
+
+    const Assigner assigner(request, config);
+
+    ASSERT_EQ(assigner.transfers().size(), 2);
+    EXPECT_EQ(assigner.transfers()[0].first_range_index, 0);
+    EXPECT_EQ(assigner.transfers()[0].offset, 0);
+    EXPECT_EQ(assigner.transfers()[1].first_range_index, 1);
+    EXPECT_EQ(assigner.transfers()[1].offset, 500);
+    EXPECT_EQ(assigner.transfers()[1].destination, base + 100);
+}
+
+TEST_F(AssignerTest, Coalesce_Broken_By_Destination_Gap)
+{
+    char * const base = fake_base();
+
+    // adjacent in the file, but a hole in the destination - one read cannot fill two buffers
+    std::vector<FileRanges> request;
+    request.push_back(file_with(utils::random::string(), {
+        ReadRange{ 0,   100, base },
+        ReadRange{ 100, 100, base + 4096 },   // destination gap
+    }));
+
+    const Assigner assigner(request, config);
+
+    ASSERT_EQ(assigner.transfers().size(), 2);
+    EXPECT_EQ(assigner.transfers()[0].destination, base);
+    EXPECT_EQ(assigner.transfers()[1].destination, base + 4096);
+    EXPECT_EQ(assigner.transfers()[1].first_range_index, 1);
+}
+
+TEST_F(AssignerTest, Coalesce_Never_Spans_Files)
+{
+    char * const base = fake_base();
+
+    // two files whose ranges would look adjacent if the file boundary were ignored
+    std::vector<FileRanges> request;
+    request.push_back(contiguous_file(utils::random::string(), 0, { 100 }, base));
+    request.push_back(contiguous_file(utils::random::string(), 100, { 100 }, base + 100));
+
+    const Assigner assigner(request, config);
+
+    ASSERT_EQ(assigner.transfers().size(), 2);
+    EXPECT_EQ(assigner.transfers()[0].file_index, 0);
+    EXPECT_EQ(assigner.transfers()[1].file_index, 1);
+    EXPECT_EQ(assigner.transfers()[1].first_range_index, 0);
+}
+
+TEST_F(AssignerTest, Coalesce_Unordered_Ranges_Are_Not_Merged)
+{
+    char * const base = fake_base();
+
+    // the same two ranges as Coalesce_Adjacent_Ranges, listed back to front. Coalescing works on the
+    // order given, so nothing merges - the DEBUG log records the lost coalescing.
+    std::vector<FileRanges> request;
+    request.push_back(file_with(utils::random::string(), {
+        ReadRange{ 100, 100, base + 100 },
+        ReadRange{ 0,   100, base },
+    }));
+
+    const Assigner assigner(request, config);
+
+    EXPECT_EQ(assigner.transfers().size(), 2);
+}
+
+TEST_F(AssignerTest, Coalesce_With_Single_Worker)
+{
+    // Coalescing must not depend on the worker count: it happens before any assignment, so a
+    // single-worker streamer still reads a coalesced group with one read rather than one per range.
+    config->concurrency = 1;
+    config->s3_concurrency = 1;
+
+    char * const base = fake_base();
+    const std::vector<size_t> sizes = { 10, 20, 30, 40, 50 };
+
+    std::vector<FileRanges> request;
+    request.push_back(contiguous_file(utils::random::string(), 0, sizes, base));
+
+    const Assigner assigner(request, config);
+
+    ASSERT_EQ(assigner.transfers().size(), 1);
+    EXPECT_EQ(assigner.transfers()[0].range_sizes.size(), sizes.size());
+
+    // one worker, so the transfer is never split
+    ASSERT_EQ(assigner.transfers()[0].tasks.size(), 1);
+    EXPECT_EQ(assigner.transfers()[0].tasks[0].size, 150);
+    EXPECT_EQ(assigner.num_workloads(), 1);
+}
+
+TEST_F(AssignerTest, Transfer_Split_Across_Workers)
+{
+    // A transfer larger than a worker's target is split; the slices must tile it exactly, with the
+    // offset and destination advancing together so each slice stays contiguous.
+    config->concurrency = 8;
+
+    char * const base = fake_base();
+    const size_t size = config->fs_block_bytesize * 64;
+
+    std::vector<FileRanges> request;
+    request.push_back(contiguous_file(utils::random::string(), 0, { size }, base));
+
+    const Assigner assigner(request, config);
+
+    ASSERT_EQ(assigner.transfers().size(), 1);
+    const auto & transfer = assigner.transfers()[0];
+    EXPECT_GT(transfer.tasks.size(), 1);
+
+    size_t expected_offset = 0;
+    std::set<unsigned> worker_indices;
+    for (const auto & task : transfer.tasks)
+    {
+        EXPECT_EQ(task.offset_in_file, expected_offset);
+        EXPECT_EQ(task.destination, base + expected_offset);
+        EXPECT_EQ(worker_indices.count(task.workload_index), 0);
+        worker_indices.insert(task.workload_index);
+        expected_offset += task.size;
+    }
+    EXPECT_EQ(expected_offset, size);
+}
+
+TEST_F(AssignerTest, First_Range_Index_Of_Later_Transfer)
+{
+    // The response carries the index within the FILE, so a transfer that does not start at range 0 must
+    // report where it begins - otherwise every response after the first hole is misattributed.
+    char * const base = fake_base();
+
+    std::vector<FileRanges> request;
+    request.push_back(file_with(utils::random::string(), {
+        ReadRange{ 0,    10, base },
+        ReadRange{ 10,   10, base + 10 },
+        ReadRange{ 1000, 10, base + 20 },   // hole in the file: starts a new transfer
+        ReadRange{ 1010, 10, base + 30 },
+    }));
+
+    const Assigner assigner(request, config);
+
+    ASSERT_EQ(assigner.transfers().size(), 2);
+    EXPECT_EQ(assigner.transfers()[0].first_range_index, 0);
+    EXPECT_EQ(assigner.transfers()[0].range_sizes.size(), 2);
+    EXPECT_EQ(assigner.transfers()[1].first_range_index, 2);
+    EXPECT_EQ(assigner.transfers()[1].range_sizes.size(), 2);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Assignment
+// ---------------------------------------------------------------------------------------------
 
 TEST_F(AssignerTest, Valid_Inputs)
 {
     for (bool is_object_storage : {true, false})
     {
         const size_t num_files = utils::random::number(1, 10);
-        std::vector<std::string> paths;
-        std::vector<size_t> offsets;
-        std::vector<size_t> sizes;
-        std::vector<void*> dsts;
 
+        std::vector<FileRanges> request;
+        std::vector<size_t> sizes;
+        std::vector<size_t> offsets;
+
+        char * dst = fake_base();
         size_t total_size = 0;
         for (size_t i = 0; i < num_files; ++i)
         {
             const size_t file_size = utils::random::number<size_t>(100000, 100000000);
-            paths.push_back((is_object_storage ? "s3://bucket/" : "") + utils::random::string());
-            offsets.push_back(utils::random::number<size_t>(0, 100));
+            const size_t offset = utils::random::number<size_t>(0, 100);
+
+            request.push_back(contiguous_file((is_object_storage ? "s3://bucket/" : "") + utils::random::string(),
+                                              offset, { file_size }, dst));
             sizes.push_back(file_size);
-            dsts.push_back(reinterpret_cast<void *>(utils::random::number()));
+            offsets.push_back(offset);
+            dst += file_size;
             total_size += file_size;
         }
 
-        EXPECT_NO_THROW(Assigner(paths, offsets, sizes, dsts, config));
-        const Assigner assigner(paths, offsets, sizes, dsts, config);
+        EXPECT_NO_THROW(Assigner(request, config));
+        const Assigner assigner(request, config);
 
+        // one range per file, so one transfer per file
+        ASSERT_EQ(assigner.transfers().size(), num_files);
+
+        std::set<unsigned> worker_indices;
         for (size_t i = 0; i < num_files; ++i)
         {
-            const auto & tasks = assigner.file_assignments(i);
-            EXPECT_EQ(tasks[0].offset_in_file, offsets[i]);
+            const auto & transfer = assigner.transfers()[i];
+            EXPECT_EQ(transfer.file_index, i);
+            EXPECT_EQ(transfer.offset, offsets[i]);
+            EXPECT_EQ(transfer.tasks[0].offset_in_file, offsets[i]);
+
             size_t total = 0;
-            std::set<unsigned> worker_indices;
-            for (const auto & task : tasks)
+            std::set<unsigned> file_worker_indices;
+            for (const auto & task : transfer.tasks)
             {
-                EXPECT_EQ(worker_indices.count(task.workload_index), 0);
+                EXPECT_EQ(file_worker_indices.count(task.workload_index), 0);
+                file_worker_indices.insert(task.workload_index);
                 worker_indices.insert(task.workload_index);
                 total += task.size;
             }
@@ -92,17 +317,6 @@ TEST_F(AssignerTest, Valid_Inputs)
 
         // check that the number of assignment is the same as the number of workers
         EXPECT_EQ(assigner.get_num_workers(), (is_object_storage ? config->s3_concurrency : config->concurrency));
-
-        std::set<unsigned> worker_indices;
-        for (size_t i = 0; i < num_files; ++i)
-        {
-            const auto & tasks = assigner.file_assignments(i);
-            for (const auto & task : tasks)
-            {
-                LOG(SPAM) << "file " << i << " file size: " << sizes[i] << " task.workload_index: " << task.workload_index << " task.size: " << task.size;
-                worker_indices.insert(task.workload_index);
-            }
-        }
 
         const auto concurrency = is_object_storage ? config->s3_concurrency : config->concurrency;
         const auto block_bytesize = is_object_storage ? config->s3_block_bytesize : config->fs_block_bytesize;
@@ -114,152 +328,105 @@ TEST_F(AssignerTest, Valid_Inputs)
 
 TEST_F(AssignerTest, Overflow_Check)
 {
-    std::vector<std::string> paths = {"file1", "file2"};
-    std::vector<size_t> offsets = {0, 0};
-    std::vector<size_t> sizes = {std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()};
-    std::vector<void*> dsts = {nullptr, nullptr};
+    char * const base = fake_base();
 
-    EXPECT_THROW(Assigner(paths, offsets, sizes, dsts, config), runai::llm::streamer::common::Exception);
+    std::vector<FileRanges> request;
+    request.push_back(file_with("file1", { ReadRange{ 0, std::numeric_limits<size_t>::max(), base } }));
+    request.push_back(file_with("file2", { ReadRange{ 0, std::numeric_limits<size_t>::max(), base } }));
+
+    EXPECT_THROW(Assigner(request, config), runai::llm::streamer::common::Exception);
 }
 
-TEST_F(AssignerTest, Zero_Size_Files)
+TEST_F(AssignerTest, Zero_Size_Ranges)
 {
     const size_t num_files = utils::random::number(1, 50);
-    std::vector<std::string> paths;
-    std::vector<size_t> offsets;
+
+    std::vector<FileRanges> request;
     std::vector<size_t> sizes;
-    std::vector<void *> dsts;
+    std::vector<size_t> offsets;
+
+    char * dst = fake_base();
     size_t total_size = 0;
     for (size_t i = 0; i < num_files; ++i)
     {
-        paths.push_back(utils::random::string());
-        offsets.push_back(utils::random::number<size_t>(0, 100));
-        if (utils::random::boolean())
-        {
-            sizes.push_back(0);
-        }
-        else
-        {
-            sizes.push_back(utils::random::number<size_t>(1, 1000));
-        }
-        dsts.push_back(nullptr);
-        total_size += sizes[i];
+        const size_t size = utils::random::boolean() ? 0 : utils::random::number<size_t>(1, 1000);
+        const size_t offset = utils::random::number<size_t>(0, 100);
+
+        request.push_back(contiguous_file(utils::random::string(), offset, { size }, dst));
+        sizes.push_back(size);
+        offsets.push_back(offset);
+        dst += size;
+        total_size += size;
     }
-    dsts[0] = reinterpret_cast<void *>(utils::random::number());
 
-    const Assigner assigner(paths, offsets, sizes, dsts, config);
+    const Assigner assigner(request, config);
 
-    char * global_dst = static_cast<char *>(dsts[0]);
+    // every range yields a transfer, zero sized or not - each still owes exactly one response
+    ASSERT_EQ(assigner.transfers().size(), num_files);
+
+    std::set<unsigned> worker_indices;
     for (size_t i = 0; i < num_files; ++i)
     {
-        const auto & tasks = assigner.file_assignments(i);
-        LOG(SPAM) << "file " << i << " tasks size: " << tasks.size();
+        const auto & transfer = assigner.transfers()[i];
+        EXPECT_EQ(transfer.offset, offsets[i]);
+        EXPECT_EQ(transfer.size, sizes[i]);
+
+        // a zero sized transfer still gets exactly one task, so its range is still answered
         if (sizes[i] == 0)
         {
-            EXPECT_EQ(tasks.size(), 1);
-            EXPECT_EQ(tasks[0].size, 0);
-            EXPECT_EQ(tasks[0].offset_in_file, offsets[i]);
-            EXPECT_EQ(tasks[0].destination, global_dst);
-            continue;
+            ASSERT_EQ(transfer.tasks.size(), 1);
+            EXPECT_EQ(transfer.tasks[0].size, 0);
+            EXPECT_EQ(transfer.tasks[0].offset_in_file, offsets[i]);
         }
 
-        EXPECT_EQ(tasks[0].offset_in_file, offsets[i]);
-        EXPECT_EQ(tasks[0].destination, global_dst);
-        global_dst += sizes[i];
-
         size_t total = 0;
-        std::set<unsigned> worker_indices;
-        for (const auto & task : tasks)
+        for (const auto & task : transfer.tasks)
         {
-            EXPECT_EQ(worker_indices.count(task.workload_index), 0);
             worker_indices.insert(task.workload_index);
             total += task.size;
         }
         EXPECT_EQ(total, sizes[i]);
     }
 
-    // check that the number of assignment is the same as the number of workers
     EXPECT_EQ(assigner.get_num_workers(), config->concurrency);
 
-    std::set<unsigned> worker_indices;
-    for (size_t i = 0; i < num_files; ++i)
-    {
-        const auto & tasks = assigner.file_assignments(i);
-        for (const auto & task : tasks)
-        {
-            LOG(SPAM) << "file " << i << " file size: " << sizes[i] << " task.workload_index: " << task.workload_index << " task.size: " << task.size;
-            worker_indices.insert(task.workload_index);
-        }
-    }
-
-    const auto block_bytesize = config->fs_block_bytesize;
-    const size_t expected_workers = std::max(std::min(total_size / block_bytesize, static_cast<size_t>(config->concurrency)), 1UL);
+    const size_t expected_workers = std::max(std::min(total_size / config->fs_block_bytesize, static_cast<size_t>(config->concurrency)), 1UL);
     ASSERT_EQ(worker_indices.size(), static_cast<unsigned>(expected_workers));
     ASSERT_EQ(assigner.num_workloads(), static_cast<unsigned>(expected_workers));
 }
 
-TEST_F(AssignerTest, Only_Zero_Size_Files)
+TEST_F(AssignerTest, Only_Zero_Size_Ranges)
 {
     const size_t num_files = utils::random::number(1, 10);
-    std::vector<std::string> paths;
+
+    std::vector<FileRanges> request;
     std::vector<size_t> offsets;
-    std::vector<size_t> sizes;
-    std::vector<void *> dsts;
-    size_t total_size = 0;
+
+    char * const base = fake_base();
     for (size_t i = 0; i < num_files; ++i)
     {
-        paths.push_back(utils::random::string());
-        offsets.push_back(utils::random::number<size_t>(0, 100));
-        sizes.push_back(0);
-        dsts.push_back(nullptr);
-    }
-    dsts[0] = reinterpret_cast<void *>(utils::random::number());
-
-    const Assigner assigner(paths, offsets, sizes, dsts, config);
-
-    char * global_dst = static_cast<char *>(dsts[0]);
-    for (size_t i = 0; i < num_files; ++i)
-    {
-        const auto & tasks = assigner.file_assignments(i);
-        LOG(SPAM) << "file " << i << " tasks size: " << tasks.size();
-        if (sizes[i] == 0)
-        {
-            EXPECT_EQ(tasks.size(), 1);
-            EXPECT_EQ(tasks[0].size, 0);
-            EXPECT_EQ(tasks[0].offset_in_file, offsets[i]);
-            EXPECT_EQ(tasks[0].destination, global_dst);
-            continue;
-        }
-
-        EXPECT_EQ(tasks[0].offset_in_file, offsets[i]);
-        EXPECT_EQ(tasks[0].destination, global_dst);
-        global_dst += sizes[i];
-
-        size_t total = 0;
-        std::set<unsigned> worker_indices;
-        for (const auto & task : tasks)
-        {
-            EXPECT_EQ(worker_indices.count(task.workload_index), 0);
-            worker_indices.insert(task.workload_index);
-            total += task.size;
-        }
-        EXPECT_EQ(total, sizes[i]);
+        const size_t offset = utils::random::number<size_t>(0, 100);
+        request.push_back(contiguous_file(utils::random::string(), offset, { 0 }, base));
+        offsets.push_back(offset);
     }
 
-    // check that the number of assignment is the same as the number of workers
-    EXPECT_EQ(assigner.get_num_workers(), config->concurrency);
+    const Assigner assigner(request, config);
+
+    ASSERT_EQ(assigner.transfers().size(), num_files);
 
     std::set<unsigned> worker_indices;
     for (size_t i = 0; i < num_files; ++i)
     {
-        const auto & tasks = assigner.file_assignments(i);
-        for (const auto & task : tasks)
-        {
-            LOG(SPAM) << "file " << i << " file size: " << sizes[i] << " task.workload_index: " << task.workload_index << " task.size: " << task.size;
-            worker_indices.insert(task.workload_index);
-        }
+        const auto & transfer = assigner.transfers()[i];
+        ASSERT_EQ(transfer.tasks.size(), 1);
+        EXPECT_EQ(transfer.tasks[0].size, 0);
+        EXPECT_EQ(transfer.tasks[0].offset_in_file, offsets[i]);
+        worker_indices.insert(transfer.tasks[0].workload_index);
     }
 
+    EXPECT_EQ(assigner.get_num_workers(), config->concurrency);
+
+    // no bytes to read, so everything lands on a single worker
     ASSERT_EQ(worker_indices.size(), 1);
     ASSERT_EQ(assigner.num_workloads(), 1);
 }

--- a/cpp/streamer/impl/assigner/file_read_task/file_read_task.cc
+++ b/cpp/streamer/impl/assigner/file_read_task/file_read_task.cc
@@ -4,10 +4,9 @@ namespace runai::llm::streamer::impl
 {
 
 // Constructor
-FileReadTask::FileReadTask(unsigned workload_index, unsigned file_idx, const std::string & p, size_t offset, size_t sz, char * dst) :
+FileReadTask::FileReadTask(unsigned workload_index, unsigned file_idx, size_t offset, size_t sz, char * dst) :
     workload_index(workload_index),
     original_file_index(file_idx),
-    path(p),
     offset_in_file(offset),
     size(sz),
     destination(dst)

--- a/cpp/streamer/impl/assigner/file_read_task/file_read_task.h
+++ b/cpp/streamer/impl/assigner/file_read_task/file_read_task.h
@@ -1,17 +1,22 @@
 #pragma once
 
-#include <string>
+#include <cstddef>
 
 namespace runai::llm::streamer::impl
 {
 
-// Represents a single contiguous read operation from a specific file
+// Represents a single contiguous read operation from a specific file - one worker's slice of a
+// ContiguousTransfer.
+//
+// The file is identified by original_file_index alone; the path is deliberately NOT held here. Batches
+// already receives the path once per transfer, and nothing ever read this field - keeping it copied a
+// std::string into every task, which is one heap allocation per task (thousands per submission) for a
+// value nobody used.
 
 struct FileReadTask
 {
     FileReadTask(unsigned workload_index,
                  unsigned file_idx,
-                 const std::string& p,
                  size_t offset,
                  size_t sz,
                  char * dst);
@@ -21,11 +26,10 @@ struct FileReadTask
 
     unsigned workload_index;
 
-    unsigned original_file_index; // Index from the input vectors
-    std::string path;             // Path of the file to read
+    unsigned original_file_index; // Index of the file within the submitted request
     size_t offset_in_file;        // Starting byte offset within this file
     size_t size;                  // Number of bytes to read
-    char * destination;            // Pointer to the destination buffer for this task's data
+    char * destination;           // Pointer to the destination buffer for this task's data
 };
 
 } // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/batch/batch.cc
+++ b/cpp/streamer/impl/batch/batch.cc
@@ -108,8 +108,10 @@ void Batch::read(const Config & config, std::atomic<bool> & stopped)
     }
 
     auto file_offset = range.start;
-    // For CPU buffer we assume that all the requests are written to a single continous buffer
-    char * buffer = tasks[0].destination();;
+    // A batch covers one ContiguousTransfer, whose ranges are adjacent in both the file and the
+    // destination, so the whole batch writes into one contiguous buffer starting at the first task's
+    // destination. Both cursors advance in lockstep below.
+    char * buffer = tasks[0].destination();
 
     size_t num_chunks = range.size / config.fs_block_bytesize;
 
@@ -133,6 +135,16 @@ void Batch::read(const Config & config, std::atomic<bool> & stopped)
         num_chunks++;
         i = 1;
         _reader->read(range.end - file_offset, buffer);
+        finished_until(range.end, common::ResponseCode::Success);
+    }
+
+    // An empty batch range (range.start == range.end) enters neither branch above, so without this its
+    // tasks would never be notified and the submission would wait for responses that never come. That
+    // is reachable whenever a transfer carries only zero sized ranges - which the streamer accepts and
+    // must still answer, one response per range whatever its size.
+    // finished_until only ever advances _unfinished, so this is a no-op in every other case.
+    if (!stopped)
+    {
         finished_until(range.end, common::ResponseCode::Success);
     }
 

--- a/cpp/streamer/impl/batch/batch_test.cc
+++ b/cpp/streamer/impl/batch/batch_test.cc
@@ -140,6 +140,47 @@ TEST(Read, Sanity)
     EXPECT_FALSE(mismatch);
 }
 
+// A batch whose range is empty (start == end) reads nothing: neither the block loop nor the tail read
+// in Batch::read runs, because num_chunks is 0 and file_offset == range.end. Its tasks must still be
+// notified - a zero sized range owes exactly one response, like any other range - otherwise the
+// submission waits forever for a response that never comes.
+TEST(Read, Empty_Range)
+{
+    const auto start = utils::random::number<size_t>(0, 1024);
+
+    // the file must exist and be seekable to start; its contents are never read
+    const auto data = utils::random::buffer(start + 1);
+    utils::temp::File file(data);
+    const auto path = file.path;
+    common::s3::S3ClientWrapper::Params params;
+
+    auto responder = std::make_shared<common::Responder>(1);
+    const auto config = std::make_shared<Config>();
+
+    const auto file_index = utils::random::number();
+    const auto range_index = utils::random::number();
+
+    // a single zero sized range: one task, no bytes
+    auto request = std::make_shared<Request>(start, file_index, range_index, 1 /* tasks */, 0 /* bytesize */, nullptr);
+
+    Tasks tasks;
+    tasks.push_back(Task(request, start, 0 /* size */, 0 /* destination offset */));
+
+    Batch batch(utils::random::number(), utils::random::number(), file_index, path, params, std::move(tasks), responder, config);
+
+    EXPECT_EQ(batch.total_bytes(), 0);
+
+    std::atomic<bool> stopped(false);
+    EXPECT_NO_THROW(batch.execute(stopped));
+
+    // The response must arrive even though nothing was read. Timed rather than blocking so that a
+    // regression fails the test instead of hanging it.
+    auto r = batch.responder->pop(5000);
+    EXPECT_EQ(r.ret, common::ResponseCode::Success);
+    EXPECT_EQ(r.file_index, file_index);
+    EXPECT_EQ(r.index, range_index);
+}
+
 TEST(Read, Error)
 {
     std::string path;

--- a/cpp/streamer/impl/batch/batch_test.cc
+++ b/cpp/streamer/impl/batch/batch_test.cc
@@ -396,4 +396,54 @@ TEST(Read, Stopped_During_Read)
     }
 }
 
+// handle_error on a batch that ALREADY completed must produce no further response.
+//
+// Reached in practice: ObjectStorageWorker::report_workload records errors per FILE index, and one file now
+// contributes several batches (one per contiguous transfer) - so when one transfer fails and another
+// succeeds, handle_error is called on the successful one too. A second response for a range that already
+// answered would overrun the submission's expected count.
+//
+// Nothing in Batch prevents it. Task::_finished and Request::finished's exact-count check do, independently,
+// so this fails only when both are lost. It pins the contract - one response per range, ever - not either
+// mechanism.
+TEST(Batch, Handle_Error_After_Completion_Is_Silent)
+{
+    const auto start = utils::random::number<size_t>(0, 1024);
+    const auto size = utils::random::number<size_t>(1, 1024);
+    const auto data = utils::random::buffer(start + size);
+    utils::temp::File file(data);
+    common::s3::S3ClientWrapper::Params params;
+
+    // ONE range, so exactly one response is owed - the whole subject of the test. PERSISTENT for the reason
+    // the streamer uses it: a drained FINISH_ON_DRAIN responder answers FinishedError, hiding whether
+    // anything was pushed; a drained persistent one has nothing to give, so the second pop times out.
+    auto responder = std::make_shared<common::Responder>(1, common::QueueMode::PERSISTENT);
+
+    const auto chunk_bytesize = utils::random::number<size_t>(1, size);
+    const auto config = std::make_shared<Config>(utils::random::number(1, 4), chunk_bytesize, utils::random::number<size_t>(1, chunk_bytesize), false /* do not force minimum chunk size */);
+
+    std::vector<char> dst(size);
+    auto request = std::make_shared<Request>(start, utils::random::number(), utils::random::number(), 1, size, dst.data());
+
+    Tasks tasks;
+    tasks.push_back(Task(request, start, size, 0));
+
+    Batch batch(utils::random::number(), utils::random::number(), utils::random::number(), file.path, params, std::move(tasks), responder, config);
+
+    std::atomic<bool> stopped(false);
+    EXPECT_NO_THROW(batch.execute(stopped));
+
+    EXPECT_EQ(responder->pop().ret, common::ResponseCode::Success);
+
+    // the successful batch is failed anyway, as report_workload would do
+    EXPECT_NO_THROW(batch.handle_error(common::ResponseCode::FileAccessError));
+
+    // TimedOut, not a second response: nothing more was pushed
+    EXPECT_EQ(responder->pop(200).ret, common::ResponseCode::TimedOut);
+
+    // and no push beyond the one expected: with the count at zero an extra push is REJECTED rather than
+    // queued, so the timeout above would not see it - only this flag does
+    EXPECT_EQ(responder->valid(), common::ResponseCode::Success);
+}
+
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/batches/batches.cc
+++ b/cpp/streamer/impl/batches/batches.cc
@@ -89,14 +89,16 @@ Batches::Batches(SubmissionId submission_id,
                  std::shared_ptr<common::Responder> responder,
                  const std::string & path,
                  const common::s3::S3ClientWrapper::Params & params,
-                 const std::vector<size_t> & internal_sizes) :
+                 const std::vector<size_t> & range_sizes,
+                 unsigned first_range_index) :
     _submission_id(submission_id),
     _file_index(file_index),
+    _first_range_index(first_range_index),
     _itr(file_read_tasks),
     _responder(responder)
 {
     _batches.reserve(file_read_tasks.size());
-    build_tasks(config, path, params, internal_sizes);
+    build_tasks(config, path, params, range_sizes);
 }
 
 unsigned Batches::size() const
@@ -115,13 +117,16 @@ size_t Batches::total() const
     return _total;
 }
 
-void Batches::build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, const std::vector<size_t> & internal_sizes)
+void Batches::build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, const std::vector<size_t> & range_sizes)
 {
     const auto num_workers = _itr.workers();
     LOG(DEBUG) << "Building tasks for " <<num_workers << " workers";
     std::vector<Tasks> v_tasks(num_workers);
 
-    auto num_sizes = internal_sizes.size();
+    auto num_sizes = range_sizes.size();
+
+    // Within a transfer the ranges tile one contiguous span of both the file and the destination, so
+    // both cursors advance by the range size. That is exactly what coalescing guarantees.
     size_t request_file_offset = _itr.read_task(0).offset_in_file;
 
     auto destination_start = static_cast<char *>(_itr.read_task(0).destination);
@@ -129,13 +134,16 @@ void Batches::build_tasks(std::shared_ptr<const Config> config, const std::strin
     auto current_request_destination = destination_start;
 
     // iterate over the workers and the requests to fill each worker share
-    for (unsigned request_index = 0; request_index < num_sizes; ++request_index)
+    for (unsigned i = 0; i < num_sizes; ++i)
     {
         // create tasks for the entire requested range before sending to the threadpool
-        const size_t request_size = internal_sizes[request_index];
+        const size_t request_size = range_sizes[i];
 
-        handle_request(v_tasks, request_index, request_file_offset, request_size, current_request_destination);
-        LOG(DEBUG) << "created request index " << request_index << " dst " << static_cast<void *>(current_request_destination);
+        // the response carries the index within the FILE, so offset by this transfer's first range
+        const unsigned range_index = _first_range_index + i;
+
+        handle_request(v_tasks, range_index, request_file_offset, request_size, current_request_destination);
+        LOG(DEBUG) << "created request index " << range_index << " dst " << static_cast<void *>(current_request_destination);
 
         current_request_destination += request_size;
         request_file_offset += request_size;
@@ -161,7 +169,7 @@ void Batches::build_tasks(std::shared_ptr<const Config> config, const std::strin
     }
 }
 
-void Batches::handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size, char * destination)
+void Batches::handle_request(std::vector<Tasks> & v_tasks, unsigned range_index, size_t request_file_offset, size_t request_size, char * destination)
 {
     LOG(DEBUG) << "request file offset " << request_file_offset << " size " << request_size;
 
@@ -184,7 +192,7 @@ void Batches::handle_request(std::vector<Tasks> & v_tasks, unsigned request_inde
         destination_offset += to_read;
     } while (bytes_to_request > 0);
 
-    auto request_ptr = std::make_shared<Request>(request_file_offset, _file_index, request_index, infos.size(), request_size, destination);
+    auto request_ptr = std::make_shared<Request>(request_file_offset, _file_index, range_index, infos.size(), request_size, destination);
 
     // create tasks
     for (auto & [batch_id, info] : infos)

--- a/cpp/streamer/impl/batches/batches.h
+++ b/cpp/streamer/impl/batches/batches.h
@@ -83,8 +83,6 @@ struct Batches
     // index within the file of this transfer's first range
     unsigned _first_range_index;
 
-    unsigned _size;
-
     BatchItr _itr;
 
     std::vector<Batch> _batches;

--- a/cpp/streamer/impl/batches/batches.h
+++ b/cpp/streamer/impl/batches/batches.h
@@ -15,11 +15,19 @@
 namespace runai::llm::streamer::impl
 {
 
-// Transforms a file read request into batches, one batch per process
-// Batches is a group of Batch objects, which together read the same file
+// Transforms one ContiguousTransfer into batches, one batch per worker it was divided between.
+// Batches is a group of Batch objects which together read the same contiguous span of one file.
+//
+// Built per transfer rather than per file: within a transfer the ranges tile one contiguous span of
+// both file and destination, which is the assumption Batch is built on. A file with non-adjacent
+// ranges simply yields several Batches.
 
 struct Batches
 {
+    // range_sizes are the transfer's ranges in order, and first_range_index is the index of its first
+    // range within the file - so the j-th range of this transfer is request index first_range_index + j.
+    // That index is what the caller receives back as the response's `index`, so it must be the index in
+    // the file's original range list, not the position within this transfer.
     Batches(SubmissionId submission_id,
            unsigned file_index,
            const std::vector<FileReadTask> & file_read_tasks,
@@ -27,7 +35,8 @@ struct Batches
            std::shared_ptr<common::Responder> responder,
            const std::string & path,
            const common::s3::S3ClientWrapper::Params & params,
-           const std::vector<size_t> & internal_sizes);
+           const std::vector<size_t> & range_sizes,
+           unsigned first_range_index);
 
     Batches(Batches &&) = default;
     Batches & operator=(Batches &&) = default;
@@ -62,14 +71,17 @@ struct Batches
     };
 
     // create all the tasks
-    void build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, const std::vector<size_t> & internal_sizes);
+    void build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, const std::vector<size_t> & range_sizes);
 
-    // create tasks of a given request
-    void handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size, char * destination);
+    // create tasks of a given range; range_index is the index within the FILE, not within this transfer
+    void handle_request(std::vector<Tasks> & v_tasks, unsigned range_index, size_t request_file_offset, size_t request_size, char * destination);
 
     SubmissionId _submission_id;
 
     unsigned _file_index;
+
+    // index within the file of this transfer's first range
+    unsigned _first_range_index;
 
     unsigned _size;
 

--- a/cpp/streamer/impl/batches/batches_test.cc
+++ b/cpp/streamer/impl/batches/batches_test.cc
@@ -2,7 +2,10 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <numeric>
 #include <set>
+#include <string>
+#include <vector>
 
 #include "streamer/impl/assigner/assigner.h"
 
@@ -15,6 +18,30 @@
 namespace runai::llm::streamer::impl
 {
 
+namespace
+{
+
+// A file whose ranges tile [0, sum(sizes)) and are packed consecutively from dst. Coalesces to exactly
+// one ContiguousTransfer, which is the layout the previous single-destination API implied.
+FileRanges contiguous_file(const std::string & path, const std::vector<size_t> & sizes, char * dst)
+{
+    FileRanges file;
+    file.path = path;
+    file.ranges.reserve(sizes.size());
+
+    size_t offset = 0;
+    char * d = dst;
+    for (const auto size : sizes)
+    {
+        file.ranges.push_back(ReadRange{ offset, size, d });
+        offset += size;
+        d += size;
+    }
+    return file;
+}
+
+} // namespace
+
 TEST(Batches, Sanity)
 {
     auto num_files = utils::random::number(1, 10);
@@ -22,15 +49,14 @@ TEST(Batches, Sanity)
 
     common::s3::S3ClientWrapper::Params s3_params;
 
-    std::vector<std::string> paths;
-    std::vector<size_t> file_offsets;
-    std::vector<size_t> bytesizes;
-    std::vector<void*> dsts;
+    std::vector<FileRanges> request;
     std::vector<std::vector<unsigned>> covered(num_files);
     std::vector<size_t> total_bytes(num_files);
     std::vector<std::vector<uint8_t>> data(num_files);
     std::vector<std::vector<char>> buffers(num_files);
+    std::vector<std::vector<size_t>> chunks(num_files);
     std::vector<unsigned> num_chunks(num_files);
+    std::vector<size_t> bytesizes(num_files);
     std::vector<utils::temp::File> file;
     std::vector<std::set<int>> expected_responses(num_files);
 
@@ -48,33 +74,38 @@ TEST(Batches, Sanity)
         data[i] = utils::random::buffer(size);
         file.push_back(utils::temp::File(data[i]));
 
-        std::vector<char> dst(size);
-        buffers[i] = dst;
-
+        buffers[i].resize(size);
         total_bytes[i] = 0;
         covered[i].resize(size);
+        bytesizes[i] = size;
 
-        paths.push_back(file[i].path);
-        file_offsets.push_back(0);
-        bytesizes.push_back(size);
-        dsts.push_back(buffers[i].data());
+        // the ranges must exist before the Assigner is built - it coalesces them
+        chunks[i] = utils::random::chunks(size, num_chunks[i]);
+        EXPECT_EQ(chunks[i].size(), num_chunks[i]);
+        EXPECT_EQ(std::accumulate(chunks[i].begin(), chunks[i].end(), static_cast<size_t>(0)), size);
+
+        request.push_back(contiguous_file(file[i].path, chunks[i], buffers[i].data()));
+
+        for (unsigned j = 0; j < num_chunks[i]; ++j)
+        {
+            expected_responses[i].insert(j);
+        }
     }
     {
-        Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
+        Assigner assigner(request, config);
 
-        EXPECT_GT(assigner.file_assignments(0).size(), 0);
-        EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
+        // each file's ranges are adjacent in both file and buffer, so each file is exactly one transfer
+        ASSERT_EQ(assigner.transfers().size(), num_files);
 
-        // create internal division to divide the file into requests (each request represent a tensor)
-
-        for (unsigned file_idx = 0; file_idx < num_files; ++file_idx)
+        for (const auto & transfer : assigner.transfers())
         {
-            auto chunks = utils::random::chunks(bytesizes[file_idx], num_chunks[file_idx]);
-            EXPECT_EQ(chunks.size(), num_chunks[file_idx]);
-            auto total_chunks_size = std::accumulate(chunks.begin(), chunks.end(), 0u);
-            EXPECT_EQ(total_chunks_size, bytesizes[file_idx]);
+            const auto file_idx = transfer.file_index;
 
-            Batches batches(utils::random::number(), utils::random::number(), assigner.file_assignments(file_idx), config, responder, file[file_idx].path, s3_params, chunks);
+            EXPECT_GT(transfer.tasks.size(), 0);
+            EXPECT_LE(transfer.tasks.size(), config->concurrency);
+
+            Batches batches(utils::random::number(), file_idx, transfer.tasks, config, responder,
+                            request[file_idx].path, s3_params, transfer.range_sizes, transfer.first_range_index);
 
             // execute tasks
             for (unsigned i = 0; i < batches.size(); ++i)
@@ -91,11 +122,6 @@ TEST(Batches, Sanity)
 
                 batch.finished_until(batch.end_offset());
             }
-
-            for (unsigned i = 0; i < num_chunks[file_idx]; ++i)
-            {
-                expected_responses[file_idx].insert(i);
-            }
         }
     }
 
@@ -107,9 +133,13 @@ TEST(Batches, Sanity)
         {
             const auto r = responder->pop();
             EXPECT_EQ(r.ret, common::ResponseCode::Success);
-            EXPECT_EQ(expected_responses[file_idx].count(r.index), 1);
-            expected_responses[file_idx].erase(r.index);
+            EXPECT_EQ(expected_responses[r.file_index].count(r.index), 1);
+            expected_responses[r.file_index].erase(r.index);
         }
+    }
+
+    for (unsigned file_idx = 0; file_idx < num_files; ++file_idx)
+    {
         EXPECT_TRUE(expected_responses[file_idx].empty());
     }
 
@@ -150,23 +180,20 @@ TEST(Batches, Failed_Reader)
     {
         common::s3::S3ClientWrapper::Params s3_params;
 
-        std::vector<std::string> paths;
-        std::vector<size_t> file_offsets;
-        std::vector<size_t> bytesizes;
-        std::vector<void*> dsts;
-
         const auto file_path = utils::random::string();
-        paths.push_back(file_path);
-        file_offsets.push_back(0);
-        bytesizes.push_back(size);
-        dsts.push_back(dst.data());
 
-        Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
+        std::vector<FileRanges> request;
+        request.push_back(contiguous_file(file_path, chunks, dst.data()));
 
-        EXPECT_GT(assigner.file_assignments(0).size(), 0);
-        EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
+        Assigner assigner(request, config);
 
-        Batches batches(utils::random::number(), utils::random::number(), assigner.file_assignments(0), config, responder, file_path, s3_params, chunks);
+        ASSERT_EQ(assigner.transfers().size(), 1);
+        const auto & transfer = assigner.transfers()[0];
+        EXPECT_GT(transfer.tasks.size(), 0);
+        EXPECT_LE(transfer.tasks.size(), config->concurrency);
+
+        Batches batches(utils::random::number(), transfer.file_index, transfer.tasks, config, responder,
+                        file_path, s3_params, transfer.range_sizes, transfer.first_range_index);
     }
     catch(const common::Exception & e)
     {
@@ -224,22 +251,21 @@ TEST(Batches, Zero_Size_Request)
     {
         common::s3::S3ClientWrapper::Params s3_params;
 
-        std::vector<std::string> paths;
-        std::vector<size_t> file_offsets;
-        std::vector<size_t> bytesizes;
-        std::vector<void*> dsts;
+        std::vector<FileRanges> request;
+        request.push_back(contiguous_file(file.path, chunks, dst.data()));
 
-        paths.push_back(file.path);
-        file_offsets.push_back(0);
-        bytesizes.push_back(size);
-        dsts.push_back(dst.data());
+        Assigner assigner(request, config);
 
-        Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
+        // a zero sized range neither advances the file offset nor the destination, so it stays inside the
+        // same transfer as its neighbours - the whole file is still one contiguous read
+        ASSERT_EQ(assigner.transfers().size(), 1);
+        const auto & transfer = assigner.transfers()[0];
+        EXPECT_EQ(transfer.range_sizes.size(), num_chunks);
+        EXPECT_GT(transfer.tasks.size(), 0);
+        EXPECT_LE(transfer.tasks.size(), config->concurrency);
 
-        EXPECT_GT(assigner.file_assignments(0).size(), 0);
-        EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
-
-        Batches batches(utils::random::number(), utils::random::number(), assigner.file_assignments(0), config, responder, file.path, s3_params, chunks);
+        Batches batches(utils::random::number(), transfer.file_index, transfer.tasks, config, responder,
+                        file.path, s3_params, transfer.range_sizes, transfer.first_range_index);
 
         // execute tasks
         for (unsigned i = 0; i < batches.size(); ++i)

--- a/cpp/streamer/impl/config/config.h
+++ b/cpp/streamer/impl/config/config.h
@@ -6,12 +6,18 @@
 namespace runai::llm::streamer::impl
 {
 
+// Two environment variables configure both backends, each with its own default when unset (config.cc):
+//     RUNAI_STREAMER_CONCURRENCY     -> concurrency (file system, default 16) and s3_concurrency (object
+//                                      storage, default 8). One variable, two defaults: setting it
+//                                      overrides BOTH backends with the same value.
+//     RUNAI_STREAMER_CHUNK_BYTESIZE  -> fs_block_bytesize and s3_block_bytesize, likewise.
+
 // Reading from file system path
-//     Concurrency :       number of readers - default 20
+//     concurrency :       number of readers - default 16
 //     fs_block_bytesize : number of bytes in a single os call to read from file - minimum and default is 2 MiB
 
 // Reading from S3 path
-//     Concurrency :       number of asynchronous S3 clients - default 20
+//     s3_concurrency :    number of asynchronous S3 clients - default 8
 //     s3_block_bytesize : number of bytes in a single request to the S3 client - minimum is 5 MiB and default is 8 MiB
 
 struct Config

--- a/cpp/streamer/impl/file/file.cc
+++ b/cpp/streamer/impl/file/file.cc
@@ -43,7 +43,13 @@ void File::read(size_t bytesize, char * buffer)
     }
     catch(const std::exception& e)
     {
-        throw common::Exception(common::ResponseCode::UnknownError);
+        // FileAccessError, not UnknownError: a failed read is attributable to THIS file, and the caller
+        // may keep going with the rest. UnknownError is reserved for unrecoverable conditions (corruption,
+        // out of memory) and tells the caller to abort everything - so using it here would let one file's
+        // I/O error poison every other in-flight submission. seek() and the short-read path below already
+        // report specific codes for the same reason.
+        LOG(ERROR) << "Failed to read " << bytesize << " bytes with fd " << _fd.fd();
+        throw common::Exception(common::ResponseCode::FileAccessError);
     }
 
     if (result != bytesize)

--- a/cpp/streamer/impl/object_storage_worker/object_storage_worker.cc
+++ b/cpp/streamer/impl/object_storage_worker/object_storage_worker.cc
@@ -36,7 +36,7 @@ std::size_t ObjectStorageWorker::capacity(const Workload & first)
     // Config so the reference S3 holds stays valid after the building workload finalizes (batches dropped).
     if (_reader == nullptr)
     {
-        const auto & batch = first.batches().begin()->second;
+        const auto & batch = first.batches().front();
         _config = batch.config;
         _chunk_bytesize = std::max(static_cast<size_t>(1), _config->s3_block_bytesize);
 
@@ -103,7 +103,7 @@ void ObjectStorageWorker::enqueue(Workload && workload)
 {
     // Count chunks up front so we can reserve one contiguous block of handles and size chunk_task_idx.
     size_t total_chunks = 0;
-    for (const auto & [file_index, batch] : workload.batches())
+    for (const auto & batch : workload.batches())
     {
         for (const auto & task : batch.tasks)
         {
@@ -121,7 +121,7 @@ void ObjectStorageWorker::enqueue(Workload && workload)
         Inflight wl;
         wl.workload = std::move(workload);
         // the workload was fully populated via add_batch before dispatch, so batches() is complete here
-        for (auto & [file_index, batch] : wl.workload.batches())
+        for (auto & batch : wl.workload.batches())
         {
             for (const auto & task : batch.tasks)
             {
@@ -155,7 +155,10 @@ void ObjectStorageWorker::enqueue(Workload && workload)
         wl.chunk_task_idx.resize(total_chunks);
 
         size_t next_chunk = 0;
-        for (auto & [file_index, batch] : wl.workload.batches())
+        // &batch below outlives this loop (it is stored in wl.tasks and used to route completions): the
+        // workload has already been moved into its _inflight entry, _inflight is node-stable, and no batch is
+        // added to a dispatched workload - so the batches vector is never grown or moved again.
+        for (auto & batch : wl.workload.batches())
         {
             for (const auto & task : batch.tasks)
             {
@@ -286,14 +289,16 @@ void ObjectStorageWorker::complete_chunk(InflightMap::iterator wlit, size_t task
 
 void ObjectStorageWorker::report_workload(Inflight & wl, common::ResponseCode code)
 {
-    for (auto & [file_index, batch] : wl.workload.batches())
+    for (auto & batch : wl.workload.batches())
     {
         // whole-workload abort fails every file; otherwise fail only files with a recorded error
         // (handle_error(Success) is a no-op for files whose tasks all completed)
         auto error_code = code;
         if (error_code == common::ResponseCode::Success)
         {
-            auto it = wl.error_by_file_index.find(file_index);
+            // batch.file_index, not the batch's position: one file can contribute several batches (one per
+            // contiguous transfer), and errors are recorded per file, so several batches can share an entry
+            auto it = wl.error_by_file_index.find(batch.file_index);
             if (it != wl.error_by_file_index.end())
             {
                 error_code = it->second;

--- a/cpp/streamer/impl/object_storage_worker/object_storage_worker_test.cc
+++ b/cpp/streamer/impl/object_storage_worker/object_storage_worker_test.cc
@@ -42,6 +42,8 @@ struct Submission
         expected(num_files)
     {
         const std::string bucket = "test-bucket";
+        std::vector<std::vector<size_t>> chunks(num_files);
+
         for (unsigned i = 0; i < num_files; ++i)
         {
             const auto size = utils::random::number(1000, 100000);
@@ -51,29 +53,50 @@ struct Submission
             total_bytes += size;
 
             paths.push_back("s3://" + bucket + "/" + utils::random::string());
-            file_offsets.push_back(0);
-            bytesizes.push_back(size);
+
+            // the ranges must exist before the Assigner is built - it coalesces them
+            chunks[i] = utils::random::chunks(size, num_chunks[i]);
+            EXPECT_EQ(chunks[i].size(), num_chunks[i]);
         }
+
         buffer.resize(total_bytes);
-        dsts.push_back(buffer.data());
+
+        // each file's ranges tile it contiguously, and the files are packed consecutively into the one
+        // buffer, so every file coalesces to exactly one transfer
+        request.resize(num_files);
+        char * dst = buffer.data();
+        for (unsigned i = 0; i < num_files; ++i)
+        {
+            request[i].path = paths[i];
+            request[i].ranges.reserve(chunks[i].size());
+
+            size_t offset = 0;
+            for (const auto size : chunks[i])
+            {
+                request[i].ranges.push_back(ReadRange{ offset, size, dst });
+                offset += size;
+                dst += size;
+            }
+        }
     }
 
-    // build the workloads (one Assigner over all files, Batches per file) ready to push to the pool
+    // build the workloads (one Assigner over the request, Batches per contiguous transfer) ready to push
+    // to the pool
     std::vector<Workload> build()
     {
-        Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
+        Assigner assigner(request, config);
         std::vector<Workload> workloads(assigner.num_workloads());
 
         const common::s3::Credentials credentials;
-        for (unsigned file_idx = 0; file_idx < paths.size(); ++file_idx)
+        for (const auto & transfer : assigner.transfers())
         {
-            auto chunks = utils::random::chunks(bytesizes[file_idx], num_chunks[file_idx]);
-            EXPECT_EQ(chunks.size(), num_chunks[file_idx]);
+            const auto file_idx = transfer.file_index;
 
             auto uri = std::make_shared<common::s3::StorageUri>(paths[file_idx]);
             common::s3::S3ClientWrapper::Params params(uri, credentials, config->s3_block_bytesize);
 
-            Batches batches(submission_id, file_idx, assigner.file_assignments(file_idx), config, responder, paths[file_idx], params, chunks);
+            Batches batches(submission_id, file_idx, transfer.tasks, config, responder, paths[file_idx], params,
+                            transfer.range_sizes, transfer.first_range_index);
             for (size_t j = 0; j < batches.size(); ++j)
             {
                 workloads[batches[j].workload_index].add_batch(std::move(batches[j]));
@@ -96,9 +119,7 @@ struct Submission
     std::shared_ptr<Config> config;
     std::shared_ptr<common::Responder> responder;
     std::vector<std::string> paths;
-    std::vector<size_t> file_offsets;
-    std::vector<size_t> bytesizes;
-    std::vector<void*> dsts;
+    std::vector<FileRanges> request;
     std::vector<char> buffer;
     size_t total_bytes = 0;
     std::vector<unsigned> num_chunks;

--- a/cpp/streamer/impl/request/request.h
+++ b/cpp/streamer/impl/request/request.h
@@ -5,11 +5,32 @@
 #include <memory>
 #include <functional>
 #include <string>
+#include <vector>
 
 #include "common/response_code/response_code.h"
 
 namespace runai::llm::streamer::impl
 {
+
+// ReadRange - a single range to read, as supplied by the caller: an arbitrary (offset, size) within its
+// file, with its own destination. Ranges need not be contiguous in the file, need not be contiguous in
+// memory, and need not be ordered. This is the input description; Request below is the streamer's
+// internal per-range object built from it.
+
+struct ReadRange
+{
+    size_t offset;   // source offset within the file
+    size_t size;     // bytes to read
+    void * dst;      // destination for this range
+};
+
+// FileRanges - one file of a submission, with all the ranges requested from it
+
+struct FileRanges
+{
+    std::string path;
+    std::vector<ReadRange> ranges;
+};
 
 // Request represents a sub range in a file
 // For each request the streamer will issue a correponding response when the sub range is ready

--- a/cpp/streamer/impl/streamer/BUILD
+++ b/cpp/streamer/impl/streamer/BUILD
@@ -8,6 +8,7 @@ runai_cc_auto_library(
         "//streamer/impl/batches",
         "//streamer/impl/workload",
         "//streamer/impl/object_storage_worker",
+        "//streamer/impl/request",
         "//streamer/impl/submissions:submissions_mgr",
         "//streamer/impl/pools:backend_pools",
         "//common/responder",

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -385,14 +385,24 @@ void Streamer::verify_requests(std::vector<FileRanges> & request)
 
 common::ResponseCode Streamer::lock_object_plugin(const std::vector<FileRanges> & request)
 {
-    // Find the object-storage plugin this submission uses (filesystem paths are ignored and coexist);
-    // reject a submission that itself mixes two object-storage plugins.
+    // Classify every path, and reject a submission that mixes backends - either two object-storage
+    // plugins, or filesystem and object storage together.
+    //
+    // A STREAMER serves both kinds happily: BackendPools holds one pool per kind, created lazily, so a
+    // filesystem submission and an object-storage submission can follow each other on the same streamer.
+    // A SUBMISSION must pick one, because the Assigner divides it with a single backend's worker count
+    // and block size, and a workload must be homogeneous for BackendPools::push to route it. Without
+    // this check a mixed submission is accepted or rejected depending on where the assigner's slice
+    // happens to land - InvalidParameterError out of Workload::add_batch when both kinds share a
+    // workload, silently accepted with the wrong block size when they do not.
     std::optional<BackendPools::Plugin> submission_plugin;
+    bool has_filesystem = false;
     for (const auto & file : request)
     {
         auto uri = try_parse_uri(file.path);
         if (uri == nullptr)
         {
+            has_filesystem = true;
             continue;   // filesystem path
         }
 
@@ -411,6 +421,12 @@ common::ResponseCode Streamer::lock_object_plugin(const std::vector<FileRanges> 
     if (!submission_plugin.has_value())
     {
         return common::ResponseCode::Success;   // pure filesystem submission - nothing to lock
+    }
+
+    if (has_filesystem)
+    {
+        LOG(ERROR) << "Submission mixes filesystem and object storage paths; rejecting";
+        return common::ResponseCode::UnsupportedBackendMix;
     }
 
     // Lock the object-storage pool to this plugin (first submission) or verify it matches; the lock lives in

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -399,6 +399,16 @@ common::ResponseCode Streamer::lock_object_plugin(const std::vector<FileRanges> 
     bool has_filesystem = false;
     for (const auto & file : request)
     {
+        // A file with no ranges reaches no storage at all (verify_requests accepts it deliberately, and it
+        // yields no transfer), so it must not influence backend selection. Classifying it would let an
+        // empty "s3://..." entry permanently lock the streamer's plugin - and build the object-storage
+        // pool - for a submission that reads nothing, and would reject a filesystem submission that merely
+        // carries an empty object-storage entry alongside it.
+        if (file.ranges.empty())
+        {
+            continue;
+        }
+
         auto uri = try_parse_uri(file.path);
         if (uri == nullptr)
         {

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -298,22 +298,40 @@ common::ResponseCode Streamer::async_request(
     // If dispatch throws (e.g. bad_alloc) after increment(), drain the not-yet-dispatched
     // workloads (index >= next) as UnknownError on unwind, so every sub-range still completes and
     // the responder/registry reach zero - the consumer gets a clean failure instead of hanging.
-    // The exception then propagates and the caller maps it to UnknownError.
     size_t next = 0;
     utils::ScopeGuard drain_guard([&]() { drain_undispatched(submission_id, workloads, next); });
 
-    for (; next < workloads.size(); ++next) // ++next runs after the body, so a throwing push leaves next at it
+    try
     {
-        if (workloads[next].size() > 0)
+        for (; next < workloads.size(); ++next) // ++next runs after the body, so a throwing push leaves next at it
         {
-            LOG(DEBUG) << "Submission " << submission_id << " sending workload to worker with batches " << workloads[next].size();
+            if (workloads[next].size() > 0)
+            {
+                LOG(DEBUG) << "Submission " << submission_id << " sending workload to worker with batches " << workloads[next].size();
 
-            // route to the pool for this workload's backend kind (a workload is homogeneous)
-            const auto kind = workloads[next].is_object_storage()
-                ? BackendPools::Kind::ObjectStorage
-                : BackendPools::Kind::FileSystem;
-            _pools.push(kind, std::move(workloads[next]));
+                // route to the pool for this workload's backend kind (a workload is homogeneous)
+                const auto kind = workloads[next].is_object_storage()
+                    ? BackendPools::Kind::ObjectStorage
+                    : BackendPools::Kind::FileSystem;
+                _pools.push(kind, std::move(workloads[next]));
+            }
         }
+    }
+    catch (...)
+    {
+        // A failure HERE is past the point of no return: the submission is registered and its responses
+        // are already counted. There is no recovery - report UnknownError, whatever was thrown.
+        //
+        // UnknownError is the code that tells the caller to abort everything; every other code says the
+        // failure is attributable to this submission and the caller may carry on. Reporting a specific
+        // code from here would be a lie, because drain_undispatched (still armed - it runs as this
+        // returns) fails the undispatched ranges as UnknownError, and because the drain itself is
+        // best-effort under severe OOM, so the submission-done flag may never arrive. Normalising here
+        // rather than relying on the C layer's catch-all keeps that true whatever a future change throws:
+        // today only std::bad_alloc can escape, which the catch-all would have mapped correctly by
+        // accident, but a common::Exception would now surface its own code instead.
+        LOG(ERROR) << "Submission " << submission_id << " failed during dispatch; reporting UnknownError";
+        return common::ResponseCode::UnknownError;
     }
 
     drain_guard.cancel(); // all workloads dispatched

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <filesystem>
 #include <memory>
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <string>
@@ -189,17 +190,30 @@ common::ResponseCode Streamer::async_request(
         return ret;
     }
 
-    // One response is issued per range whatever its size - a zero-sized range is completed immediately
-    // below rather than reaching storage - so total_sizes counts every range.
-    unsigned total_sizes = 0;
+    // One response per range whatever its size, so total_ranges counts every range - a zero-sized one is
+    // completed below without reaching storage. A COUNT, unlike total_bytes beside it.
+    size_t total_ranges = 0;
     size_t total_bytes = 0;
     for (const auto & file : request)
     {
-        total_sizes += file.ranges.size();
+        total_ranges += file.ranges.size();
         for (const auto & range : file.ranges)
         {
             total_bytes += range.size;
         }
+    }
+
+    // The responder and the submission registry both carry the expected count as `unsigned`, so a total
+    // that does not fit would truncate to total_ranges % 2^32 - fewer responses expected than ranges
+    // submitted, so the submission reports done early and the caller frees buffers still being written.
+    // Rejected before an id is minted, rather than narrowed silently.
+    //
+    // Untested on purpose: unreachable below ~4.29 billion ranges in one submission.
+    if (total_ranges > std::numeric_limits<unsigned>::max())
+    {
+        LOG(ERROR) << "Submission has " << total_ranges << " ranges, which exceeds the maximum of "
+                   << std::numeric_limits<unsigned>::max();
+        return common::ResponseCode::InvalidParameterError;
     }
 
     // Mint the submission id up front so batches can be stamped with it, and hand it back to the
@@ -221,7 +235,7 @@ common::ResponseCode Streamer::async_request(
     // zero would insert an entry that consume() can never erase. Returning Success with the minted id
     // leaves nothing behind. (A submission whose ranges are all ZERO SIZED is different - it does owe
     // one response per range, and goes through the normal path below.)
-    if (total_sizes == 0)
+    if (total_ranges == 0)
     {
         LOG(DEBUG) << "Submission " << submission_id << " contains no ranges; nothing to read";
         return common::ResponseCode::Success;
@@ -286,8 +300,10 @@ common::ResponseCode Streamer::async_request(
 
     // Commit the submission: register it, grow the persistent responder's expected count, then
     // dispatch. increment() must happen before any workload runs so _running covers the responses.
-    _submissions.add(submission_id, total_sizes, total_bytes);
-    _responder->increment(total_sizes);
+    // narrowing is safe: the guard above rejected anything that does not fit
+    const auto expected_responses = static_cast<unsigned>(total_ranges);
+    _submissions.add(submission_id, expected_responses, total_bytes);
+    _responder->increment(expected_responses);
 
     // The drain guard relies on push_back's strong guarantee for the workload whose push throws,
     // which holds only because Workload's move is noexcept (so the throw is the node allocation,

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -18,6 +18,7 @@
 #include "streamer/impl/workload/workload.h"
 #include "streamer/impl/object_storage_worker/object_storage_worker.h"
 #include "streamer/impl/assigner/assigner.h"
+#include "streamer/impl/batches/batches.h"
 #include "common/exception/exception.h"
 #include "common/storage_uri/storage_uri.h"
 

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -85,24 +85,23 @@ common::ResponseCode Streamer::async_read(const std::string & path, size_t file_
 
     try
     {
-        std::vector<std::string> paths;
-        std::vector<size_t> file_offsets;
-        std::vector<size_t> bytesizes;
-        std::vector<void *> dsts;
-        std::vector<unsigned> num_sizes_v;
-        std::vector<std::vector<size_t>> internal_sizes_vv;
+        // This convenience wrapper keeps the classic contiguous semantics: the sub ranges tile
+        // [file_offset, file_offset + bytesize) in order, and are written consecutively from dst.
+        // The general API can express any layout; here the offsets and destinations are accumulated.
+        std::vector<FileRanges> request(1);
+        request[0].path = path;
+        request[0].ranges.reserve(num_sizes);
 
-        paths.push_back(path);
-        file_offsets.push_back(file_offset);
-        bytesizes.push_back(bytesize);
-        dsts.push_back(dst);
-        num_sizes_v.push_back(num_sizes);
+        size_t offset = file_offset;
+        char * destination = static_cast<char *>(dst);
+        for (unsigned i = 0; i < num_sizes; ++i)
+        {
+            request[0].ranges.push_back(ReadRange{ offset, internal_sizes[i], destination });
+            offset += internal_sizes[i];
+            destination += internal_sizes[i];
+        }
 
-        std::vector<size_t> internal_sizes_v(internal_sizes, internal_sizes + num_sizes);
-
-        internal_sizes_vv.push_back(internal_sizes_v);
-
-        ret = async_request(paths, file_offsets, bytesizes, dsts, num_sizes_v, internal_sizes_vv);
+        ret = async_request(request);
     }
     catch(const common::Exception & e)
     {
@@ -168,12 +167,7 @@ common::Response Streamer::response(unsigned timeout_ms, bool & submission_done)
 }
 
 common::ResponseCode Streamer::async_request(
-    std::vector<std::string> & paths,
-    std::vector<size_t> & file_offsets,
-    std::vector<size_t> & bytesizes,
-    std::vector<void *> & dsts,
-    std::vector<unsigned> & num_sizes,
-    std::vector<std::vector<size_t>> & internal_sizes,
+    std::vector<FileRanges> & request,
     SubmissionId * out_submission_id)
 {
     // Default the caller's id to 0 ("none"). It is overwritten with the real id the instant one is
@@ -184,18 +178,28 @@ common::ResponseCode Streamer::async_request(
     }
 
     // verify input
-    verify_requests(paths, file_offsets, bytesizes, num_sizes, dsts);
+    verify_requests(request);
 
     // A streamer serves a single object-storage plugin; reject a submission that mixes object-storage plugins
     // or differs from the locked plugin. Nothing is committed yet, so returning is clean. Credentials are
     // streamer-scoped and read only at client creation (in the worker), so they are not touched here.
-    if (const auto ret = lock_object_plugin(paths); ret != common::ResponseCode::Success)
+    if (const auto ret = lock_object_plugin(request); ret != common::ResponseCode::Success)
     {
         return ret;
     }
 
-    const auto total_sizes = std::accumulate(num_sizes.begin(), num_sizes.end(), 0u);
-    const size_t total_bytes = std::accumulate(bytesizes.begin(), bytesizes.end(), static_cast<size_t>(0));
+    // One response is issued per range whatever its size - a zero-sized range is completed immediately
+    // below rather than reaching storage - so total_sizes counts every range.
+    unsigned total_sizes = 0;
+    size_t total_bytes = 0;
+    for (const auto & file : request)
+    {
+        total_sizes += file.ranges.size();
+        for (const auto & range : file.ranges)
+        {
+            total_bytes += range.size;
+        }
+    }
 
     // Mint the submission id up front so batches can be stamped with it, and hand it back to the
     // caller immediately: the id is always reported once it exists, regardless of how the call
@@ -211,20 +215,51 @@ common::ResponseCode Streamer::async_request(
         *out_submission_id = submission_id;
     }
 
+    // A submission with no ranges at all owes no responses, so it is deliberately NOT registered:
+    // completion is driven by consuming responses, and _submissions.add() with an expected count of
+    // zero would insert an entry that consume() can never erase. Returning Success with the minted id
+    // leaves nothing behind. (A submission whose ranges are all ZERO SIZED is different - it does owe
+    // one response per range, and goes through the normal path below.)
+    if (total_sizes == 0)
+    {
+        LOG(DEBUG) << "Submission " << submission_id << " contains no ranges; nothing to read";
+        return common::ResponseCode::Success;
+    }
+
     // divide reading between workers
-    Assigner assigner(paths, file_offsets, bytesizes, dsts, _config);
+    Assigner assigner(request, _config);
 
     std::vector<Workload> workloads(assigner.num_workloads());
 
-    // Create batches for each file
+    // Create batches for each contiguous transfer. Batches is built per transfer rather than per file:
+    // within a transfer the ranges tile one contiguous span of both file and destination, which is the
+    // assumption Batch is built on. A file whose ranges are not all adjacent yields several transfers.
 
-    for (size_t i = 0; i < paths.size(); ++i)
+    unsigned params_file_index = 0;
+    bool has_params = false;
+    common::s3::S3ClientWrapper::Params params;
+
+    for (const auto & transfer : assigner.transfers())
     {
-        auto params = handle_s3(i, paths[i]);
-        LOG(DEBUG) << "Submission " << submission_id << " creating batches for file index " << i << " path: " <<  paths[i];
-        Batches batches(submission_id, i, assigner.file_assignments(i), _config, _responder, paths[i], params, internal_sizes[i]);
+        const auto & path = request[transfer.file_index].path;
+
+        // Transfers are produced grouped by file, so the params are rebuilt only when the file changes;
+        // handle_s3 parses the URI, which would otherwise be repeated for every transfer of a file.
+        if (!has_params || transfer.file_index != params_file_index)
+        {
+            params = handle_s3(transfer.file_index, path);
+            params_file_index = transfer.file_index;
+            has_params = true;
+        }
+
+        LOG(DEBUG) << "Submission " << submission_id << " creating batches for file index " << transfer.file_index
+                   << " path: " << path << " offset " << transfer.offset << " size " << transfer.size
+                   << " ranges " << transfer.range_sizes.size() << " from index " << transfer.first_range_index;
+
+        Batches batches(submission_id, transfer.file_index, transfer.tasks, _config, _responder, path, params,
+                        transfer.range_sizes, transfer.first_range_index);
         const auto num_batches = batches.size();
-        LOG(DEBUG) << "Created " << num_batches << " batches for file index " << i;
+        LOG(DEBUG) << "Created " << num_batches << " batches for file index " << transfer.file_index;
         for (size_t j = 0; j < num_batches; ++j)
         {
             auto & batch = batches[j];
@@ -318,44 +353,43 @@ bool Streamer::consume_submission_response(SubmissionId submission_id)
     return false;
 }
 
-void Streamer::verify_requests(std::vector<std::string> & paths, std::vector<size_t> & file_offsets, std::vector<size_t> & bytesizes, std::vector<unsigned> & num_sizes, std::vector<void *> & dsts)
+// Every destination is now caller-supplied and really dereferenced, so unlike the previous API - where only
+// dsts[0] was ever used, and so only it could be checked - every range's destination is validated here.
+//
+// Deliberately NOT rejected:
+//   - a file with no ranges: it contributes no responses and never reaches storage
+//   - a range of size zero: it is completed as Success immediately (see async_request), so the caller
+//     still receives exactly one response per range
+//
+// Overlapping destinations are NOT verified: laying out the destination buffer is the caller's
+// responsibility. Such a check is possible here if it is ever wanted - sort the ranges by destination and
+// compare each against its neighbour, O(n log n) per submission.
+void Streamer::verify_requests(std::vector<FileRanges> & request)
 {
-    // Only dsts[0] is checked because only dsts[0] is ever used: for CPU reads the destination is a single
-    // contiguous buffer whose base is dsts[0], and every file/sub-range is written at an offset into it (see
-    // Assigner: "ASSUMES dsts[0] is base of one large buffer"). dsts[1..] are never dereferenced - callers
-    // may even pass a single-element dsts for a multi-file request - so there is no per-file null to check.
-    if (dsts[0] == 0)
+    for (const auto & file : request)
     {
-        LOG(ERROR) << "Destination buffer is null";
-        throw common::Exception(common::ResponseCode::InvalidParameterError);
-    }
+        LOG(SPAM) << "Requested to read asynchronously " << file.ranges.size() << " ranges from " << file.path;
 
-    for (size_t i = 0; i < paths.size(); ++i)
-    {
-        LOG(SPAM) << "Requested to read asynchronously " << bytesizes[i] << " bytes from " << paths[i] << " offset " << file_offsets[i] << " in " << num_sizes[i] << " chunks";
-
-        if (bytesizes[i] == 0 && num_sizes[i] == 0)
+        for (const auto & range : file.ranges)
         {
-            LOG(ERROR) << "Empty request - no response will be sent";
-            throw common::Exception(common::ResponseCode::EmptyRequestError);
-        }
-
-        if (num_sizes[i] == 0 || bytesizes[i] == 0)
-        {
-            LOG(ERROR) << "Total bytes to read is " << bytesizes[i] << " but number of sub requests is " << num_sizes[i];
-            throw common::Exception(common::ResponseCode::InvalidParameterError);
+            // a zero-sized range writes nothing, so a null destination is harmless there
+            if (range.size > 0 && range.dst == nullptr)
+            {
+                LOG(ERROR) << "Destination buffer is null for " << file.path << " offset " << range.offset;
+                throw common::Exception(common::ResponseCode::InvalidParameterError);
+            }
         }
     }
 }
 
-common::ResponseCode Streamer::lock_object_plugin(const std::vector<std::string> & paths)
+common::ResponseCode Streamer::lock_object_plugin(const std::vector<FileRanges> & request)
 {
     // Find the object-storage plugin this submission uses (filesystem paths are ignored and coexist);
     // reject a submission that itself mixes two object-storage plugins.
     std::optional<BackendPools::Plugin> submission_plugin;
-    for (const auto & path : paths)
+    for (const auto & file : request)
     {
-        auto uri = try_parse_uri(path);
+        auto uri = try_parse_uri(file.path);
         if (uri == nullptr)
         {
             continue;   // filesystem path

--- a/cpp/streamer/impl/streamer/streamer.h
+++ b/cpp/streamer/impl/streamer/streamer.h
@@ -90,10 +90,12 @@ struct Streamer
     // Try to parse path as an object storage URI; returns nullptr for a filesystem path
     std::shared_ptr<common::s3::StorageUri> try_parse_uri(const std::string & path);
 
-    // Reject a submission that mixes object-storage plugins, and lock the streamer to a single
-    // object-storage plugin (first object-storage submission wins). Filesystem paths are ignored and coexist
-    // with the lock. Returns UnsupportedBackendMix on a mixed submission or a plugin differing from the lock,
-    // else Success.
+    // Reject a submission that mixes backends, and lock the streamer to a single object-storage plugin
+    // (first object-storage submission wins). A submission must be either wholly filesystem or wholly one
+    // object-storage plugin; the STREAMER may serve both kinds across different submissions (BackendPools
+    // keeps one pool per kind). Returns UnsupportedBackendMix when a submission mixes filesystem with
+    // object storage, mixes two object-storage plugins, or uses a plugin differing from the lock; else
+    // Success.
     common::ResponseCode lock_object_plugin(const std::vector<FileRanges> & request);
     // Build the object-storage params for a batch. Credentials are NOT included here (they are read only at
     // client creation, from credentials()); the batch params carry the URI, which is all the per-read path uses.

--- a/cpp/streamer/impl/streamer/streamer.h
+++ b/cpp/streamer/impl/streamer/streamer.h
@@ -17,6 +17,7 @@
 #include "streamer/impl/workload/workload.h"
 #include "streamer/impl/s3/s3.h"
 #include "streamer/impl/batches/batches.h"
+#include "streamer/impl/request/request.h"
 #include "streamer/impl/submissions/submissions_mgr.h"
 #include "streamer/impl/pools/backend_pools.h"
 
@@ -48,13 +49,13 @@ struct Streamer
     // per request - async_request/list_files use whatever was set here.
     common::ResponseCode set_credentials(const common::s3::Credentials & credentials);
 
+    // Submit a read request: a list of files, each with the ranges to read from it. A range is an
+    // arbitrary (offset, size) within its file with its own destination - ranges need not be contiguous
+    // in the file, contiguous in memory, or ordered.
+    // Exactly one response is issued per range, including for a zero-sized range (which is completed
+    // immediately without reaching storage). A file with no ranges contributes no responses.
     common::ResponseCode async_request(
-      std::vector<std::string> & paths,
-      std::vector<size_t> & file_offsets,
-      std::vector<size_t> & bytesizes,
-      std::vector<void *> & dsts,
-      std::vector<unsigned> & num_sizes,
-      std::vector<std::vector<size_t>> & internal_sizes,
+      std::vector<FileRanges> & request,
       SubmissionId * out_submission_id = nullptr);
 
     // Consume the next ready sub-range response over the persistent responder. Blocks up to timeout_ms
@@ -93,7 +94,7 @@ struct Streamer
     // object-storage plugin (first object-storage submission wins). Filesystem paths are ignored and coexist
     // with the lock. Returns UnsupportedBackendMix on a mixed submission or a plugin differing from the lock,
     // else Success.
-    common::ResponseCode lock_object_plugin(const std::vector<std::string> & paths);
+    common::ResponseCode lock_object_plugin(const std::vector<FileRanges> & request);
     // Build the object-storage params for a batch. Credentials are NOT included here (they are read only at
     // client creation, from credentials()); the batch params carry the URI, which is all the per-read path uses.
     common::s3::S3ClientWrapper::Params handle_s3(unsigned file_index, const std::string & path);
@@ -102,7 +103,7 @@ struct Streamer
     // its own mutex). Called only at client-creation points (the worker's first client build, and list_files)
     // - never on the per-request path.
     common::s3::Credentials credentials() const;
-    void verify_requests(std::vector<std::string> & paths, std::vector<size_t> & file_offsets, std::vector<size_t> & bytesizes, std::vector<unsigned> & num_sizes, std::vector<void *> & dsts);
+    void verify_requests(std::vector<FileRanges> & request);
 
     // Account for one consumed response of submission_id (delegates to _submissions): on the
     // submission's last response, log per-submission throughput. Returns true iff it was the

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -555,6 +555,44 @@ TEST(AsyncRequest, MixedObjectPluginsRejected)
     EXPECT_EQ(streamer.async_request(request), common::ResponseCode::UnsupportedBackendMix);
 }
 
+// A submission must pick ONE backend kind. The streamer serves both across submissions (see
+// FilesystemAndObjectStorageSubmissionsCoexist), but within a submission the Assigner divides the work
+// with a single backend's worker count and block size, and a workload has to be homogeneous to be routed.
+// Rejecting up front replaces a slice-dependent outcome: without the check, this is InvalidParameterError
+// when both kinds land in one workload and silently accepted with the wrong block size when they do not.
+TEST(AsyncRequest, MixedFilesystemAndObjectStorageRejected)
+{
+    const auto size = utils::random::number(100, 1000);
+    const auto chunk_size = utils::random::number<size_t>(1, 1024);
+    const auto bulk_size = utils::random::number<size_t>(1, chunk_size);
+    Config config(utils::random::number(1, 20), utils::random::number(1, 20), chunk_size, bulk_size, false /* do not enforce minimum */);
+
+    Streamer streamer(config);
+
+    const auto data = utils::random::buffer(size);
+    utils::temp::File file(data);
+
+    std::vector<unsigned char> dst0(size);
+    std::vector<unsigned char> dst1(size);
+
+    // both orders: the check must not depend on which kind is seen first (a first-file test would pass
+    // one of these by accident)
+    {
+        std::vector<FileRanges> request;
+        request.push_back(FileRanges{ file.path, { ReadRange{ 0, static_cast<size_t>(size), dst0.data() } } });
+        request.push_back(FileRanges{ "s3://bucket/a.txt", { ReadRange{ 0, static_cast<size_t>(size), dst1.data() } } });
+
+        EXPECT_EQ(streamer.async_request(request), common::ResponseCode::UnsupportedBackendMix);
+    }
+    {
+        std::vector<FileRanges> request;
+        request.push_back(FileRanges{ "s3://bucket/a.txt", { ReadRange{ 0, static_cast<size_t>(size), dst0.data() } } });
+        request.push_back(FileRanges{ file.path, { ReadRange{ 0, static_cast<size_t>(size), dst1.data() } } });
+
+        EXPECT_EQ(streamer.async_request(request), common::ResponseCode::UnsupportedBackendMix);
+    }
+}
+
 namespace
 {
 

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -667,4 +667,78 @@ TEST(ListFiles, FilesystemEmptyDirectory)
     EXPECT_TRUE(entries.empty());
 }
 
+TEST(Async, Scattered_Ranges_And_Destinations)
+{
+    // The point of the range API: ranges need not be contiguous in the file, need not be ordered, and
+    // need not be written to adjacent memory. Every other data test here goes through async_read, which
+    // tiles one span of the file into one buffer - so none of them would notice if offsets or
+    // destinations were silently paired by position instead of being honoured per range.
+    const size_t size = 1000;
+    const auto data = utils::random::buffer(size);
+    utils::temp::File file(data);
+    const auto expected = utils::Fd::read(file.path);
+    ASSERT_EQ(expected.size(), size);
+
+    const auto chunk_size = utils::random::number<size_t>(1, 1024);
+    Config config(utils::random::number(1, 20), utils::random::number(1, 20), chunk_size,
+                  utils::random::number<size_t>(1, chunk_size), false /* do not enforce minimum */);
+    Streamer streamer(config);
+
+    // deliberately: descending file order, gaps between ranges, a zero-sized range, and two ranges
+    // reading the SAME source bytes (source overlap is legal - only destinations must not overlap)
+    const std::vector<std::pair<size_t, size_t>> ranges =
+    {
+        { 700, 120 },
+        {  50, 200 },
+        { 400,   0 },
+        { 700, 120 },
+        { 900, 100 },
+    };
+
+    // each destination is its OWN allocation, not an offset into a shared buffer: this is what proves a
+    // destination need not belong to any single buffer. The extra byte is a guard against an over-long write.
+    std::vector<std::vector<unsigned char>> dsts;
+    for (const auto & range : ranges)
+    {
+        dsts.emplace_back(range.second + 1, 0xAB);
+    }
+
+    FileRanges file_ranges;
+    file_ranges.path = file.path;
+    for (size_t i = 0; i < ranges.size(); ++i)
+    {
+        file_ranges.ranges.push_back(ReadRange{ ranges[i].first, ranges[i].second, dsts[i].data() });
+    }
+
+    std::vector<FileRanges> request{ file_ranges };
+    SubmissionId submission_id = 0;
+    EXPECT_EQ(streamer.async_request(request, &submission_id), common::ResponseCode::Success);
+
+    std::set<unsigned> received;
+    for (size_t i = 0; i < ranges.size(); ++i)
+    {
+        const auto r = recv(streamer);
+        EXPECT_EQ(r.response.ret, common::ResponseCode::Success);
+        EXPECT_EQ(r.response.file_index, 0u);
+        received.insert(r.response.index);
+        EXPECT_EQ(r.submission_done, i + 1 == ranges.size());
+    }
+
+    // exactly one response per range, indexed within the file - a dropped or duplicated zero-sized
+    // range would shift every later index
+    EXPECT_EQ(received.size(), ranges.size());
+
+    for (size_t i = 0; i < ranges.size(); ++i)
+    {
+        const auto offset = ranges[i].first;
+        const auto length = ranges[i].second;
+        for (size_t j = 0; j < length; ++j)
+        {
+            ASSERT_EQ(dsts[i][j], expected[offset + j])
+                << "range " << i << " (offset " << offset << " size " << length << ") differs at byte " << j;
+        }
+        EXPECT_EQ(dsts[i][length], 0xAB) << "range " << i << " wrote past the end of its destination";
+    }
+}
+
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -67,6 +67,40 @@ TEST(Creation, Sanity)
     EXPECT_FALSE(submission_done);
 }
 
+// A read failure is attributable to its file, so it must NOT be reported as UnknownError. UnknownError is
+// reserved for unrecoverable conditions (corruption, out of memory) and tells the caller to abort
+// everything - reporting it for one file's I/O error would poison every other in-flight submission.
+//
+// A directory is the cheapest real read failure available: open(O_RDONLY) succeeds on it, and the read
+// then fails with EISDIR - no fault injection needed.
+TEST(Async, ReadFailureIsAttributableNotUnknown)
+{
+    utils::temp::Dir dir;
+
+    const auto chunk_size = utils::random::number<size_t>(1, 1024);
+    const auto bulk_size = utils::random::number<size_t>(1, chunk_size);
+    Config config(utils::random::number(1, 20), utils::random::number(1, 20), chunk_size, bulk_size, false /* do not enforce minimum */);
+
+    Streamer streamer(config);
+
+    const size_t size = 128;
+    std::vector<unsigned char> dst(size);
+
+    std::vector<FileRanges> request;
+    request.push_back(FileRanges{ dir.path, { ReadRange{ 0, size, dst.data() } } });
+
+    EXPECT_EQ(streamer.async_request(request), common::ResponseCode::Success);
+
+    bool done = false;
+    const auto response = streamer.response(60000, done);
+
+    EXPECT_NE(response.ret, common::ResponseCode::Success);
+    EXPECT_NE(response.ret, common::ResponseCode::UnknownError)
+        << "a per-file read failure must not tell the caller to abort everything";
+    // the submission still completes - the caller's buffer is released only on this flag
+    EXPECT_TRUE(done);
+}
+
 TEST(Async, ResponseBlocksUntilResponseArrives)
 {
     // response(0) on a streamer with no ready response BLOCKS until one arrives (persistent responder, no

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -593,6 +593,54 @@ TEST(AsyncRequest, MixedFilesystemAndObjectStorageRejected)
     }
 }
 
+// A file with no ranges reaches no storage (verify_requests accepts it deliberately, and it yields no
+// transfer), so it must take no part in backend selection.
+TEST(AsyncRequest, FilesWithoutRangesDoNotSelectTheBackend)
+{
+    const auto size = utils::random::number(100, 1000);
+    const auto chunk_size = utils::random::number<size_t>(1, 1024);
+    const auto bulk_size = utils::random::number<size_t>(1, chunk_size);
+    Config config(utils::random::number(1, 20), utils::random::number(1, 20), chunk_size, bulk_size, false /* do not enforce minimum */);
+
+    const auto data = utils::random::buffer(size);
+    utils::temp::File file(data);
+
+    {
+        // An empty object-storage entry must not lock the streamer's plugin: that submission reads
+        // nothing, so a later submission using a DIFFERENT plugin is still legitimate. Both submissions
+        // here are empty, so neither reaches a pool or loads a plugin - the lock alone is under test.
+        Streamer streamer(config);
+
+        std::vector<FileRanges> s3_only;
+        s3_only.push_back(FileRanges{ "s3://bucket/empty.txt", {} });
+        EXPECT_EQ(streamer.async_request(s3_only), common::ResponseCode::Success);
+
+        std::vector<FileRanges> gcs_only;
+        gcs_only.push_back(FileRanges{ "gs://bucket/empty.txt", {} });
+        EXPECT_EQ(streamer.async_request(gcs_only), common::ResponseCode::Success);
+    }
+
+    {
+        // A filesystem submission carrying an empty object-storage entry is NOT a mixed submission: the
+        // empty entry contributes no batch, so every workload is still filesystem. It must also not
+        // select the object-storage worker count and block size for the assignment.
+        Streamer streamer(config);
+
+        std::vector<unsigned char> dst(size);
+        std::vector<FileRanges> request;
+        request.push_back(FileRanges{ "s3://bucket/empty.txt", {} });
+        request.push_back(FileRanges{ file.path, { ReadRange{ 0, static_cast<size_t>(size), dst.data() } } });
+
+        EXPECT_EQ(streamer.async_request(request), common::ResponseCode::Success);
+
+        // drain the single range and check it really read the filesystem file
+        bool done = false;
+        const auto response = streamer.response(60000, done);
+        EXPECT_EQ(response.ret, common::ResponseCode::Success);
+        EXPECT_EQ(dst, std::vector<unsigned char>(data.begin(), data.end()));
+    }
+}
+
 namespace
 {
 

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -41,6 +41,19 @@ Received recv(Streamer & streamer)
     return Received{ response, submission_done };
 }
 
+// The range indices a submission of n ranges owes: exactly {0, 1, ... n-1}. Compared as a SET, because a
+// count (received.size() == n) also passes when a range is answered twice and another dropped, or when an
+// index is out of range entirely.
+std::set<unsigned> range_indices(unsigned n)
+{
+    std::set<unsigned> indices;
+    for (unsigned i = 0; i < n; ++i)
+    {
+        indices.insert(i);
+    }
+    return indices;
+}
+
 // short wait used to assert a fresh/empty responder delivers nothing (it times out rather than blocking)
 constexpr unsigned EMPTY_WAIT_MS = 50;
 
@@ -492,7 +505,7 @@ TEST(Async, Zero_Sized_Ranges)
         EXPECT_EQ(done, i + 1 == num_ranges);   // completion lands on the last range
     }
 
-    EXPECT_EQ(received.size(), num_ranges);
+    EXPECT_EQ(received, range_indices(num_ranges));
 }
 
 TEST(Async, ConcurrentRequests)
@@ -806,7 +819,7 @@ TEST(Async, Scattered_Ranges_And_Destinations)
 
     // deliberately: descending file order, gaps between ranges, a zero-sized range, and two ranges
     // reading the SAME source bytes (source overlap is legal - only destinations must not overlap)
-    const std::vector<std::pair<size_t, size_t>> ranges =
+    std::vector<std::pair<size_t, size_t>> ranges =
     {
         { 700, 120 },
         {  50, 200 },
@@ -814,6 +827,15 @@ TEST(Async, Scattered_Ranges_And_Destinations)
         { 700, 120 },
         { 900, 100 },
     };
+
+    // Then a random number of random ranges on top: the five above are the shapes worth naming, but their
+    // count is arbitrary, and a fixed count is one a position bug can fit by accident.
+    const unsigned extra = utils::random::number(0, 15);
+    for (unsigned i = 0; i < extra; ++i)
+    {
+        const size_t offset = utils::random::number<size_t>(0, size - 1);
+        ranges.emplace_back(offset, utils::random::number<size_t>(0, size - offset));
+    }
 
     // each destination is its OWN allocation, not an offset into a shared buffer: this is what proves a
     // destination need not belong to any single buffer. The extra byte is a guard against an over-long write.
@@ -846,7 +868,7 @@ TEST(Async, Scattered_Ranges_And_Destinations)
 
     // exactly one response per range, indexed within the file - a dropped or duplicated zero-sized
     // range would shift every later index
-    EXPECT_EQ(received.size(), ranges.size());
+    EXPECT_EQ(received, range_indices(ranges.size()));
 
     for (size_t i = 0; i < ranges.size(); ++i)
     {

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -376,7 +376,7 @@ TEST(Async, End_Of_File_Error)
     EXPECT_EQ(done_count, 1u);   // submission completes once its last sub-range lands
 }
 
-TEST(Async, Zero_Requests_Error)
+TEST(Async, Zero_Requests)
 {
     auto size = utils::random::number(100, 1000);
 
@@ -394,12 +394,14 @@ TEST(Async, Zero_Requests_Error)
     Streamer streamer(config);
 
     std::vector<char> dst(size);
-    // sending zero instead of num_chunks
-    EXPECT_EQ(streamer.async_read(utils::random::string(), 0, size, dst.data(), 0, chunks.data()), common::ResponseCode::InvalidParameterError);
-    // the failed request created no submission, so there is nothing to receive
+
+    // A submission with no ranges is accepted, not rejected: it simply reads nothing. Empties are
+    // absorbed rather than refused, so there is no InvalidParameterError / EmptyRequestError here any
+    // more. It is not registered either, so it owes no responses and there is nothing to receive.
+    EXPECT_EQ(streamer.async_read(utils::random::string(), 0, size, dst.data(), 0, chunks.data()), common::ResponseCode::Success);
 }
 
-TEST(Async, Zero_Bytes_To_Read_Error)
+TEST(Async, Zero_Bytes_To_Read)
 {
     auto size = utils::random::number(100, 1000);
 
@@ -417,22 +419,46 @@ TEST(Async, Zero_Bytes_To_Read_Error)
     Streamer streamer(config);
 
     std::vector<char> dst(size);
-    // sending zero instead of num_chunks
 
-    for (unsigned num_chunks_ : {0U, num_chunks})
+    // Zero ranges is legal and reads nothing. (The path is random and does not exist, which does not
+    // matter: with no ranges nothing ever reaches storage.)
+    EXPECT_EQ(streamer.async_read(utils::random::string(), 0, 0, dst.data(), 0, chunks.data()), common::ResponseCode::Success);
+}
+
+// Replaces the second branch of the old Zero_Bytes_To_Read_Error, which asserted that a zero total with
+// non-zero sub ranges was rejected. That contradiction is unrepresentable now - the ranges define the
+// span, there is no separate total to disagree with - so this asserts what the new contract says
+// instead: zero sized ranges are accepted AND answered, one response each.
+TEST(Async, Zero_Sized_Ranges)
+{
+    const unsigned num_ranges = utils::random::number(1, 20);
+    std::vector<size_t> zero_chunks(num_ranges, 0);
+
+    const auto chunk_size = utils::random::number<size_t>(1, 1024);
+    const auto bulk_size = utils::random::number<size_t>(1, chunk_size);
+    Config config(utils::random::number(1, 20), utils::random::number(1, 20), chunk_size, bulk_size, false /* do not enforce minimum */);
+
+    Streamer streamer(config);
+
+    // a real file: a zero sized transfer still opens its file, it just reads nothing from it
+    const auto data = utils::random::buffer(utils::random::number(1, 100));
+    utils::temp::File file(data);
+
+    std::vector<char> dst(1);
+    EXPECT_EQ(streamer.async_read(file.path, 0, 0, dst.data(), num_ranges, zero_chunks.data()),
+              common::ResponseCode::Success);
+
+    std::set<unsigned> received;
+    for (unsigned i = 0; i < num_ranges; ++i)
     {
-        auto result = streamer.async_read(utils::random::string(), 0, 0, dst.data(), num_chunks_, chunks.data());
-        if (num_chunks_ > 0)
-        {
-            EXPECT_EQ(result, common::ResponseCode::InvalidParameterError);
-        }
-        else
-        {
-            EXPECT_EQ(result, common::ResponseCode::EmptyRequestError);
-        }
-
-        // the failed request created no submission, so there is nothing to receive
+        bool done = false;
+        const auto r = streamer.response(60000, done);
+        EXPECT_EQ(r.ret, common::ResponseCode::Success);
+        received.insert(r.index);
+        EXPECT_EQ(done, i + 1 == num_ranges);   // completion lands on the last range
     }
+
+    EXPECT_EQ(received.size(), num_ranges);
 }
 
 TEST(Async, ConcurrentRequests)
@@ -485,32 +511,27 @@ TEST(Async, ConcurrentRequests)
     }
 }
 
+// Previously this asserted the Assigner's "Input vector sizes mismatch" throw - it passed two paths but
+// one entry in every other vector. Mismatched lengths are unrepresentable now (a request is a list of
+// FileRanges), so it asserts the surviving property of a submission whose paths disagree: mixing two
+// object-storage plugins is rejected up front. A different pair than MixedObjectPluginsRejected below.
 TEST(AsyncRequest, InvalidScheme)
 {
-    auto size = utils::random::number(100, 1000);
-    const auto data = utils::random::buffer(size);
-    std::string s3_path = "s3://s3-bucket/file-01.txt";
-    std::string gcs_path = "gs://gcs-bucket/file-02.txt";
-
+    const auto size = utils::random::number(100, 1000);
     const auto chunk_size = utils::random::number<size_t>(1, 1024);
     const auto bulk_size = utils::random::number<size_t>(1, chunk_size);
     Config config(utils::random::number(1, 20), utils::random::number(1, 20), chunk_size, bulk_size, false /* do not enforce minimum */);
 
-
     Streamer streamer(config);
 
-    std::vector<unsigned char> dst(size);
-    std::vector<size_t> sizes;
-    sizes.push_back(size);
+    std::vector<unsigned char> dst0(size);
+    std::vector<unsigned char> dst1(size);
 
-    std::vector<std::string> paths = {s3_path, gcs_path};
-    std::vector<size_t> file_offsets = {0};
-    std::vector<size_t> bytesizes = {size};
-    std::vector<void *> dsts = {dst.data()};
-    std::vector<unsigned> num_sizes = {1};
-    std::vector<std::vector<size_t>> internal_sizes =  { sizes };
+    std::vector<FileRanges> request;
+    request.push_back(FileRanges{ "s3://s3-bucket/file-01.txt", { ReadRange{ 0, static_cast<size_t>(size), dst0.data() } } });
+    request.push_back(FileRanges{ "az://az-account/file-02.txt", { ReadRange{ 0, static_cast<size_t>(size), dst1.data() } } });
 
-    EXPECT_THROW(streamer.async_request(paths, file_offsets, bytesizes, dsts, num_sizes, internal_sizes), runai::llm::streamer::common::Exception);
+    EXPECT_EQ(streamer.async_request(request), common::ResponseCode::UnsupportedBackendMix);
 }
 
 TEST(AsyncRequest, MixedObjectPluginsRejected)
@@ -527,15 +548,11 @@ TEST(AsyncRequest, MixedObjectPluginsRejected)
 
     // a single submission that mixes two object-storage plugins (s3 + gcs) is rejected up front,
     // before any dispatch or plugin load
-    std::vector<std::string> paths = {"s3://bucket/a.txt", "gs://bucket/b.txt"};
-    std::vector<size_t> file_offsets = {0, 0};
-    std::vector<size_t> bytesizes = {size, size};
-    std::vector<void *> dsts = {dst0.data(), dst1.data()};
-    std::vector<unsigned> num_sizes = {1, 1};
-    std::vector<std::vector<size_t>> internal_sizes = { {static_cast<size_t>(size)}, {static_cast<size_t>(size)} };
+    std::vector<FileRanges> request;
+    request.push_back(FileRanges{ "s3://bucket/a.txt", { ReadRange{ 0, static_cast<size_t>(size), dst0.data() } } });
+    request.push_back(FileRanges{ "gs://bucket/b.txt", { ReadRange{ 0, static_cast<size_t>(size), dst1.data() } } });
 
-    EXPECT_EQ(streamer.async_request(paths, file_offsets, bytesizes, dsts, num_sizes, internal_sizes),
-              common::ResponseCode::UnsupportedBackendMix);
+    EXPECT_EQ(streamer.async_request(request), common::ResponseCode::UnsupportedBackendMix);
 }
 
 namespace

--- a/cpp/streamer/impl/workload/workload.cc
+++ b/cpp/streamer/impl/workload/workload.cc
@@ -12,24 +12,23 @@ namespace runai::llm::streamer::impl
 
 size_t Workload::size() const
 {
-    return _batches_by_file_index.size();
+    return _batches.size();
 }
 
-std::map<unsigned, Batch> & Workload::batches()
+std::vector<Batch> & Workload::batches()
 {
-    return _batches_by_file_index;
+    return _batches;
 }
 
-const std::map<unsigned, Batch> & Workload::batches() const
+const std::vector<Batch> & Workload::batches() const
 {
-    return _batches_by_file_index;
+    return _batches;
 }
 
 common::ResponseCode Workload::add_batch(Batch && batch)
 {
-    const auto file_index = batch.file_index;
-    ASSERT(_batches_by_file_index.find(file_index) == _batches_by_file_index.end()) << "Batch for file index " << file_index << " already exists";
-
+    // Appended, not keyed by batch.file_index: one file can contribute several batches to the same workload
+    // (one per ContiguousTransfer) as soon as its ranges are not all contiguous.
     if (size() == 0)
     {
         _is_object_storage = batch.is_object_storage();
@@ -39,7 +38,7 @@ common::ResponseCode Workload::add_batch(Batch && batch)
         return res;
     }
 
-    _batches_by_file_index.emplace(file_index, std::move(batch));
+    _batches.push_back(std::move(batch));
 
     return common::ResponseCode::Success;
 }
@@ -51,7 +50,7 @@ bool Workload::is_object_storage() const
 
 void Workload::fail(common::ResponseCode code)
 {
-    for (auto & [file_index, batch] : _batches_by_file_index)
+    for (auto & batch : _batches)
     {
         batch.handle_error(code);
     }
@@ -79,7 +78,7 @@ void Workload::execute(std::atomic<bool> & stopped)
     // Object-storage workloads are read asynchronously by the ObjectStorageWorker pool, not here.
     ASSERT(!is_object_storage()) << "object-storage workload must be executed by ObjectStorageWorker";
 
-    for (auto & [file_index, batch] : _batches_by_file_index)
+    for (auto & batch : _batches)
     {
         batch.execute(stopped);
         LOG(DEBUG) << "Finished batch " << batch;

--- a/cpp/streamer/impl/workload/workload.h
+++ b/cpp/streamer/impl/workload/workload.h
@@ -2,14 +2,16 @@
 #pragma once
 
 #include <atomic>
-#include <map>
+#include <vector>
 #include "streamer/impl/batch/batch.h"
 #include "common/response_code/response_code.h"
 
 namespace runai::llm::streamer::impl
 {
 
-// Workload - a validated container of batches (one per file) that share a backend kind. It is otherwise
+// Workload - a validated container of batches that share a backend kind. NOT one batch per file: a file
+// whose ranges are not all contiguous yields one ContiguousTransfer per contiguous group, and several of
+// those can land in the same workload. It is otherwise
 // stateless: filesystem workloads are read synchronously by execute(); object-storage workloads are handed
 // to the ObjectStorageWorker pool, which reads the batches via batches() and owns the async scheduling.
 struct Workload
@@ -34,17 +36,24 @@ struct Workload
 
     bool is_object_storage() const;
 
-    // The batches, keyed by file index. Exposed (rather than befriending the worker) so ObjectStorageWorker
-    // can chunk the tasks and route completions; non-const because completion handling mutates the batches
-    // (handle_response / handle_error). add_batch stays the validated way to add one, and is always called
-    // (populating the workload) before batches() is read - the workload is fully built at dispatch time.
-    std::map<unsigned, Batch> & batches();
-    const std::map<unsigned, Batch> & batches() const;
+    // The batches, in insertion order. There is no index to look one up by: a file whose ranges are not all
+    // contiguous yields several ContiguousTransfers, hence several Batches, and two of them can be assigned
+    // to the same workload - so position is NOT a file index. Every consumer iterates, and each batch
+    // carries its own file_index, which is what completions and errors are attributed by (see
+    // ObjectStorageWorker::report_workload). Responses are routed by Batch pointer (TaskState::batch), not
+    // by position; those pointers are taken after the workload has been moved into its Inflight entry and no
+    // batch is added afterwards, so vector growth cannot invalidate them.
+    // Exposed (rather than befriending the worker) so ObjectStorageWorker can chunk the tasks and route
+    // completions; non-const because completion handling mutates the batches (handle_response /
+    // handle_error). add_batch stays the validated way to add one, and is always called (populating the
+    // workload) before batches() is read - the workload is fully built at dispatch time.
+    std::vector<Batch> & batches();
+    const std::vector<Batch> & batches() const;
 
  private:
     common::ResponseCode verify_batch(const Batch & batch);
 
-    std::map<unsigned, Batch> _batches_by_file_index;
+    std::vector<Batch> _batches;
     bool _is_object_storage = false;
 };
 

--- a/cpp/streamer/impl/workload/workload_test.cc
+++ b/cpp/streamer/impl/workload/workload_test.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "streamer/impl/assigner/assigner.h"
+#include "streamer/impl/batches/batches.h"
 
 #include "utils/random/random.h"
 #include "utils/temp/file/file.h"

--- a/cpp/streamer/impl/workload/workload_test.cc
+++ b/cpp/streamer/impl/workload/workload_test.cc
@@ -21,6 +21,38 @@
 namespace runai::llm::streamer::impl
 {
 
+namespace
+{
+
+// Build a request whose ranges tile each file contiguously and are packed consecutively into a single
+// buffer - the layout the previous single-destination API implied. Every file therefore coalesces to
+// exactly one ContiguousTransfer, which keeps these tests equivalent to what they asserted before.
+std::vector<FileRanges> build_contiguous_request(const std::vector<std::string> & paths,
+                                                 const std::vector<std::vector<size_t>> & chunks,
+                                                 char * buffer)
+{
+    std::vector<FileRanges> request(paths.size());
+
+    char * dst = buffer;
+    for (size_t i = 0; i < paths.size(); ++i)
+    {
+        request[i].path = paths[i];
+        request[i].ranges.reserve(chunks[i].size());
+
+        size_t offset = 0;
+        for (const auto size : chunks[i])
+        {
+            request[i].ranges.push_back(ReadRange{ offset, size, dst });
+            offset += size;
+            dst += size;
+        }
+    }
+
+    return request;
+}
+
+} // namespace
+
 TEST(Workload, Sanity)
 {
     auto num_files = utils::random::number(1, 10);
@@ -30,9 +62,7 @@ TEST(Workload, Sanity)
 
     std::atomic<bool> stopped(false);
     std::vector<std::string> paths;
-    std::vector<size_t> file_offsets;
-    std::vector<size_t> bytesizes;
-    std::vector<void*> dsts;
+    std::vector<std::vector<size_t>> chunks(num_files);
     std::vector<std::vector<uint8_t>> data(num_files);
     std::vector<unsigned> num_chunks(num_files);
     std::vector<utils::temp::File> file;
@@ -52,42 +82,47 @@ TEST(Workload, Sanity)
         total_bytes += size;
         data[i] = utils::random::buffer(size);
         file.push_back(utils::temp::File(data[i]));
-
         paths.push_back(file[i].path);
-        file_offsets.push_back(0);
-        bytesizes.push_back(size);
+
+        // The ranges must exist before the Assigner is built - it coalesces them - so the chunk sizes
+        // are chosen here rather than after the assignment as they used to be.
+        chunks[i] = utils::random::chunks(size, num_chunks[i]);
+        EXPECT_EQ(chunks[i].size(), num_chunks[i]);
+        EXPECT_EQ(std::accumulate(chunks[i].begin(), chunks[i].end(), static_cast<size_t>(0)), size);
+
+        for (unsigned j = 0; j < num_chunks[i]; ++j)
+        {
+            expected_responses[i].insert(j);
+        }
     }
 
     std::vector<char> buffer(total_bytes);
-    dsts.push_back(buffer.data());
+    const auto request = build_contiguous_request(paths, chunks, buffer.data());
 
     {
-        Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
+        Assigner assigner(request, config);
 
-        EXPECT_GT(assigner.file_assignments(0).size(), 0);
-        EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
+        // each file's ranges are adjacent in both the file and the buffer, so each file is one transfer
+        EXPECT_EQ(assigner.transfers().size(), num_files);
         EXPECT_LE(assigner.num_workloads(), config->concurrency);
 
         std::vector<Workload> workloads(assigner.num_workloads());
 
-        for (unsigned file_idx = 0; file_idx < num_files; ++file_idx)
+        for (const auto & transfer : assigner.transfers())
         {
-            auto chunks = utils::random::chunks(bytesizes[file_idx], num_chunks[file_idx]);
-            EXPECT_EQ(chunks.size(), num_chunks[file_idx]);
-            auto total_chunks_size = std::accumulate(chunks.begin(), chunks.end(), 0u);
-            EXPECT_EQ(total_chunks_size, bytesizes[file_idx]);
+            EXPECT_GT(transfer.tasks.size(), 0);
+            EXPECT_LE(transfer.tasks.size(), config->concurrency);
+            EXPECT_EQ(transfer.first_range_index, 0);
+            EXPECT_EQ(transfer.range_sizes.size(), num_chunks[transfer.file_index]);
 
-            Batches batches(utils::random::number(), file_idx, assigner.file_assignments(file_idx), config, responder, file[file_idx].path, s3_params, chunks);
+            Batches batches(utils::random::number(), transfer.file_index, transfer.tasks, config, responder,
+                            request[transfer.file_index].path, s3_params,
+                            transfer.range_sizes, transfer.first_range_index);
 
             for (size_t j = 0; j < batches.size(); ++j)
             {
                 auto & batch = batches[j];
                 workloads[batch.workload_index].add_batch(std::move(batch));
-            }
-
-            for (unsigned i = 0; i < num_chunks[file_idx]; ++i)
-            {
-                expected_responses[file_idx].insert(i);
             }
         }
         // execute workloads
@@ -136,15 +171,15 @@ TEST(Workload, Stopped)
 
     std::atomic<bool> stopped(false);
     std::vector<std::string> paths;
-    std::vector<size_t> file_offsets;
-    std::vector<size_t> bytesizes;
-    std::vector<void*> dsts;
+    std::vector<std::vector<size_t>> chunks(num_files);
     std::vector<std::vector<uint8_t>> data(num_files);
     std::vector<unsigned> num_chunks(num_files);
     std::vector<utils::temp::File> file;
     std::vector<std::set<int>> expected_responses(num_files);
 
     const auto chunk_size = utils::random::number<size_t>(1, 1024);
+    // concurrency 1: coalescing must still merge each file's ranges into a single read, since it runs
+    // before any work is divided between workers
     auto config = std::make_shared<Config>(1, 1, utils::random::number<size_t>(1, 1024), chunk_size, false /* do not force minimum chunk size */);
     auto responder = std::make_shared<common::Responder>(0);
 
@@ -158,41 +193,40 @@ TEST(Workload, Stopped)
         total_bytes += size;
         data[i] = utils::random::buffer(size);
         file.push_back(utils::temp::File(data[i]));
-
         paths.push_back(file[i].path);
-        file_offsets.push_back(0);
-        bytesizes.push_back(size);
+
+        chunks[i] = utils::random::chunks(size, num_chunks[i]);
+        EXPECT_EQ(chunks[i].size(), num_chunks[i]);
+        EXPECT_EQ(std::accumulate(chunks[i].begin(), chunks[i].end(), static_cast<size_t>(0)), size);
+
+        for (unsigned j = 0; j < num_chunks[i]; ++j)
+        {
+            expected_responses[i].insert(j);
+        }
     }
 
     std::vector<char> buffer(total_bytes);
-    dsts.push_back(buffer.data());
+    const auto request = build_contiguous_request(paths, chunks, buffer.data());
 
-    Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
+    Assigner assigner(request, config);
 
-    EXPECT_GT(assigner.file_assignments(0).size(), 0);
-    EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
-
+    EXPECT_EQ(assigner.transfers().size(), num_files);
 
     Workload workload;
 
-    for (unsigned file_idx = 0; file_idx < num_files; ++file_idx)
+    for (const auto & transfer : assigner.transfers())
     {
-        auto chunks = utils::random::chunks(bytesizes[file_idx], num_chunks[file_idx]);
-        EXPECT_EQ(chunks.size(), num_chunks[file_idx]);
-        auto total_chunks_size = std::accumulate(chunks.begin(), chunks.end(), 0u);
-        EXPECT_EQ(total_chunks_size, bytesizes[file_idx]);
+        // one worker, so a transfer is never split
+        EXPECT_EQ(transfer.tasks.size(), 1);
 
-        Batches batches(utils::random::number(), file_idx, assigner.file_assignments(file_idx), config, responder, file[file_idx].path, s3_params, chunks);
+        Batches batches(utils::random::number(), transfer.file_index, transfer.tasks, config, responder,
+                        request[transfer.file_index].path, s3_params,
+                        transfer.range_sizes, transfer.first_range_index);
 
         for (size_t j = 0; j < batches.size(); ++j)
         {
             auto & batch = batches[j];
             workload.add_batch(std::move(batch));
-        }
-
-        for (unsigned i = 0; i < num_chunks[file_idx]; ++i)
-        {
-            expected_responses[file_idx].insert(i);
         }
     }
 

--- a/cpp/streamer/streamer.cc
+++ b/cpp/streamer/streamer.cc
@@ -138,6 +138,11 @@ _RUNAI_EXTERN_C int runai_set_credentials(
 
         return static_cast<int>(s->set_credentials(common::s3::Credentials(param_keys, param_values, num_params)));
     }
+    catch (const common::Exception & e)
+    {
+        // report the specific code (see runai_request for why this matters)
+        return static_cast<int>(e.error());
+    }
     catch(...)
     {
     }
@@ -173,6 +178,15 @@ _RUNAI_EXTERN_C int runai_request(
         // credentials are streamer-scoped (runai_set_credentials), not per request
         return submit_request(s, out_submission_id, num_files, paths, num_ranges, range_offsets, range_sizes, range_dsts);
     }
+    catch (const common::Exception & e)
+    {
+        // Report the specific code rather than collapsing it to UnknownError. async_request lets typed
+        // exceptions escape - a null destination or a byte-total overflow both throw InvalidParameterError -
+        // and UnknownError is the code that tells a caller to abort everything, whereas an argument error is
+        // attributable to this submission and recoverable. Nothing is committed when these throw, so
+        // returning the real code leaves no responses owed.
+        return static_cast<int>(e.error());
+    }
     catch(...)
     {
     }
@@ -203,6 +217,11 @@ _RUNAI_EXTERN_C int runai_response(
         if (out_submission_id != nullptr) *out_submission_id = r.submission_id;
         if (submission_done != nullptr) *submission_done = done ? 1 : 0;
         return static_cast<int>(r.ret);
+    }
+    catch (const common::Exception & e)
+    {
+        // report the specific code (see runai_request for why this matters)
+        return static_cast<int>(e.error());
     }
     catch(...)
     {

--- a/cpp/streamer/streamer.cc
+++ b/cpp/streamer/streamer.cc
@@ -12,14 +12,12 @@
 namespace runai::llm::streamer
 {
 
-// Library for reading a large file concurrently to a given host memory buffer
-// Reads a single file at a time
+// Library for reading files concurrently into host memory buffers
+// A single submission (runai_request) may cover many files, and many submissions may be in flight at
+// once - each response carries the id of the submission it belongs to
 // NOT THREAD SAFE - caller must not send requests and responses in parallel
 
-// creates streamer object with threadpool of the given size
-// returns streamer response code Success or error code
-// chunk_bytesize : number of bytes to read by each thread before sending response to the caller (in case there are new completed sub requests)
-// block_bytesize : maximal number of bytes to read from the storage in a single read call
+// Creates a streamer object; see streamer.h for the configuration environment variables.
 
 _RUNAI_EXTERN_C int runai_start(void ** streamer)
 {
@@ -62,43 +60,60 @@ _RUNAI_EXTERN_C void runai_end(void * streamer)
     }
 }
 
-// send asynchronous read request to read multiple files
-//
-// num_files : number of files to read
-// paths : list of files paths
-// file_offsets : offset for each file path, from which to start reading
-// bytesizes : size of each destination buffer
-// dsts : destination buffers
-//        for reading to CPU memory, dsts[0] only is used as a single buffer to contain all the files in the order specified by paths
-// num_sizes : number of sub requests for each file
-// internal_sizes : a list containing the size of each sub request, where the first sub request starts at the given file offset and each sub request starts at the end of the previous one
-// return Success if request is valid
-
 namespace
 {
 
 // Marshal the C request arrays and submit, forwarding out_submission_id. Credentials are NOT passed here:
 // they are streamer-scoped, set once via runai_set_credentials.
+//
+// The C arrays are flat and grouped by file in the order of paths; they are transposed here into one
+// FileRanges per file, each holding its ranges as (offset, size, dst) triples. Validation is ordered so
+// that no array is dereferenced before it has been checked - in particular paths[i] is checked before
+// being used to construct a std::string.
 int submit_request(impl::Streamer * s,
                    SubmissionId * out_submission_id,
                    unsigned num_files,
-                   const char ** paths, size_t * file_offsets, size_t * bytesizes,
-                   void ** dsts, unsigned * num_sizes, size_t ** internal_sizes)
+                   const char ** paths, unsigned * num_ranges,
+                   size_t * range_offsets, size_t * range_sizes, void ** range_dsts)
 {
-    std::vector<std::string> paths_v(paths, paths + num_files);
-    std::vector<size_t> file_offsets_v(file_offsets, file_offsets + num_files);
-    std::vector<size_t> bytesizes_v(bytesizes, bytesizes + num_files);
-    std::vector<void *> dsts_v(dsts, dsts + num_files);
-    std::vector<unsigned> num_sizes_v(num_sizes, num_sizes + num_files);
-    std::vector<size_t *> internal_sizes_v(internal_sizes, internal_sizes + num_files);
-
-    std::vector<std::vector<size_t>> internal_sizes_vv(num_files);
-    for (unsigned i = 0; i < num_files; ++i)
+    if (num_files > 0 && (paths == nullptr || num_ranges == nullptr))
     {
-        internal_sizes_vv[i] = std::vector<size_t>(internal_sizes_v[i], internal_sizes_v[i] + num_sizes_v[i]);
+        return static_cast<int>(common::ResponseCode::InvalidParameterError);
     }
 
-    return static_cast<int>(s->async_request(paths_v, file_offsets_v, bytesizes_v, dsts_v, num_sizes_v, internal_sizes_vv, out_submission_id));
+    size_t total_ranges = 0;
+    for (unsigned i = 0; i < num_files; ++i)
+    {
+        total_ranges += num_ranges[i];
+    }
+
+    // the range arrays are dereferenced only if the submission actually carries ranges
+    if (total_ranges > 0 && (range_offsets == nullptr || range_sizes == nullptr || range_dsts == nullptr))
+    {
+        return static_cast<int>(common::ResponseCode::InvalidParameterError);
+    }
+
+    std::vector<impl::FileRanges> request(num_files);
+
+    size_t base = 0;
+    for (unsigned i = 0; i < num_files; ++i)
+    {
+        if (paths[i] == nullptr)
+        {
+            return static_cast<int>(common::ResponseCode::InvalidParameterError);
+        }
+        request[i].path = paths[i];
+
+        const unsigned n = num_ranges[i];
+        request[i].ranges.reserve(n);
+        for (unsigned j = 0; j < n; ++j)
+        {
+            request[i].ranges.push_back(impl::ReadRange{ range_offsets[base + j], range_sizes[base + j], range_dsts[base + j] });
+        }
+        base += n;
+    }
+
+    return static_cast<int>(s->async_request(request, out_submission_id));
 }
 
 } // namespace
@@ -134,11 +149,10 @@ _RUNAI_EXTERN_C int runai_request(
     SubmissionId * out_submission_id,
     unsigned num_files,
     const char ** paths,
-    size_t * file_offsets,
-    size_t * bytesizes,
-    void ** dsts,
-    unsigned * num_sizes,
-    size_t ** internal_sizes
+    unsigned * num_ranges,
+    size_t * range_offsets,
+    size_t * range_sizes,
+    void ** range_dsts
 )
 {
     // default the id to 0 ("none") so every return path - including early failures and a throw
@@ -157,7 +171,7 @@ _RUNAI_EXTERN_C int runai_request(
         }
 
         // credentials are streamer-scoped (runai_set_credentials), not per request
-        return submit_request(s, out_submission_id, num_files, paths, file_offsets, bytesizes, dsts, num_sizes, internal_sizes);
+        return submit_request(s, out_submission_id, num_files, paths, num_ranges, range_offsets, range_sizes, range_dsts);
     }
     catch(...)
     {

--- a/cpp/streamer/streamer.h
+++ b/cpp/streamer/streamer.h
@@ -63,6 +63,14 @@ _RUNAI_EXTERN_C int runai_set_credentials(
 // The three flat arrays are indexed identically and grouped by file in the order of paths: file f's
 // ranges occupy [sum(num_ranges[0..f)), sum(num_ranges[0..f])). Destinations must not overlap.
 //
+// RESPONSE COUNT - a submission owes exactly sum(num_ranges) responses, one per range:
+//   - a ZERO-SIZED range still gets its own response (it is completed immediately, without reaching
+//     storage), so it must be counted like any other;
+//   - a file with num_ranges[f] == 0 contributes no responses, and is otherwise accepted.
+// Size the response loop by that sum. runai_response blocks indefinitely at timeout_ms = 0, so a
+// caller that skips zero-sized ranges when counting waits for a response that has already been
+// delivered. A submission with sum(num_ranges) == 0 owes nothing and completes immediately.
+//
 // Credentials are NOT passed here - set them once via runai_set_credentials.
 //  out_submission_id : always set to this submission's id once one is assigned, and left 0 only
 //                      if the call fails before that (e.g. invalid parameters). On Success it

--- a/cpp/streamer/streamer.h
+++ b/cpp/streamer/streamer.h
@@ -15,14 +15,18 @@ namespace runai::llm::streamer
 
 typedef void (*RunaiFileListCallback)(const char* path, size_t file_size, void* user_data);
 
-// Library for reading a large file concurrently to a given host memory buffer
-// Reads a single file at a time
+// Library for reading files concurrently into host memory buffers
+// A single submission (runai_request) may cover many files, and many submissions may be in flight at
+// once - each response carries the id of the submission it belongs to
 // NOT THREAD SAFE - caller must not send requests and responses in parallel
 
-// creates streamer object with threadpool of the given size
-// return streamer response code Success or error code
-// chunk_bytesize : number of bytes to read by each thread before sending response to the caller (in case there are new completed sub requests)
-// block_bytesize : maximal number of bytes to read from the storage in a single read call
+// Creates a streamer object; returns Success or an error code.
+// Takes no configuration arguments - the streamer configures itself from the environment. Each variable
+// below sets BOTH backends; when a variable is unset the two backends fall back to different defaults:
+//   RUNAI_STREAMER_CONCURRENCY    : number of worker threads. Unset: 16 filesystem, 8 object storage
+//   RUNAI_STREAMER_CHUNK_BYTESIZE : bytes per read call. Unset: 2 MiB filesystem, the S3 client default
+//                                   for object storage. Minimums are enforced - 2 MiB and 5 MiB respectively
+// Worker pools are created lazily, one per backend actually used.
 
 _RUNAI_EXTERN_C int runai_start(void ** streamer /* return parameter */);
 
@@ -45,15 +49,20 @@ _RUNAI_EXTERN_C int runai_set_credentials(
 
 // Multi-request submit: read multiple files concurrently.
 //
-// num_files : number of files to read
-// paths : list of files paths
-// file_offsets : offset for each file path, from which to start reading
-// bytesizes : size of each destination buffer
-// dsts : destination buffers; for reading to CPU memory, dsts[0] only is used as a single buffer to contain
-//        all the files in the order specified by paths
-// num_sizes : number of sub requests for each file
-// internal_sizes : a list containing the size of each sub request, where the first sub request starts at the
-//                  given file offset and each subsequent sub request starts at the end of the previous one
+// A submission is a list of files; each file carries a list of RANGES to read. A range is an
+// arbitrary (source offset, size) within its file with its own destination - ranges need not be
+// contiguous in the file, need not be contiguous in memory, and need not be ordered.
+//
+// num_files     : number of files to read
+// paths         : list of file paths - one entry per file, however many ranges that file has
+// num_ranges    : number of ranges for each file
+// range_offsets : flat array of sum(num_ranges) source offsets, each within its owning file
+// range_sizes   : flat array of sum(num_ranges) range sizes in bytes
+// range_dsts    : flat array of sum(num_ranges) destination pointers
+//
+// The three flat arrays are indexed identically and grouped by file in the order of paths: file f's
+// ranges occupy [sum(num_ranges[0..f)), sum(num_ranges[0..f])). Destinations must not overlap.
+//
 // Credentials are NOT passed here - set them once via runai_set_credentials.
 //  out_submission_id : always set to this submission's id once one is assigned, and left 0 only
 //                      if the call fails before that (e.g. invalid parameters). On Success it
@@ -65,19 +74,18 @@ _RUNAI_EXTERN_C int runai_request(
     SubmissionId * out_submission_id /* return parameter */,
     unsigned num_files,
     const char ** paths,
-    size_t * file_offsets,
-    size_t * bytesizes,
-    void ** dsts,
-    unsigned * num_sizes,
-    size_t ** internal_sizes
+    unsigned * num_ranges,
+    size_t * range_offsets,
+    size_t * range_sizes,
+    void ** range_dsts
 );
 
-// Multi-request response. Returns the next ready sub-range from any in-flight submission.
+// Multi-request response. Returns the next ready range from any in-flight submission.
 //  out_submission_id : set to the owning submission's id (which submission this response is for).
-//  file_index, index : the file and sub-range within that submission.
+//  file_index, index : the file, and the index of the range within that file, as submitted.
 //  submission_done   : set to 1 iff this was the submission's last response (it is now complete).
 //  timeout_ms        : max time to wait for a response; 0 blocks indefinitely.
-// ret is the truthful per-sub-range code (Success or a specific error), TimedOut on timeout, or
+// ret is the truthful per-range code (Success or a specific error), TimedOut on timeout, or
 // FinishedError on teardown.
 _RUNAI_EXTERN_C int runai_response(
     void * streamer,

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -28,11 +28,39 @@ namespace
 // expected, the test fails visibly instead of blocking forever (the multi-request API has no finish-on-drain).
 constexpr unsigned RESPONSE_TIMEOUT_MS = 60000;
 
+// Keeps the classic per-file argument shape so the tests below are unchanged, and adapts it to the range
+// API: each file's sub ranges tile [file_offsets[i], file_offsets[i] + bytesizes[i]) in order, and every
+// file is written consecutively into the single buffer at dsts[0] - the layout the previous API implied.
 inline int submit(void * streamer, unsigned num_files, const char ** paths, size_t * file_offsets,
                   size_t * bytesizes, void ** dsts, unsigned * num_sizes, size_t ** internal_sizes)
 {
+    (void)bytesizes;   // implied by the sub range sizes
+
+    std::vector<unsigned> num_ranges(num_files);
+    std::vector<size_t> range_offsets;
+    std::vector<size_t> range_sizes;
+    std::vector<void *> range_dsts;
+
+    char * dst = static_cast<char *>(dsts[0]);
+    for (unsigned i = 0; i < num_files; ++i)
+    {
+        num_ranges[i] = num_sizes[i];
+
+        size_t offset = file_offsets[i];
+        for (unsigned j = 0; j < num_sizes[i]; ++j)
+        {
+            const size_t size = internal_sizes[i][j];
+            range_offsets.push_back(offset);
+            range_sizes.push_back(size);
+            range_dsts.push_back(dst);
+            offset += size;
+            dst += size;
+        }
+    }
+
     SubmissionId submission_id = 0;
-    return runai_request(streamer, &submission_id, num_files, paths, file_offsets, bytesizes, dsts, num_sizes, internal_sizes);
+    return runai_request(streamer, &submission_id, num_files, paths, num_ranges.data(),
+                         range_offsets.data(), range_sizes.data(), range_dsts.data());
 }
 
 inline int next_response(void * streamer, unsigned * file_index, unsigned * index)

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -15,6 +15,7 @@
 #include "utils/env/env.h"
 #include "utils/dylib/dylib.h"
 #include "utils/temp/env/env.h"
+#include "utils/temp/file/file.h"
 #include "utils/fdlimit/fdlimit.h"
 
 namespace runai::llm::streamer
@@ -716,6 +717,125 @@ TEST_F(StreamerTest, Multiple_Files)
         EXPECT_LT(file_index, num_files);
         EXPECT_EQ(expected_response[file_index].count(r), 1);
         expected_response[file_index].erase(r);
+    }
+
+    runai_end(streamer);
+    EXPECT_EQ(verify_mock(), 0);
+}
+
+// A submission must pick one backend kind (Streamer::lock_object_plugin rejects a mix), but a STREAMER
+// serves both: BackendPools holds one pool per kind, created lazily, so filesystem and object-storage
+// submissions coexist on the same handle. Both orders are exercised, because the pools are created
+// lazily and by different paths - the filesystem pool on first push, the object-storage pool by the
+// plugin lock - so an ordering bug would show up in only one of them.
+TEST_F(StreamerTest, Filesystem_And_Object_Storage_Submissions_Coexist)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+
+    const auto fs_data = utils::random::buffer(utils::random::number(100, 1000));
+    utils::temp::File fs_file(fs_data);
+
+    // Read the filesystem file in one range, and drain it, checking the bytes actually arrived.
+    auto read_filesystem = [&](void * streamer)
+    {
+        std::vector<unsigned char> dst(fs_data.size());
+        void * dst_ptr = dst.data();
+        const char * path = fs_file.path.c_str();
+        unsigned num_ranges = 1;
+        size_t offset = 0;
+        size_t size = fs_data.size();
+
+        SubmissionId submission_id = 0;
+        EXPECT_EQ(runai_request(streamer, &submission_id, 1, &path, &num_ranges, &offset, &size, &dst_ptr),
+                  static_cast<int>(common::ResponseCode::Success));
+
+        unsigned file_index = 0;
+        unsigned range_index = 0;
+        EXPECT_EQ(next_response(streamer, &file_index, &range_index),
+                  static_cast<int>(common::ResponseCode::Success));
+        EXPECT_EQ(dst, std::vector<unsigned char>(fs_data.begin(), fs_data.end()));
+    };
+
+    // Read the fixture's object-storage files, and drain every expected response.
+    auto read_object_storage = [&](void * streamer)
+    {
+        EXPECT_EQ(submit(streamer, num_files, file_names.data(), file_offsets.data(), sizes.data(),
+                         dsts.data(), num_ranges.data(), internal_sizes.data()),
+                  static_cast<int>(common::ResponseCode::Success));
+
+        for (unsigned i = 0; i < num_expected_responses; ++i)
+        {
+            unsigned file_index = 0;
+            unsigned range_index = 0;
+            const auto response_code = next_response(streamer, &file_index, &range_index);
+            EXPECT_EQ(response_code, static_cast<int>(common::ResponseCode::Success));
+            if (response_code != static_cast<int>(common::ResponseCode::Success))
+            {
+                break;
+            }
+        }
+    };
+
+    void * streamer;
+    ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
+
+    read_filesystem(streamer);
+    read_object_storage(streamer);
+
+    runai_end(streamer);
+    EXPECT_EQ(verify_mock(), 0);
+}
+
+// The reverse order, as its own test rather than a second streamer in the one above: the object-storage
+// mock's backend handle is process-global, so two streamers in a single test exercise the plugin
+// teardown/reopen lifecycle instead of the thing under test. Every test in this file uses one streamer.
+TEST_F(StreamerTest, Object_Storage_Then_Filesystem_Submission)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+
+    const auto fs_data = utils::random::buffer(utils::random::number(100, 1000));
+    utils::temp::File fs_file(fs_data);
+
+    void * streamer;
+    ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
+
+    // object storage first - this is what creates the object-storage pool (via the plugin lock)
+    EXPECT_EQ(submit(streamer, num_files, file_names.data(), file_offsets.data(), sizes.data(),
+                     dsts.data(), num_ranges.data(), internal_sizes.data()),
+              static_cast<int>(common::ResponseCode::Success));
+
+    for (unsigned i = 0; i < num_expected_responses; ++i)
+    {
+        unsigned file_index = 0;
+        unsigned range_index = 0;
+        const auto response_code = next_response(streamer, &file_index, &range_index);
+        EXPECT_EQ(response_code, static_cast<int>(common::ResponseCode::Success));
+        if (response_code != static_cast<int>(common::ResponseCode::Success))
+        {
+            break;
+        }
+    }
+
+    // then a filesystem submission on the same streamer, which creates the filesystem pool
+    {
+        std::vector<unsigned char> dst(fs_data.size());
+        void * dst_ptr = dst.data();
+        const char * path = fs_file.path.c_str();
+        unsigned n_ranges = 1;
+        size_t offset = 0;
+        size_t size = fs_data.size();
+
+        SubmissionId submission_id = 0;
+        EXPECT_EQ(runai_request(streamer, &submission_id, 1, &path, &n_ranges, &offset, &size, &dst_ptr),
+                  static_cast<int>(common::ResponseCode::Success));
+
+        unsigned file_index = 0;
+        unsigned range_index = 0;
+        EXPECT_EQ(next_response(streamer, &file_index, &range_index),
+                  static_cast<int>(common::ResponseCode::Success));
+        EXPECT_EQ(dst, std::vector<unsigned char>(fs_data.begin(), fs_data.end()));
     }
 
     runai_end(streamer);

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -729,7 +730,9 @@ TEST_F(StreamerTest, Multiple_Files_Error)
     set_backend_shutdown_policy(utils::random::boolean() ? common::backend_api::ObjectShutdownPolicy_t::OBJECT_SHUTDOWN_POLICY_ON_STREAMER_SHUTDOWN : common::backend_api::ObjectShutdownPolicy_t::OBJECT_SHUTDOWN_POLICY_ON_PROCESS_EXIT);
 
     const auto error_code = common::ResponseCode::FileAccessError;
-    utils::temp::Env env_rc("RUNAI_STREAMER_S3_MOCK_RESPONSE_CODE", static_cast<int>(error_code));
+    // Scoped to the reads only, released before runai_end below: the injected code reaches every mock entry
+    // point, so leaving it set across teardown injects failures into the shutdown path too.
+    auto env_rc = std::make_unique<utils::temp::Env>("RUNAI_STREAMER_S3_MOCK_RESPONSE_CODE", static_cast<int>(error_code));
 
     void * streamer;
     EXPECT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
@@ -764,6 +767,7 @@ TEST_F(StreamerTest, Multiple_Files_Error)
         expected_response[file_index].erase(r);
     }
 
+    env_rc.reset();   // stop injecting failures before the streamer tears the backend down
     runai_end(streamer);
     EXPECT_EQ(verify_mock(), 0);
 }

--- a/cpp/streamer/streamer_test.cc
+++ b/cpp/streamer/streamer_test.cc
@@ -28,11 +28,63 @@ namespace
 // streams and drain by a known count, so submit() discards the id and next_response() blocks (timeout 0) for
 // the next sub-range. There is no finish-on-drain: a submission's last response carries submission_done, so
 // the tests never call next_response() past the expected count (that would block).
+// submit() keeps the classic per-file argument shape so the tests below are unchanged, and adapts it to
+// the range API: each file's sub ranges tile [file_offsets[i], file_offsets[i] + bytesizes[i]) in order,
+// and every file is written consecutively into the single buffer at dsts[0] - the layout the previous
+// API implied.
 inline int submit(void * streamer, unsigned num_files, const char ** paths, size_t * file_offsets,
                   size_t * bytesizes, void ** dsts, unsigned * num_sizes, size_t ** internal_sizes)
 {
+    (void)bytesizes;   // implied by the sub range sizes
+
+    std::vector<unsigned> num_ranges(num_files);
+    std::vector<size_t> range_offsets;
+    std::vector<size_t> range_sizes;
+    std::vector<void *> range_dsts;
+
+    char * dst = static_cast<char *>(dsts[0]);
+    for (unsigned i = 0; i < num_files; ++i)
+    {
+        num_ranges[i] = num_sizes[i];
+
+        size_t offset = file_offsets[i];
+        for (unsigned j = 0; j < num_sizes[i]; ++j)
+        {
+            const size_t size = internal_sizes[i][j];
+            range_offsets.push_back(offset);
+            range_sizes.push_back(size);
+            range_dsts.push_back(dst);
+            offset += size;
+            dst += size;
+        }
+    }
+
     SubmissionId submission_id = 0;
-    return runai_request(streamer, &submission_id, num_files, paths, file_offsets, bytesizes, dsts, num_sizes, internal_sizes);
+    return runai_request(streamer, &submission_id, num_files, paths, num_ranges.data(),
+                         range_offsets.data(), range_sizes.data(), range_dsts.data());
+}
+
+// Single-file variant that reports the submission id, for the concurrent-submission tests. The sub ranges
+// tile [offset, offset + sum(sizes)) and are written consecutively from dst.
+inline int submit_one(void * streamer, SubmissionId * id, const char * path, size_t offset,
+                      void * dst, std::vector<size_t> & sizes)
+{
+    unsigned num_ranges = sizes.size();
+    std::vector<size_t> range_offsets;
+    std::vector<void *> range_dsts;
+
+    char * d = static_cast<char *>(dst);
+    size_t o = offset;
+    for (const auto size : sizes)
+    {
+        range_offsets.push_back(o);
+        range_dsts.push_back(d);
+        o += size;
+        d += size;
+    }
+
+    return runai_request(streamer, id, 1, &path, &num_ranges,
+                         range_offsets.data(), sizes.data(), range_dsts.data());
 }
 
 inline int next_response(void * streamer, unsigned * file_index, unsigned * index)
@@ -93,6 +145,38 @@ TEST_F(StreamerTest, Creation)
     auto res = runai_start(&streamer);
     EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
     EXPECT_NE(streamer, nullptr);
+
+    EXPECT_NO_THROW(runai_end(streamer));
+}
+
+// Replaces AssignerTest.Mismatched_Input_Sizes, which asserted the old per-file vector length check.
+// Lengths cannot disagree now - num_ranges describes the flat arrays - so what remains checkable at the C
+// boundary is null-ness, validated in submit_request before anything is dereferenced.
+TEST(Request, Null_Parameters)
+{
+    void * streamer = nullptr;
+    ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
+
+    SubmissionId id = 0;
+    const char * path = "/tmp/no-such-file";
+    unsigned num_ranges = 1;
+    size_t offset = 0;
+    size_t size = 10;
+    std::vector<char> buffer(size);
+    void * dst = buffer.data();
+
+    const auto invalid = static_cast<int>(common::ResponseCode::InvalidParameterError);
+
+    EXPECT_EQ(runai_request(streamer, &id, 1, nullptr, &num_ranges, &offset, &size, &dst), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, nullptr, &offset, &size, &dst), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, nullptr, &size, &dst), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, nullptr, &dst), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &size, nullptr), invalid);
+
+    // a null path entry is caught before it is used to construct a std::string - the previous code built
+    // the vector straight from the array, which was undefined behaviour on a null element
+    const char * null_path = nullptr;
+    EXPECT_EQ(runai_request(streamer, &id, 1, &null_path, &num_ranges, &offset, &size, &dst), invalid);
 
     EXPECT_NO_THROW(runai_end(streamer));
 }
@@ -439,27 +523,22 @@ TEST(AsyncEx, ConcurrentSubmissionsDemux)
 
     const char * path = file.path.c_str();
     size_t offset = 0;
-    size_t bytesize = size;
 
     // Submission A: 2 sub-ranges into dstA
     std::vector<unsigned char> dstA(size);
     const size_t s1 = size / 2;
     std::vector<size_t> subA = { s1, size - s1 };
-    size_t * subA_ptr = subA.data();
-    unsigned numA = 2;
     SubmissionId idA = 0;
     void * dstA_ptr = dstA.data();
-    ASSERT_EQ(runai_request(streamer, &idA, 1, &path, &offset, &bytesize, &dstA_ptr, &numA, &subA_ptr),
+    ASSERT_EQ(submit_one(streamer, &idA, path, offset, dstA_ptr, subA),
               static_cast<int>(common::ResponseCode::Success));
 
     // Submission B: 1 sub-range into dstB
     std::vector<unsigned char> dstB(size);
     std::vector<size_t> subB = { size };
-    size_t * subB_ptr = subB.data();
-    unsigned numB = 1;
     SubmissionId idB = 0;
     void * dstB_ptr = dstB.data();
-    ASSERT_EQ(runai_request(streamer, &idB, 1, &path, &offset, &bytesize, &dstB_ptr, &numB, &subB_ptr),
+    ASSERT_EQ(submit_one(streamer, &idB, path, offset, dstB_ptr, subB),
               static_cast<int>(common::ResponseCode::Success));
 
     EXPECT_NE(idA, 0u);
@@ -519,25 +598,19 @@ TEST(AsyncEx, PerSubmissionErrorIsolation)
 
     // Submission A: valid full read
     std::vector<unsigned char> dstA(data_size);
-    size_t bytesizeA = data_size;
     std::vector<size_t> subA = { data_size };
-    size_t * subA_ptr = subA.data();
-    unsigned numA = 1;
     SubmissionId idA = 0;
     void * dstA_ptr = dstA.data();
-    ASSERT_EQ(runai_request(streamer, &idA, 1, &path, &offset, &bytesizeA, &dstA_ptr, &numA, &subA_ptr),
+    ASSERT_EQ(submit_one(streamer, &idA, path, offset, dstA_ptr, subA),
               static_cast<int>(common::ResponseCode::Success));
 
     // Submission B: read past EOF -> EofError
     const size_t over = data_size + utils::random::number(1, 100);
     std::vector<unsigned char> dstB(over);
-    size_t bytesizeB = over;
     std::vector<size_t> subB = { over };
-    size_t * subB_ptr = subB.data();
-    unsigned numB = 1;
     SubmissionId idB = 0;
     void * dstB_ptr = dstB.data();
-    ASSERT_EQ(runai_request(streamer, &idB, 1, &path, &offset, &bytesizeB, &dstB_ptr, &numB, &subB_ptr),
+    ASSERT_EQ(submit_one(streamer, &idB, path, offset, dstB_ptr, subB),
               static_cast<int>(common::ResponseCode::Success));
 
     EXPECT_NE(idA, idB);
@@ -596,12 +669,9 @@ TEST(AsyncEx, MultipleSubmitterThreads)
             {
                 const char * path = file.path.c_str();
                 size_t offset = 0;
-                size_t bytesize = size;
                 std::vector<size_t> sub = { size };
-                size_t * sub_ptr = sub.data();
-                unsigned num = 1;
                 void * dst = dsts[t].data();
-                submit_ret[t] = runai_request(streamer, &ids[t], 1, &path, &offset, &bytesize, &dst, &num, &sub_ptr);
+                submit_ret[t] = submit_one(streamer, &ids[t], path, offset, dst, sub);
             });
         }
     }

--- a/cpp/streamer/streamer_test.cc
+++ b/cpp/streamer/streamer_test.cc
@@ -178,6 +178,18 @@ TEST(Request, Null_Parameters)
     const char * null_path = nullptr;
     EXPECT_EQ(runai_request(streamer, &id, 1, &null_path, &num_ranges, &offset, &size, &dst), invalid);
 
+    // A null destination ELEMENT (the array itself is fine) is caught deeper, by verify_requests, which
+    // throws rather than returning. The specific code has to survive the C boundary: UnknownError is what
+    // tells a caller to abort everything, while an argument error is attributable and recoverable, so
+    // collapsing this to UnknownError would turn a bad argument into a dead stream.
+    void * null_dst = nullptr;
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &size, &null_dst), invalid);
+
+    // a zero-sized range writes nothing, so a null destination there is accepted
+    size_t zero = 0;
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &zero, &null_dst),
+              static_cast<int>(common::ResponseCode::Success));
+
     EXPECT_NO_THROW(runai_end(streamer));
 }
 

--- a/cpp/streamer/streamer_test.cc
+++ b/cpp/streamer/streamer_test.cc
@@ -158,7 +158,11 @@ TEST(Request, Null_Parameters)
     ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
 
     SubmissionId id = 0;
-    const char * path = "/tmp/no-such-file";
+    // a real file, so the one submission that IS accepted below reads successfully and the test is about
+    // argument validation only
+    const auto data = utils::random::buffer(utils::random::number(10, 100));
+    utils::temp::File file(data);
+    const char * path = file.path.c_str();
     unsigned num_ranges = 1;
     size_t offset = 0;
     size_t size = 10;
@@ -189,6 +193,19 @@ TEST(Request, Null_Parameters)
     size_t zero = 0;
     EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &zero, &null_dst),
               static_cast<int>(common::ResponseCode::Success));
+
+    // The only submission accepted above, so it owes one response and must be drained before the test
+    // returns - an in-flight submission writes into buffers the caller has released.
+    unsigned file_index = 0;
+    unsigned range_index = 0;
+    int submission_done = 0;
+    SubmissionId response_id = 0;
+    EXPECT_EQ(runai_response(streamer, &response_id, &file_index, &range_index, &submission_done, 0),
+              static_cast<int>(common::ResponseCode::Success));
+    EXPECT_EQ(response_id, id);
+    EXPECT_EQ(file_index, 0u);
+    EXPECT_EQ(range_index, 0u);
+    EXPECT_EQ(submission_done, 1);
 
     EXPECT_NO_THROW(runai_end(streamer));
 }

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -232,7 +232,7 @@ class _distributedStreamerParams:
         self.broadcast_timeout = self.get_broadcast_timeout()
 
         # find the size of the maximal chunk for the reusable buffer
-        max_chunks_per_file = (fc.max_chunk_size() for fc in file_stream_requests if fc.chunks)
+        max_chunks_per_file = (fc.max_chunk_size() for fc in file_stream_requests if fc.sizes)
         self.max_chunk = max(max_chunks_per_file, default=0)
 
         # set the value of RUNAI_STREAMER_PROCESS_GROUP_SIZE to be the number of processes in the distribution group (or 1 if process group is not initialized)

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -277,7 +277,7 @@ class _distributedStreamer:
                 self.distribution_group = None
         return
 
-    def create_distribution_group(self) -> dist.GroupSpec:
+    def create_distribution_group(self) -> Optional[dist.ProcessGroup]:
         if self.distribution_group:
             return self.distribution_group
 
@@ -297,7 +297,7 @@ class _distributedStreamer:
         logger.debug(f"[RunAI Streamer][Distributed] Created distribution group with size {dist.get_world_size(group=group)}")
         return group
 
-    def create_local_distribution_group(self) -> dist.GroupSpec:
+    def create_local_distribution_group(self) -> Optional[dist.ProcessGroup]:
         """
         Creates a torch.distributed.ProcessGroup containing all ranks on the current node.
         This version uses a coordinated creation pattern to avoid deadlocks.

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/partition.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/partition.py
@@ -152,11 +152,10 @@ def partition_by_files(
     if not file_stream_requests:
         return [[] for _ in range(n)]
 
-    # 1. Sort the FileChunks objects from largest to smallest total size, keeping track of original index.
-    requests_with_indices = list(enumerate(file_stream_requests))
+    # 1. Sort the FileChunks objects from largest to smallest total size.
     sorted_requests = sorted(
-        requests_with_indices,
-        key=lambda item: item[1].total_size(),
+        file_stream_requests,
+        key=lambda request: request.total_size(),
         reverse=True
     )
 
@@ -164,13 +163,19 @@ def partition_by_files(
     partitions: List[List[Tuple[FileChunks, Dict[int, Tuple[int, int, int]]]]] = [[] for _ in range(n)]
     partition_sizes: List[int] = [0] * n
 
-    for original_request_index, request in sorted_requests:
+    for request in sorted_requests:
         min_size_idx = partition_sizes.index(min(partition_sizes))
         
-        # Create the source map. Since we aren't changing the chunk order within
+        # Create the source map. Since we aren't changing the range order within
         # the FileChunks object, the mapping is direct.
+        #
+        # Keyed on request.id, NOT the request's position in file_stream_requests: the map's contract is
+        # "original FileChunks.id and range index" (see DistributedStreamer.rank_dicts_map), which is what
+        # partition_by_chunks emits and what the receiving ranks look tensors up by. Today the only
+        # production caller happens to assign id == position, so the two agree by accident - but a caller
+        # that does not would silently receive the wrong tensor under the `files` policy.
         source_map = {
-            chunk_idx: (original_request_index, chunk_idx, request.sizes[chunk_idx])
+            chunk_idx: (request.id, chunk_idx, request.sizes[chunk_idx])
             for chunk_idx in range(len(request.sizes))
         }
 

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/partition.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/partition.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import os
 import dataclasses
 from collections import defaultdict
-from typing import List, Dict
+from typing import Dict, List, Tuple
 import humanize
 from runai_model_streamer.file_streamer import FileChunks
 

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/partition.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/partition.py
@@ -59,19 +59,20 @@ def partition_by_chunks(
         return [[] for _ in range(n)]
 
     # 1. Flatten the input `FileChunks` into a single list of `_WorkUnit`s.
+    # Zero-sized ranges are kept, not filtered: a zero-element tensor is a real safetensors entry
+    # (header shape [0, 3], data_offsets [x, x]) that the reference implementation yields, and
+    # create_torch_tensor reconstructs its shape. Dropping them here would make the distributed path
+    # yield fewer tensors than the single-process path.
     all_units: List[_WorkUnit] = []
-    for req_idx, request in enumerate(file_stream_requests):
-        current_offset = request.offset
-        for chunk_idx, chunk_size in enumerate(request.chunks):
-            if chunk_size > 0:
-                all_units.append(_WorkUnit(
-                    path=request.path,
-                    offset=current_offset,
-                    size=chunk_size,
-                    original_request_index=request.id,
-                    original_chunk_index=chunk_idx
-                ))
-            current_offset += chunk_size
+    for request in file_stream_requests:
+        for chunk_idx, (offset, size) in enumerate(zip(request.offsets, request.sizes)):
+            all_units.append(_WorkUnit(
+                path=request.path,
+                offset=offset,
+                size=size,
+                original_request_index=request.id,
+                original_chunk_index=chunk_idx
+            ))
 
     # 2. Sort the atomic work units from largest to smallest.
     all_units.sort(key=lambda u: u.size, reverse=True)
@@ -95,28 +96,32 @@ def partition_by_chunks(
             units_by_path[unit.path].append(unit)
         
         for path, units in units_by_path.items():
-            units.sort(key=lambda u: u.offset)
-            if not units:
-                continue
+            # Sorted by offset not in order to merge anything - ranges carry their own offsets now - but
+            # because the C++ assigner only coalesces ranges that arrive in ascending file order. Sorting
+            # here is what lets it turn a rank's scattered ranges back into contiguous transfers.
+            #
+            # Size breaks ties so that a zero sized range sorts BEFORE a range starting at the same
+            # offset. Placed after, it would land at the far end of the preceding range and break the
+            # transfer twice; placed before, both the file offsets and the destinations stay adjacent.
+            units.sort(key=lambda u: (u.offset, u.size))
 
-            current_fc = FileChunks(id=id_generator, path=path, offset=units[0].offset, chunks=[units[0].size])
-            current_map = {0: (units[0].original_request_index, units[0].original_chunk_index, units[0].size)}
+            # One FileChunks per path per rank. Previously a rank's units for a path were split into one
+            # FileChunks per contiguous run, which on a 66-shard model produced 16308 entries (mean run
+            # length 1.14) and 16308 duplicated path strings for 66 distinct paths.
+            new_partition.append((
+                FileChunks(
+                    id=id_generator,
+                    path=path,
+                    offsets=[unit.offset for unit in units],
+                    sizes=[unit.size for unit in units],
+                ),
+                {
+                    index: (unit.original_request_index, unit.original_chunk_index, unit.size)
+                    for index, unit in enumerate(units)
+                },
+            ))
             id_generator += 1
-            
-            for i in range(1, len(units)):
-                next_unit = units[i]
-                if current_fc.offset + sum(current_fc.chunks) == next_unit.offset:
-                    new_chunk_index = len(current_fc.chunks)
-                    current_fc.chunks.append(next_unit.size)
-                    current_map[new_chunk_index] = (next_unit.original_request_index, next_unit.original_chunk_index, next_unit.size)
-                else:
-                    new_partition.append((current_fc, current_map))
-                    current_fc = FileChunks(id=id_generator, path=path, offset=next_unit.offset, chunks=[next_unit.size])
-                    current_map = {0: (next_unit.original_request_index, next_unit.original_chunk_index, next_unit.size)}
-                    id_generator += 1
-            
-            new_partition.append((current_fc, current_map))
-        
+
         result_partitions.append(new_partition)
 
     return result_partitions
@@ -151,7 +156,7 @@ def partition_by_files(
     requests_with_indices = list(enumerate(file_stream_requests))
     sorted_requests = sorted(
         requests_with_indices,
-        key=lambda item: sum(item[1].chunks),
+        key=lambda item: item[1].total_size(),
         reverse=True
     )
 
@@ -165,12 +170,12 @@ def partition_by_files(
         # Create the source map. Since we aren't changing the chunk order within
         # the FileChunks object, the mapping is direct.
         source_map = {
-            chunk_idx: (original_request_index, chunk_idx, request.chunks[chunk_idx])
-            for chunk_idx in range(len(request.chunks))
+            chunk_idx: (original_request_index, chunk_idx, request.sizes[chunk_idx])
+            for chunk_idx in range(len(request.sizes))
         }
-        
+
         partitions[min_size_idx].append((request, source_map))
-        partition_sizes[min_size_idx] += sum(request.chunks)
+        partition_sizes[min_size_idx] += request.total_size()
 
     return partitions
 
@@ -196,12 +201,12 @@ def partition(file_stream_requests: List[FileChunks], n: int) -> List[List[Tuple
 def get_total_number_of_chunks(partitions: List[List[Tuple[FileChunks, dict]]]) -> int:
     if partitions is None or len(partitions) == 0:
         return 0
-    return sum(sum(len(fc.chunks) for fc, _ in p) for p in partitions)
+    return sum(sum(len(fc.sizes) for fc, _ in p) for p in partitions)
 
 def get_total_size_of_partition(partition: List[Tuple[FileChunks, dict]]) -> int:
     if partition is None or len(partition) == 0:
         return 0
-    return sum(sum(fc.chunks) for fc, _ in partition)
+    return sum(fc.total_size() for fc, _ in partition)
 
 def log_partition_info(partitions: List[List[Tuple[FileChunks, dict]]]):
     log_string = "[RunAI Streamer][Distributed] Partitions sizes:"

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/dist_test_distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/dist_test_distributed_streamer.py
@@ -46,7 +46,7 @@ class TestDistributedStreamer(unittest.TestCase):
                 content = torch.randint(0, 256, (spec["size"],), dtype=torch.uint8).numpy().tobytes()
                 with open(file_path, "wb") as f:
                     f.write(content)
-                file_requests.append(FileChunks(id=i, path=file_path, chunks=spec["chunks"], offset=0))
+                file_requests.append(FileChunks.contiguous(id=i, path=file_path, sizes=spec["chunks"], offset=0))
             data_bytes = pickle.dumps(file_requests)
             size_tensor = torch.tensor([len(data_bytes)], dtype=torch.long)
         else:
@@ -69,7 +69,7 @@ class TestDistributedStreamer(unittest.TestCase):
         for req in requests:
             with open(req.path, "rb") as f:
                 original_data_map[req.id] = f.read()
-        reconstructed_data_map = {req.id: [None] * len(req.chunks) for req in requests}
+        reconstructed_data_map = {req.id: [None] * len(req.sizes) for req in requests}
         env_vars = {"RUNAI_STREAMER_DIST": "1", "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0"}
         with patch.dict(os.environ, env_vars):
             with DistributedStreamer() as streamer:
@@ -128,7 +128,7 @@ class TestDistributedStreamer(unittest.TestCase):
             with open(req.path, "rb") as f:
                 original_data_map[req.id] = f.read()
 
-        reconstructed_data_map = {req.id: [None] * len(req.chunks) for req in requests}
+        reconstructed_data_map = {req.id: [None] * len(req.sizes) for req in requests}
         env_vars = {"RUNAI_STREAMER_DIST": "1", "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0"}
         with patch.dict(os.environ, env_vars):
             with DistributedStreamer() as streamer:
@@ -207,7 +207,7 @@ class TestDistributedStreamer(unittest.TestCase):
                     streamer.is_distributed,
                     "Distributed streaming should be disabled for gloo backend when RUNAI_STREAMER_DIST=auto"
                 )
-                reconstructed_data_map = {req.id: [None] * len(req.chunks) for req in requests}
+                reconstructed_data_map = {req.id: [None] * len(req.sizes) for req in requests}
                 for req_id, chunk_idx, data_tensor in streamer.get_chunks():
                     reconstructed_data_map[req_id][chunk_idx] = data_tensor.cpu().numpy().tobytes()
 

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/test_partition.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/test_partition.py
@@ -13,12 +13,18 @@ from runai_model_streamer.file_streamer import FileChunks
 
 class TestPartitioning(unittest.TestCase):
     def setUp(self):
-        """Set up a standard set of requests for use in multiple tests."""
+        """Set up a standard set of requests for use in multiple tests.
+
+        The ids are deliberately NOT the requests' positions in this list. A source map's first element is
+        the original FileChunks.id (see DistributedStreamer.rank_dicts_map), and the only production caller
+        happens to assign id == position - so fixtures that do the same cannot tell the two apart, and a
+        policy emitting positional indices would pass. These ids make that distinguishable.
+        """
         self.requests: List[FileChunks] = [
-            FileChunks.contiguous(0, path="file_A.dat", offset=1000, sizes=[100, 50, 200]), # Total: 350
-            FileChunks.contiguous(1, path="file_B.dat", offset=0, sizes=[400]),             # Total: 400
-            FileChunks.contiguous(2, path="file_A.dat", offset=5000, sizes=[80, 20]),       # Total: 100
-            FileChunks.contiguous(3, path="file_C.dat", offset=800, sizes=[300, 150]),      # Total: 450
+            FileChunks.contiguous(101, path="file_A.dat", offset=1000, sizes=[100, 50, 200]), # Total: 350
+            FileChunks.contiguous(7, path="file_B.dat", offset=0, sizes=[400]),               # Total: 400
+            FileChunks.contiguous(55, path="file_A.dat", offset=5000, sizes=[80, 20]),        # Total: 100
+            FileChunks.contiguous(23, path="file_C.dat", offset=800, sizes=[300, 150]),       # Total: 450
         ]
         self.total_size = sum(r.total_size() for r in self.requests) # 1300
 
@@ -111,6 +117,34 @@ class TestPartitioning(unittest.TestCase):
 
         self._verify_all_chunks_present(self.requests, partitions)
         self._verify_chunk_maps(self.requests, partitions)
+
+    def test_source_maps_reference_original_ids_not_positions(self):
+        """Both policies must key the source map on the original FileChunks.id.
+
+        The receiving ranks look a tensor up by the id carried in the broadcast metadata
+        (DistributedStreamer.rank_dicts_map -> safetensors metadata), so a policy that emitted the
+        request's POSITION in the input list would hand back the wrong tensor whenever the caller's ids
+        are not 0..n-1. Asserted for both policies together because they are interchangeable behind
+        RUNAI_STREAMER_PARTITION_POLICY and must agree on this.
+        """
+        original_ids = {request.id for request in self.requests}
+        positions = set(range(len(self.requests)))
+        self.assertTrue(original_ids.isdisjoint(positions),
+                        "fixture must use ids that are not positions, or this test proves nothing")
+
+        for policy in (partition_by_files, partition_by_chunks):
+            for n in (1, 3, 5):
+                mapped_ids = {
+                    source_id
+                    for partition in policy(self.requests, n)
+                    for _new_fc, source_map in partition
+                    for source_id, _chunk_idx, _size in source_map.values()
+                }
+                self.assertEqual(
+                    mapped_ids, original_ids,
+                    f"{policy.__name__} with n={n} mapped to {sorted(mapped_ids)}; "
+                    f"expected the original ids {sorted(original_ids)}",
+                )
 
     def test_partition_by_chunks(self):
         """Tests for the partition_by_chunks function."""

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/test_partition.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/test_partition.py
@@ -1,4 +1,5 @@
 import unittest
+from collections import Counter
 from typing import List, Dict, Tuple
 
 # Assuming the classes and functions are in these locations for the test.
@@ -6,6 +7,7 @@ from typing import List, Dict, Tuple
 from runai_model_streamer.distributed_streamer.partition import (
     partition_by_chunks,
     partition_by_files,
+    get_total_number_of_chunks,
 )
 from runai_model_streamer.file_streamer import FileChunks
 
@@ -13,83 +15,72 @@ class TestPartitioning(unittest.TestCase):
     def setUp(self):
         """Set up a standard set of requests for use in multiple tests."""
         self.requests: List[FileChunks] = [
-            FileChunks(0, path="file_A.dat", offset=1000, chunks=[100, 50, 200]), # Total: 350
-            FileChunks(1, path="file_B.dat", offset=0, chunks=[400]),             # Total: 400
-            FileChunks(2, path="file_A.dat", offset=5000, chunks=[80, 20]),       # Total: 100
-            FileChunks(3, path="file_C.dat", offset=800, chunks=[300, 150]),      # Total: 450
+            FileChunks.contiguous(0, path="file_A.dat", offset=1000, sizes=[100, 50, 200]), # Total: 350
+            FileChunks.contiguous(1, path="file_B.dat", offset=0, sizes=[400]),             # Total: 400
+            FileChunks.contiguous(2, path="file_A.dat", offset=5000, sizes=[80, 20]),       # Total: 100
+            FileChunks.contiguous(3, path="file_C.dat", offset=800, sizes=[300, 150]),      # Total: 450
         ]
-        self.total_size = sum(sum(r.chunks) for r in self.requests) # 1300
+        self.total_size = sum(r.total_size() for r in self.requests) # 1300
 
     def _get_partition_total_size(self, partition: List[Tuple[FileChunks, dict]]) -> int:
         """Helper to calculate the total byte size of a single partition."""
-        return sum(sum(fc.chunks) for fc, _ in partition)
+        return sum(fc.total_size() for fc, _ in partition)
 
     def _verify_all_chunks_present(self, original_requests: List[FileChunks], partitions: List[List[Tuple[FileChunks, dict]]]):
         """
-        Verifies that every individual chunk from the original requests is present
-        in the output partitions, preserving path, offset, and size.
-        """
-        original_chunks_set = set()
-        for req in original_requests:
-            current_offset = req.offset
-            for chunk_size in req.chunks:
-                # The partition function intentionally ignores zero-sized chunks,
-                # so we must ignore them in our verification set as well.
-                if chunk_size > 0:
-                    original_chunks_set.add((req.path, current_offset, chunk_size))
-                current_offset += chunk_size
+        Verifies that every individual range from the original requests is present in the output
+        partitions, preserving path, offset, and size.
 
-        output_chunks_set = set()
-        for partition in partitions:
-            for fc, _ in partition:
-                current_offset = fc.offset
-                for chunk_size in fc.chunks:
-                    output_chunks_set.add((fc.path, current_offset, chunk_size))
-                    current_offset += chunk_size
-        
-        self.assertEqual(original_chunks_set, output_chunks_set, 
-                         "All original non-zero chunks must be present in the output partitions with correct path, offset, and size")
+        Counted as a multiset, not a set: zero-sized ranges share an offset with the range that
+        follows them, so two of them at the same offset are indistinguishable as tuples and a set
+        would silently collapse them.
+        """
+        def census(requests):
+            counter = Counter()
+            for req in requests:
+                for offset, size in zip(req.offsets, req.sizes):
+                    counter[(req.path, offset, size)] += 1
+            return counter
+
+        original = census(original_requests)
+        output = census([fc for partition in partitions for fc, _ in partition])
+
+        self.assertEqual(original, output,
+                         "Every original range must be present in the output partitions with correct path, offset, and size")
 
     def _verify_chunk_maps(self, original_requests: List[FileChunks], partitions: List[List[Tuple[FileChunks, dict]]]):
-        """Verifies the correctness of the source maps for partitioned chunks."""
+        """Verifies the correctness of the source maps for partitioned ranges."""
         total_mapped_chunks = 0
         original_chunk_data = {}
-        for req_idx, req in enumerate(original_requests):
-            current_offset = req.offset
-            for chunk_idx, chunk_size in enumerate(req.chunks):
-                if chunk_size > 0:
-                    original_chunk_data[(req_idx, chunk_idx)] = (req.path, current_offset, chunk_size)
-                current_offset += chunk_size
-        
+        for req in original_requests:
+            for chunk_idx, (offset, size) in enumerate(zip(req.offsets, req.sizes)):
+                original_chunk_data[(req.id, chunk_idx)] = (req.path, offset, size)
+
         for partition in partitions:
             for new_fc, source_map in partition:
                 total_mapped_chunks += len(source_map)
-                new_fc_offset = new_fc.offset
                 for new_chunk_idx, (orig_req_idx, orig_chunk_idx, map_chunk_size) in source_map.items():
                     original_pos_tuple = (orig_req_idx, orig_chunk_idx)
                     self.assertIn(original_pos_tuple, original_chunk_data)
-                    
-                    orig_path, orig_offset, orig_size = original_chunk_data[original_pos_tuple]
-                    new_chunk_size = new_fc.chunks[new_chunk_idx]
 
-                    self.assertEqual(new_chunk_size, orig_size, "Chunk size in new object must match original")
-                    self.assertEqual(map_chunk_size, orig_size, "Chunk size in map must match original")
-                    
-                    new_chunk_internal_offset = sum(new_fc.chunks[:new_chunk_idx])
-                    new_chunk_abs_offset = new_fc_offset + new_chunk_internal_offset
-                    self.assertEqual(new_chunk_abs_offset, orig_offset, "Absolute offset must match original")
+                    orig_path, orig_offset, orig_size = original_chunk_data[original_pos_tuple]
+
+                    self.assertEqual(new_fc.sizes[new_chunk_idx], orig_size, "Range size in new object must match original")
+                    self.assertEqual(map_chunk_size, orig_size, "Range size in map must match original")
+                    # the offset is carried, not derived from a prefix sum over the preceding sizes
+                    self.assertEqual(new_fc.offsets[new_chunk_idx], orig_offset, "Offset must match original")
                     self.assertEqual(new_fc.path, orig_path, "Path must match original")
 
-        self.assertEqual(len(original_chunk_data), total_mapped_chunks, "Total number of mapped chunks must equal total original non-zero chunks")
+        self.assertEqual(len(original_chunk_data), total_mapped_chunks, "Total number of mapped ranges must equal total original ranges")
 
     def test_partition_by_files(self):
         """Tests for the partition_by_files function."""
         # Test case 1: Basic partitioning into 3 parts
         n = 3
         partitions = partition_by_files(self.requests, n)
-        
+
         self.assertEqual(len(partitions), n, "Should return the correct number of partitions")
-        
+
         partition_sizes = [self._get_partition_total_size(p) for p in partitions]
         self.assertEqual(sum(partition_sizes), self.total_size, "Total size should be conserved")
         self.assertCountEqual(partition_sizes, [450, 400, 450])
@@ -102,7 +93,7 @@ class TestPartitioning(unittest.TestCase):
         partitions = partition_by_files(self.requests, n)
         self.assertEqual(len(partitions), n)
         self.assertEqual(self._get_partition_total_size(partitions[0]), self.total_size)
-        
+
         self._verify_all_chunks_present(self.requests, partitions)
         self._verify_chunk_maps(self.requests, partitions)
 
@@ -117,7 +108,7 @@ class TestPartitioning(unittest.TestCase):
         self.assertEqual(len(partitions), n)
         self.assertEqual(sum(self._get_partition_total_size(p) for p in partitions), self.total_size)
         self.assertTrue(any(len(p) == 0 for p in partitions))
-        
+
         self._verify_all_chunks_present(self.requests, partitions)
         self._verify_chunk_maps(self.requests, partitions)
 
@@ -126,7 +117,7 @@ class TestPartitioning(unittest.TestCase):
         # Test case 1: Basic partitioning into 3 parts
         n = 3
         partitions = partition_by_chunks(self.requests, n)
-        
+
         self.assertEqual(len(partitions), n, "Should return the correct number of partitions")
 
         partition_sizes = [self._get_partition_total_size(p) for p in partitions]
@@ -141,30 +132,64 @@ class TestPartitioning(unittest.TestCase):
         partitions = partition_by_chunks(self.requests, n)
         self.assertEqual(len(partitions), n)
         self.assertEqual(self._get_partition_total_size(partitions[0]), self.total_size)
-        
+
         self._verify_all_chunks_present(self.requests, partitions)
         self._verify_chunk_maps(self.requests, partitions)
 
-        # Test case 3: Test re-merging of contiguous chunks
+    def test_one_file_chunks_per_path_per_rank(self):
+        """A rank's ranges for a path are emitted as a single FileChunks, whether or not they are
+        contiguous. Previously the reconstruction split them into one FileChunks per contiguous run,
+        which on a 66-shard model produced 16308 entries with a mean run length of 1.14."""
         contiguous_requests = [
-            FileChunks(0, path="A", offset=0, chunks=[10, 20]),
-            FileChunks(1, path="A", offset=30, chunks=[5])
+            FileChunks.contiguous(0, path="A", offset=0, sizes=[10, 20]),
+            FileChunks.contiguous(1, path="A", offset=30, sizes=[5]),
         ]
         partitions = partition_by_chunks(contiguous_requests, 1)
-        self.assertEqual(len(partitions[0]), 1, "All contiguous chunks should be merged")
-        
-        new_fc, source_map = partitions[0][0]
-        self.assertEqual(new_fc.offset, 0)
-        self.assertListEqual(new_fc.chunks, [10, 20, 5])
-        
+        self.assertEqual(len(partitions[0]), 1)
+
+        new_fc, _ = partitions[0][0]
+        self.assertListEqual(new_fc.offsets, [0, 10, 30])
+        self.assertListEqual(new_fc.sizes, [10, 20, 5])
+
         self._verify_all_chunks_present(contiguous_requests, partitions)
         self._verify_chunk_maps(contiguous_requests, partitions)
 
+    def test_non_contiguous_ranges_share_one_file_chunks(self):
+        """Ranges carry their own offsets, so a gap no longer forces a second FileChunks."""
+        gapped_requests = [
+            FileChunks.contiguous(0, path="A", offset=0, sizes=[10]),
+            FileChunks.contiguous(1, path="A", offset=9000, sizes=[10]),
+        ]
+        partitions = partition_by_chunks(gapped_requests, 1)
+        self.assertEqual(len(partitions[0]), 1)
+
+        new_fc, _ = partitions[0][0]
+        self.assertListEqual(new_fc.offsets, [0, 9000])
+        self.assertListEqual(new_fc.sizes, [10, 10])
+
+        self._verify_all_chunks_present(gapped_requests, partitions)
+        self._verify_chunk_maps(gapped_requests, partitions)
+
+    def test_ranges_are_sorted_by_offset(self):
+        """Sorting is what lets the C++ assigner coalesce a rank's ranges back into contiguous
+        transfers - it only merges ranges that arrive in ascending file order."""
+        requests = [FileChunks(0, path="A", offsets=[500, 0, 250], sizes=[10, 10, 10])]
+        partitions = partition_by_chunks(requests, 1)
+
+        new_fc, _ = partitions[0][0]
+        self.assertListEqual(new_fc.offsets, [0, 250, 500])
+
     def test_partition_by_chunks_with_zero_size_chunks(self):
-        """Tests that zero-sized chunks are correctly handled (ignored)."""
+        """Zero-sized ranges are kept, not dropped.
+
+        A zero-element tensor is a real safetensors entry that the reference implementation yields
+        with its shape intact, and the C++ layer answers one response per range including this one.
+        Dropping them here would make the distributed path yield fewer tensors than the
+        single-process path.
+        """
         requests_with_zero = [
-            FileChunks(0, path="Z.dat", offset=0, chunks=[10, 50, 0, 100]),
-            FileChunks(1, path="Y.dat", offset=10, chunks=[0, 0, 25])
+            FileChunks.contiguous(0, path="Z.dat", offset=0, sizes=[10, 50, 0, 100]),
+            FileChunks.contiguous(1, path="Y.dat", offset=10, sizes=[0, 0, 25]),
         ]
         n = 2
         partitions = partition_by_chunks(requests_with_zero, n)
@@ -174,8 +199,22 @@ class TestPartitioning(unittest.TestCase):
         expected_size = (10 + 50 + 100) + 25
         self.assertEqual(total_size, expected_size)
 
+        # every range is accounted for, the zero-sized ones included
+        self.assertEqual(get_total_number_of_chunks(partitions), 7)
+
         self._verify_all_chunks_present(requests_with_zero, partitions)
         self._verify_chunk_maps(requests_with_zero, partitions)
+
+    def test_zero_sized_range_sorts_before_a_range_at_the_same_offset(self):
+        """A zero-sized range shares the offset of whatever follows it. Sorted after that range it
+        would land at the far end of it and break the contiguous transfer twice; sorted before, both
+        the file offsets and the destinations stay adjacent and the transfer survives."""
+        requests = [FileChunks.contiguous(0, path="A", offset=0, sizes=[10, 0, 50])]
+        partitions = partition_by_chunks(requests, 1)
+
+        new_fc, _ = partitions[0][0]
+        self.assertListEqual(new_fc.offsets, [0, 10, 10])
+        self.assertListEqual(new_fc.sizes, [10, 0, 50])
 
     def tearDown(self):
         """No cleanup needed for these tests."""
@@ -183,4 +222,3 @@ class TestPartitioning(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -207,39 +207,62 @@ class FileStreamer:
         # Only one submission is in flight at a time (get_chunks fully drains the active request before
         # submitting the next), so every response here belongs to self.submission_id and the count loop is
         # exact. runai_response blocks indefinitely (timeout 0) and returns None only on teardown.
-        for i in range(self.active_request.num_ranges):
-            response = runai_response(self.streamer)
-            if response is None:
-                return
-            ret, submission_id, file_relative_index, chunk_relative_index, _submission_done = response
-            # Single-submission invariant: FileStreamer drains one submission fully before starting the next,
-            # so every response must belong to self.submission_id. This catches a stale response from a prior
-            # (e.g. failed) submission being misattributed to this one and returning wrong data. Use if/raise
-            # (not assert) so this data-integrity check is not stripped under `python -O`.
-            # REMOVE THIS for the ring buffer: FileStreamer will then manage CONCURRENT submissions and
-            # request_ready_chunks must demux responses by submission_id instead of enforcing a single one.
-            if submission_id != self.submission_id:
-                raise ValueError(
-                    f"response for submission {submission_id} but expected {self.submission_id}"
-                )
-            # single-submission streaming: any per-sub-range error fails the whole stream (fail-fast)
-            if ret != SUCCESS_ERROR_CODE:
-                raise ValueError(
-                    f"Could not receive response from libstreamer due to: {runai_response_str(ret)}"
-                )
+        num_ranges = self.active_request.num_ranges
+        consumed = 0
+        try:
+            for i in range(num_ranges):
+                response = runai_response(self.streamer)
+                if response is None:
+                    return
+                consumed += 1
+                ret, submission_id, file_relative_index, chunk_relative_index, _submission_done = response
+                # Single-submission invariant: FileStreamer drains one submission fully before starting the next,
+                # so every response must belong to self.submission_id. This catches a stale response from a prior
+                # (e.g. failed) submission being misattributed to this one and returning wrong data. Use if/raise
+                # (not assert) so this data-integrity check is not stripped under `python -O`.
+                # REMOVE THIS for the ring buffer: FileStreamer will then manage CONCURRENT submissions and
+                # request_ready_chunks must demux responses by submission_id instead of enforcing a single one.
+                if submission_id != self.submission_id:
+                    raise ValueError(
+                        f"response for submission {submission_id} but expected {self.submission_id}"
+                    )
+                # single-submission streaming: any per-sub-range error fails the whole stream (fail-fast)
+                if ret != SUCCESS_ERROR_CODE:
+                    raise ValueError(
+                        f"Could not receive response from libstreamer due to: {runai_response_str(ret)}"
+                    )
 
-            file_path, chunk_index, chunk_buffer = self.requests_iterator.get_global_file_and_chunk(file_relative_index, chunk_relative_index)
-            # create one dimensional tensor from the chunk buffer
-            # we return a tensor of shape (1, chunk_buffer.size)
-            # the data type of the original chunk_buffer, as created by the requests_iterator, is preserved (uint8)
-            tensor = torch.from_numpy(chunk_buffer).view(1, -1)
+                file_path, chunk_index, chunk_buffer = self.requests_iterator.get_global_file_and_chunk(file_relative_index, chunk_relative_index)
+                # create one dimensional tensor from the chunk buffer
+                # we return a tensor of shape (1, chunk_buffer.size)
+                # the data type of the original chunk_buffer, as created by the requests_iterator, is preserved (uint8)
+                tensor = torch.from_numpy(chunk_buffer).view(1, -1)
 
-            # currently file streamer is always reading a cpu buffer
-            # so we don't need to move the tensor to the device
-            # for future GDS/CUDA support we will need to move the tensor to the device (cpu or different device)
-            if self.device_str == "cpu":
-                yield file_path, chunk_index, tensor
-            else:
-                device_tensor = tensor.to(self.device_str)
-                yield file_path, chunk_index, device_tensor
+                # currently file streamer is always reading a cpu buffer
+                # so we don't need to move the tensor to the device
+                # for future GDS/CUDA support we will need to move the tensor to the device (cpu or different device)
+                if self.device_str == "cpu":
+                    yield file_path, chunk_index, tensor
+                else:
+                    device_tensor = tensor.to(self.device_str)
+                    yield file_path, chunk_index, device_tensor
+        finally:
+            # The submission must be drained however this generator ends, not only when it runs to
+            # completion. range_dsts are raw addresses into the requests iterator's buffer, so a range still
+            # in flight writes into memory the next stream_files has already freed and handed to the next
+            # submission - and its late response is then delivered to that submission's drain loop, which
+            # rejects it and abandons ITS responses in turn, so the streamer never recovers.
+            # A finally covers both exits: the fail-fast raises above, and a caller abandoning the generator
+            # (break, or raising inside its for loop - which safetensors_pytorch does), since closing a
+            # generator resumes it here.
+            self.drain_active_submission(num_ranges - consumed)
+
+    def drain_active_submission(self, remaining: int) -> None:
+        # self.streamer is already cleared if the generator is collected after __exit__; runai_end has joined
+        # the workers by then, so there is nothing left to wait for and the handle must not be touched.
+        if not self.streamer:
+            return
+        for _ in range(remaining):
+            if runai_response(self.streamer) is None:
+                return   # teardown: no further responses are coming
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -163,13 +163,24 @@ class FileStreamer:
         if self.active_request is None:
             return
 
+        self.submit_active_request()
+
+    def submit_active_request(self) -> None:
+        # The three range arrays are flat and grouped by file, in the order of paths - which is the order
+        # the request's files are in, and the order range_dsts was built in, so it passes through as is.
+        #
+        # range_dsts are RAW ADDRESSES into the requests iterator's buffer: they keep nothing alive. The
+        # buffer must outlive the submission, until its last response has been consumed. That holds here
+        # because self.requests_iterator owns the buffer and is only replaced by the next stream_files,
+        # which cannot start before get_chunks has drained this one.
+        request = self.active_request
         self.submission_id = runai_request(
             self.streamer,
-            [file_request.path for file_request in self.active_request.files],
-            [file_request.offset for file_request in self.active_request.files],
-            [sum(file_request.chunks) for file_request in self.active_request.files],
-            self.requests_iterator.file_buffers,
-            [file_request.chunks for file_request in self.active_request.files],
+            [file_request.path for file_request in request.files],
+            [len(file_request.sizes) for file_request in request.files],
+            [offset for file_request in request.files for offset in file_request.offsets],
+            [size for file_request in request.files for size in file_request.sizes],
+            request.range_dsts,
         )
 
     def get_chunks(self) -> Iterator:
@@ -187,14 +198,7 @@ class FileStreamer:
             if self.active_request is None:
                 break
 
-            self.submission_id = runai_request(
-                self.streamer,
-                [file_request.path for file_request in self.active_request.files],
-                [file_request.offset for file_request in self.active_request.files],
-                [sum(file_request.chunks) for file_request in self.active_request.files],
-                self.requests_iterator.file_buffers,
-                [file_request.chunks for file_request in self.active_request.files],
-            )
+            self.submit_active_request()
 
     # This function iterates over indexes of ready chunks.
     # The indexes are relative to the last request that sent
@@ -203,7 +207,7 @@ class FileStreamer:
         # Only one submission is in flight at a time (get_chunks fully drains the active request before
         # submitting the next), so every response here belongs to self.submission_id and the count loop is
         # exact. runai_response blocks indefinitely (timeout 0) and returns None only on teardown.
-        for i in range(sum(len(file_request.chunks) for file_request in self.active_request.files)):
+        for i in range(self.active_request.num_ranges):
             response = runai_response(self.streamer)
             if response is None:
                 return

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -23,29 +23,65 @@ class MemoryCapMode(enum.Enum):
     largest_chunk = 3
 
 class FileChunks:
-    def __init__(self, id: int, path: str, offset: int, chunks: List[int]) -> None:
+    """One file plus the ranges to read from it. A range is an arbitrary (offset, size) within the
+    file: ranges need not be contiguous with each other and need not be ordered.
+
+    offsets and sizes are parallel lists rather than a list of (offset, size) pairs because they are
+    exactly the C layer's range_offsets / range_sizes arrays - they pass through with no per-range
+    object, which matters at a few hundred thousand tensors per model."""
+
+    def __init__(self, id: int, path: str, offsets: List[int], sizes: List[int]) -> None:
+        if len(offsets) != len(sizes):
+            raise ValueError(
+                f"offsets ({len(offsets)}) and sizes ({len(sizes)}) must be parallel"
+            )
         self.id = id # the id of the file chunk must be unique in the context of a single stream_files request
         self.path = path
-        self.offset = offset
-        self.chunks = chunks
+        self.offsets = offsets
+        self.sizes = sizes
+
+    @staticmethod
+    def contiguous(id: int, path: str, offset: int, sizes: List[int]) -> "FileChunks":
+        """The common case: sizes laid out back to back in the file, starting at offset."""
+        offsets = []
+        running = offset
+        for size in sizes:
+            offsets.append(running)
+            running += size
+        return FileChunks(id, path, offsets, sizes)
 
     def total_size(self) -> int:
-        return sum(self.chunks)
+        return sum(self.sizes)
 
     def max_chunk_size(self) -> int:
-        return max(self.chunks)
+        return max(self.sizes)
 
     def __repr__(self) -> str:
         """Provides a clear string representation for the object."""
-        return (f"FileChunks(id='{self.id}', path='{self.path}', offset={self.offset}, "
-                f"num_chunks={len(self.chunks)}, total_size={self.total_size()})")
+        return (f"FileChunks(id='{self.id}', path='{self.path}', "
+                f"num_ranges={len(self.sizes)}, total_size={self.total_size()})")
 
 class FilesRequest:
+    """One submission: the files to read, plus a destination for every range.
+
+    range_dsts is flat and in flattened range order (file 0's ranges, then file 1's, ...) - it IS the
+    array handed to runai_request, and the same array response-time lookup indexes. file_base holds
+    each file's first flat position, so mapping a response's (file_index, range_index) to a
+    destination is O(1) rather than a prefix-sum walk per response."""
+
     def __init__(self) -> None:
         self.files: List[FileChunks] = []
+        self.file_base: List[int] = []
+        self.num_ranges = 0
+        self.range_dsts: List[int] = []
 
     def append(self, file_chunks: FileChunks) -> None:
+        self.file_base.append(self.num_ranges)
+        self.num_ranges += len(file_chunks.sizes)
         self.files.append(file_chunks)
+
+    def flat_index(self, file_index: int, range_index: int) -> int:
+        return self.file_base[file_index] + range_index
 
 
 class FilesRequestsIteratorWithBuffer:
@@ -55,32 +91,37 @@ class FilesRequestsIteratorWithBuffer:
             f"[RunAI Streamer] CPU Buffer size: {humanize.naturalsize(buffer_size, binary=True)} for files: {[file_chunks.path for file_chunks in files_chunks]}"
         )
         self.buffer = np.empty(buffer_size, dtype=np.uint8)
-        self.file_buffers = []
+        # The buffer's base address. Destinations are absolute addresses (that is the C contract), and
+        # this class packs them itself, so it can recover a range's slice of the buffer by subtracting
+        # the base. That is local knowledge of its own allocation, not an assumption the range API makes.
+        self.buffer_address = self.buffer.ctypes.data
 
-    def get_global_file_and_chunk(self, local_file_index: int, local_chunk_index: int) -> Tuple[str, int, memoryview]:
-        file_id, global_chunk_index = self.files_requests_iterator.get_global_file_and_chunk(
-            local_file_index, local_chunk_index
+    def get_global_file_and_chunk(self, local_file_index: int, local_range_index: int) -> Tuple[str, int, memoryview]:
+        file_id, global_range_index = self.files_requests_iterator.get_global_file_and_chunk(
+            local_file_index, local_range_index
         )
-        file_buffer = self.file_buffers[local_file_index]
-
-        file_active_chunks = self.files_requests_iterator.active_request.files[local_file_index].chunks
-        chunk_offset_start = sum(file_active_chunks[:local_chunk_index])
-        chunk_offset_end = chunk_offset_start + file_active_chunks[local_chunk_index]
-        return file_id, global_chunk_index, file_buffer[chunk_offset_start: chunk_offset_end]
+        request = self.files_requests_iterator.active_request
+        start = request.range_dsts[request.flat_index(local_file_index, local_range_index)] - self.buffer_address
+        size = request.files[local_file_index].sizes[local_range_index]
+        return file_id, global_range_index, self.buffer[start: start + size]
 
     def next_request(self) -> Optional[FilesRequest]:
-        next_requests = self.files_requests_iterator.next_request()
-        if next_requests is None or len(next_requests.files) == 0:
+        request = self.files_requests_iterator.next_request()
+        if request is None or len(request.files) == 0:
             return None
 
-        self.file_buffers = []
-        global_buffer_offset = 0
-        for file_request in next_requests.files:
-            chunks_size = sum(file_request.chunks)
-            self.file_buffers.append(self.buffer[global_buffer_offset: global_buffer_offset + chunks_size])
-            global_buffer_offset += chunks_size
-            
-        return next_requests
+        # Pack this request's ranges back to back into the buffer, one absolute address per range.
+        # Placement is free now (each range carries its own destination), so packing is just a running
+        # cursor - no per-file sub-buffer, and no requirement that a file's ranges be adjacent.
+        dsts = []
+        cursor = self.buffer_address
+        for file_chunks in request.files:
+            for size in file_chunks.sizes:
+                dsts.append(cursor)
+                cursor += size
+        request.range_dsts = dsts
+
+        return request
 
     @staticmethod
     def with_memory_cap(
@@ -90,20 +131,20 @@ class FilesRequestsIteratorWithBuffer:
     ) -> FilesRequestsIteratorWithBuffer:
         memory_limit = 0
         if memory_mode == MemoryCapMode.unlimited:
-            memory_limit = sum(sum(file.chunks) for file in files_chunks)
+            memory_limit = sum(file.total_size() for file in files_chunks)
         elif memory_mode == MemoryCapMode.largest_chunk:
-            memory_limit = max(max(file_chunks.chunks) for file_chunks in files_chunks)
+            memory_limit = _largest_range(files_chunks)
         elif memory_mode == MemoryCapMode.limited:
             if user_memory_limit is None:
                 raise RunaiStreamerMemoryLimitException(
                     f"MemoryCapMode is Limited, but no limit supplied"
                 )
-            largest_chunk = max((max(file_chunks.chunks, default=0) for file_chunks in files_chunks), default=0)
+            largest_chunk = _largest_range(files_chunks)
             if user_memory_limit < largest_chunk:
                 raise RunaiStreamerMemoryLimitException(
                     f"Memory limit supplied: {user_memory_limit} cannot be smaller than: {largest_chunk}"
                 )
-            memory_limit = min(user_memory_limit, sum(sum(file.chunks) for file in files_chunks))
+            memory_limit = min(user_memory_limit, sum(file.total_size() for file in files_chunks))
  
         return FilesRequestsIteratorWithBuffer(memory_limit, files_chunks)
 
@@ -143,8 +184,8 @@ class FilesRequestsIterator:
         
         if self.active_request is not None:
             for file_chunks in self.active_request.files:
-                self.file_to_current_chunk_index[file_chunks.id] += len(file_chunks.chunks)
-            
+                self.file_to_current_chunk_index[file_chunks.id] += len(file_chunks.sizes)
+
         files_request = FilesRequest()
         current_request_memory_size = 0
         while self.q:
@@ -156,20 +197,24 @@ class FilesRequestsIterator:
             if finished:
                 self.q.popleft()
             
-            if len(file_chunks.chunks) == 0 or sum(file_chunks.chunks) == 0:
+            if len(file_chunks.sizes) == 0:
                 if finished:
-                    # The file itself has no data to stream (e.g. an empty
+                    # The file itself has no range to stream (e.g. an empty
                     # safetensors shard): skip it and keep packing from the
                     # next file. Terminating here would silently drop every
                     # remaining file in the queue.
                     continue
-                # The next chunk does not fit into this request's remaining
+                # The next range does not fit into this request's remaining
                 # buffer budget: close this request; the file stays queued
                 # for the next request.
                 break
 
+            # Note the condition above is on the RANGE COUNT, not the byte total: a file that
+            # contributed only zero-sized ranges is a real contribution. The C++ layer answers a
+            # zero-sized range like any other, and the caller's tensor indexing counts on exactly
+            # one response per range.
             files_request.append(file_chunks)
-            current_request_memory_size += sum(file_chunks.chunks)
+            current_request_memory_size += file_chunks.total_size()
 
         if len(files_request.files) == 0:
             files_request = None
@@ -177,46 +222,40 @@ class FilesRequestsIterator:
         return files_request
 
 class FileChunksIterator:
+    """Hands out prefixes of a file's ranges, each fitting a caller-supplied byte budget. Ranges carry
+    their own offsets now, so this is a slice of both parallel lists - no running offset to track."""
 
     def __init__(
         self, file_chunks: FileChunks
     ) -> None:
         self.id = file_chunks.id
         self.path = file_chunks.path
-        self.next_request_offset = file_chunks.offset
-        self.chunks_iterator = ChunksIterator(file_chunks.chunks)
+        self.offsets = file_chunks.offsets
+        self.sizes = file_chunks.sizes
+        self.next_index = 0
 
     def is_finished(self) -> bool:
-        return self.chunks_iterator.is_finished()
+        return self.next_index >= len(self.sizes)
 
     def next_chunks(self, size: int) -> FileChunks:
-        chunks = self.chunks_iterator.next_chunks(size)
-        starting_offset = self.next_request_offset
-        self.next_request_offset += sum(chunks)
-        return FileChunks(self.id, self.path, starting_offset, chunks)
+        start = self.next_index
+        end = start
+        remaining = size
+        while end < len(self.sizes) and self.sizes[end] <= remaining:
+            remaining -= self.sizes[end]
+            end += 1
+        self.next_index = end
+        return FileChunks(self.id, self.path, self.offsets[start:end], self.sizes[start:end])
 
-class ChunksIterator:
-    def __init__(
-        self, chunks: List[int]
-    ) -> None:
-        self.q = deque(chunks)
+def _largest_range(files_chunks: List[FileChunks]) -> int:
+    """The largest single range across all the files, or 0 when there is none.
 
-    def is_finished(self) -> bool:
-        return len(self.q) == 0
+    Both defaults are load bearing: a file may carry no ranges at all (an empty safetensors shard),
+    and the file list itself may be empty (stream_files([])). This is the buffer's lower bound - a
+    request must be able to hold at least one range, or next_request would return an empty request,
+    which the caller reads as end of stream."""
+    return max((max(file_chunks.sizes, default=0) for file_chunks in files_chunks), default=0)
 
-    def next_chunks(self, size: int) -> List[int]:
-        chunks = []
-        current_request_size = 0
-
-        while not self.is_finished():
-            candidate_chunk = self.q[0]
-            if current_request_size + candidate_chunk > size:
-                return chunks
-
-            chunks.append(self.q.popleft())
-            current_request_size += candidate_chunk
-
-        return chunks
 
 def _get_memory_mode(memory_limit: str | None) -> MemoryCapMode:
     if memory_limit == "-1":

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -257,7 +257,7 @@ def _largest_range(files_chunks: List[FileChunks]) -> int:
     return max((max(file_chunks.sizes, default=0) for file_chunks in files_chunks), default=0)
 
 
-def _get_memory_mode(memory_limit: str | None) -> MemoryCapMode:
+def _get_memory_mode(memory_limit: Optional[str]) -> MemoryCapMode:
     if memory_limit == "-1":
         return MemoryCapMode.unlimited
     elif memory_limit == "0":

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
@@ -27,7 +27,7 @@ class TestBindings(unittest.TestCase):
             3: {"expected_text": "Test-Text3"},
         }
         with FileStreamer() as fs:
-            fs.stream_files([FileChunks(file_id, file_path, 1, request_sizes)])
+            fs.stream_files([FileChunks.contiguous(file_id, file_path, 1, request_sizes)])
             seen = set()
             for res_file_id, id, dst in fs.get_chunks():
                 seen.add(id)
@@ -55,7 +55,7 @@ class TestBindings(unittest.TestCase):
             2: {"expected_text": "Test-Text3"},
         }
         with FileStreamer() as fs:
-            fs.stream_files([FileChunks(file_id, file_path, 1, request_sizes)])
+            fs.stream_files([FileChunks.contiguous(file_id, file_path, 1, request_sizes)])
             seen = set()
             for res_file_id, id, dst in fs.get_chunks():
                 seen.add(id)
@@ -92,7 +92,7 @@ class TestBindings(unittest.TestCase):
             8: {"expected_text": "I"},
         }
         with FileStreamer() as fs:
-            fs.stream_files([FileChunks(file_id, file_path, 1, request_sizes)])
+            fs.stream_files([FileChunks.contiguous(file_id, file_path, 1, request_sizes)])
             seen = set()
             for res_file_id, id, dst, in fs.get_chunks():
                 seen.add(id)
@@ -104,6 +104,41 @@ class TestBindings(unittest.TestCase):
             # every range produced exactly one response (full drain across multiple buffer requests)
             self.assertEqual(seen, set(id_to_results))
 
+    def test_empty_file_first_does_not_drop_the_rest(self):
+        # end-to-end regression for issue #157: an empty shard ahead of a data shard used to close the
+        # request, which get_chunks reads as end of stream, silently dropping every remaining file
+        empty_path = os.path.join(self.temp_dir, "empty.txt")
+        open(empty_path, "w").close()
+        data_path = os.path.join(self.temp_dir, "data.txt")
+        with open(data_path, "w") as file:
+            file.write("HelloWorld")
+
+        with FileStreamer() as fs:
+            fs.stream_files([
+                FileChunks(17, empty_path, [], []),
+                FileChunks.contiguous(18, data_path, 0, [5, 5]),
+            ])
+            results = [(file_id, index, dst.numpy().tobytes().decode("utf-8"))
+                       for file_id, index, dst in fs.get_chunks()]
+
+        self.assertEqual(sorted(results), [(18, 0, "Hello"), (18, 1, "World")])
+
+    def test_file_of_only_zero_sized_ranges_is_answered(self):
+        # A file whose tensors are all zero sized is not an empty shard - it has header entries, and
+        # safetensors yields those tensors. Each zero-sized range must still get its own response, or
+        # the caller's tensor indexing drifts. This used to be skipped in Python because the C++ layer
+        # could not answer a zero-sized range (an empty batch range never completed its tasks).
+        file_path = os.path.join(self.temp_dir, "zeros.txt")
+        with open(file_path, "w") as file:
+            file.write("content")
+
+        with FileStreamer() as fs:
+            fs.stream_files([FileChunks.contiguous(17, file_path, 0, [0, 0, 0])])
+            results = [(file_id, index, len(dst.numpy().tobytes()))
+                       for file_id, index, dst in fs.get_chunks()]
+
+        self.assertEqual(sorted(results), [(17, 0, 0), (17, 1, 0), (17, 2, 0)])
+
     def test_get_chunks_raises_on_read_error(self):
         # FileStreamer is single-submission and fail-fast: a per-sub-range error from the streamer must raise
         # out of get_chunks (the low-level binding no longer raises, so FileStreamer itself enforces this).
@@ -114,7 +149,7 @@ class TestBindings(unittest.TestCase):
             file.write("short")   # 5 bytes
 
         with FileStreamer() as fs:
-            fs.stream_files([FileChunks(file_id, file_path, 0, [20])])   # one 20-byte range from a 5-byte file
+            fs.stream_files([FileChunks.contiguous(file_id, file_path, 0, [20])])   # one 20-byte range from a 5-byte file
             with self.assertRaises(ValueError):
                 list(fs.get_chunks())
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -1,6 +1,5 @@
 import unittest
 from runai_model_streamer.file_streamer.requests_iterator import (
-    ChunksIterator,
     FileChunksIterator,
     FilesRequestsIterator,
     FilesRequestsIteratorWithBuffer,
@@ -8,163 +7,194 @@ from runai_model_streamer.file_streamer.requests_iterator import (
     MemoryCapMode
 )
 
-class TestChunksIterator(unittest.TestCase):
-    def test_next_request_exact_limit(self):
-        chunks_iterator = ChunksIterator([1, 2, 3, 4])
 
-        chunks = chunks_iterator.next_chunks(6)
-        self.assertFalse(chunks_iterator.is_finished())
-        self.assertEqual(chunks, [1, 2, 3])
+class TestFileChunks(unittest.TestCase):
+    def test_contiguous_computes_offsets(self):
+        file_chunks = FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])
+        self.assertEqual(file_chunks.offsets, [10, 11, 13, 16])
+        self.assertEqual(file_chunks.sizes, [1, 2, 3, 4])
+        self.assertEqual(file_chunks.total_size(), 10)
+        self.assertEqual(file_chunks.max_chunk_size(), 4)
 
-        chunks = chunks_iterator.next_chunks(4)
-        self.assertTrue(chunks_iterator.is_finished())
-        self.assertEqual(chunks, [4])
+    def test_contiguous_with_zero_sized_range(self):
+        # a zero sized range does not advance the offset, so it shares the next range's offset
+        file_chunks = FileChunks.contiguous(17, "a.txt", 10, [5, 0, 3])
+        self.assertEqual(file_chunks.offsets, [10, 15, 15])
 
-    def test_next_request_high_limit(self):
-        chunks_iterator = ChunksIterator([1, 2, 3, 4])
+    def test_scattered_ranges_are_kept_as_given(self):
+        # ranges need not be contiguous, ordered, or even distinct - nothing is derived from them
+        file_chunks = FileChunks(17, "a.txt", [100, 5, 60], [4, 4, 4])
+        self.assertEqual(file_chunks.offsets, [100, 5, 60])
+        self.assertEqual(file_chunks.total_size(), 12)
 
-        chunks = chunks_iterator.next_chunks(6)
-        self.assertFalse(chunks_iterator.is_finished())
-        self.assertEqual(chunks, [1, 2, 3])
-        
-        chunks = chunks_iterator.next_chunks(6)
-        self.assertTrue(chunks_iterator.is_finished())
-        self.assertEqual(chunks, [4])
-
-    def test_next_request_low_limit(self):
-        chunks_iterator = ChunksIterator([1, 2, 3, 4])
-
-        chunks = chunks_iterator.next_chunks(6)
-        self.assertFalse(chunks_iterator.is_finished())
-        self.assertEqual(chunks, [1, 2, 3])
-        
-        chunks = chunks_iterator.next_chunks(2)
-        self.assertFalse(chunks_iterator.is_finished())
-        self.assertEqual(chunks, [])
-    
-    def test_next_request_with_item_zero(self):
-        chunks_iterator = ChunksIterator([1, 0, 3, 4])
-
-        chunks = chunks_iterator.next_chunks(4)
-        self.assertFalse(chunks_iterator.is_finished())
-        self.assertEqual(chunks, [1, 0, 3])
-        
-        chunks = chunks_iterator.next_chunks(4)
-        self.assertTrue(chunks_iterator.is_finished())
-        self.assertEqual(chunks, [4])
+    def test_mismatched_lengths_rejected(self):
+        with self.assertRaises(ValueError):
+            FileChunks(17, "a.txt", [0, 10], [4])
 
 
 class TestFileChunksIterator(unittest.TestCase):
+    # The budget tests below covered ChunksIterator before it was folded into FileChunksIterator:
+    # ranges carry their own offsets now, so there is no separate size-only iterator to drive.
     def test_next_request_exact_limit(self):
-        file_chunks_iterator = FileChunksIterator(FileChunks(17, "a.txt", 10, [1, 2, 3, 4]))
+        file_chunks_iterator = FileChunksIterator(FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4]))
 
         file_chunks = file_chunks_iterator.next_chunks(6)
         self.assertFalse(file_chunks_iterator.is_finished())
         self.assertIsNotNone(file_chunks)
         self.assertEqual(file_chunks.id, 17)
         self.assertEqual(file_chunks.path, "a.txt")
-        self.assertEqual(file_chunks.offset, 10)
-        self.assertEqual(file_chunks.chunks, [1, 2, 3])
+        self.assertEqual(file_chunks.offsets, [10, 11, 13])
+        self.assertEqual(file_chunks.sizes, [1, 2, 3])
+
+        file_chunks = file_chunks_iterator.next_chunks(4)
+        self.assertTrue(file_chunks_iterator.is_finished())
+        self.assertEqual(file_chunks.offsets, [16])
+        self.assertEqual(file_chunks.sizes, [4])
+
+    def test_next_request_high_limit(self):
+        file_chunks_iterator = FileChunksIterator(FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4]))
+
+        file_chunks = file_chunks_iterator.next_chunks(6)
+        self.assertFalse(file_chunks_iterator.is_finished())
+        self.assertEqual(file_chunks.sizes, [1, 2, 3])
 
         file_chunks = file_chunks_iterator.next_chunks(6)
         self.assertTrue(file_chunks_iterator.is_finished())
-        self.assertEqual(file_chunks.offset, 16)
-        self.assertEqual(file_chunks.chunks, [4])
+        self.assertEqual(file_chunks.sizes, [4])
+
+    def test_next_request_low_limit(self):
+        file_chunks_iterator = FileChunksIterator(FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4]))
+
+        file_chunks = file_chunks_iterator.next_chunks(6)
+        self.assertFalse(file_chunks_iterator.is_finished())
+        self.assertEqual(file_chunks.sizes, [1, 2, 3])
+
+        # the next range does not fit the remaining budget: nothing is handed out, and the file is
+        # not finished - the caller must offer it again with a fresh budget
+        file_chunks = file_chunks_iterator.next_chunks(2)
+        self.assertFalse(file_chunks_iterator.is_finished())
+        self.assertEqual(file_chunks.sizes, [])
+        self.assertEqual(file_chunks.offsets, [])
+
+    def test_next_request_with_item_zero(self):
+        file_chunks_iterator = FileChunksIterator(FileChunks.contiguous(17, "a.txt", 10, [1, 0, 3, 4]))
+
+        file_chunks = file_chunks_iterator.next_chunks(4)
+        self.assertFalse(file_chunks_iterator.is_finished())
+        self.assertEqual(file_chunks.sizes, [1, 0, 3])
+        self.assertEqual(file_chunks.offsets, [10, 11, 11])
+
+        file_chunks = file_chunks_iterator.next_chunks(4)
+        self.assertTrue(file_chunks_iterator.is_finished())
+        self.assertEqual(file_chunks.sizes, [4])
 
     def test_next_request_offset_for_non_exact_memory_limit(self):
-        file_chunks_iterator = FileChunksIterator(FileChunks(17, "a.txt", 10, [1, 2, 3, 4]))
+        file_chunks_iterator = FileChunksIterator(FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4]))
 
         file_chunks_iterator.next_chunks(5)
         file_chunks = file_chunks_iterator.next_chunks(6)
         self.assertFalse(file_chunks_iterator.is_finished())
-        self.assertEqual(file_chunks.offset, 13)
+        self.assertEqual(file_chunks.offsets, [13])
+
+    def test_scattered_ranges_survive_slicing(self):
+        file_chunks_iterator = FileChunksIterator(FileChunks(17, "a.txt", [100, 5, 60], [4, 4, 4]))
+
+        file_chunks = file_chunks_iterator.next_chunks(8)
+        self.assertEqual(file_chunks.offsets, [100, 5])
+        self.assertEqual(file_chunks.sizes, [4, 4])
+
+        file_chunks = file_chunks_iterator.next_chunks(8)
+        self.assertTrue(file_chunks_iterator.is_finished())
+        self.assertEqual(file_chunks.offsets, [60])
+
 
 class TestFilesRequestsIterator(unittest.TestCase):
     def test_next_request_single_file(self):
-        files_requests_iterator = FilesRequestsIterator(5, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4])])
+        files_requests_iterator = FilesRequestsIterator(5, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])])
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual(len(files_requests.files), 1)
         self.assertEqual(files_requests.files[0].id, 17)
         self.assertEqual(files_requests.files[0].path, "a.txt")
-        self.assertEqual(files_requests.files[0].offset, 10)
-        self.assertEqual(files_requests.files[0].chunks, [1, 2])
+        self.assertEqual(files_requests.files[0].offsets, [10, 11])
+        self.assertEqual(files_requests.files[0].sizes, [1, 2])
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual(len(files_requests.files), 1)
-        self.assertEqual(files_requests.files[0].id, 17)
-        self.assertEqual(files_requests.files[0].path, "a.txt")
-        self.assertEqual(files_requests.files[0].offset, 13)
-        self.assertEqual(files_requests.files[0].chunks, [3])
+        self.assertEqual(files_requests.files[0].offsets, [13])
+        self.assertEqual(files_requests.files[0].sizes, [3])
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual(len(files_requests.files), 1)
-        self.assertEqual(files_requests.files[0].id, 17)
-        self.assertEqual(files_requests.files[0].path, "a.txt")
-        self.assertEqual(files_requests.files[0].offset, 16)
-        self.assertEqual(files_requests.files[0].chunks, [4])
+        self.assertEqual(files_requests.files[0].offsets, [16])
+        self.assertEqual(files_requests.files[0].sizes, [4])
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNone(files_requests)
 
     def test_next_request_multi_file(self):
-        files_requests_iterator = FilesRequestsIterator(7, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4]), FileChunks(18, "b.txt", 10, [1, 2, 3, 4])])
+        files_requests_iterator = FilesRequestsIterator(
+            7,
+            [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4]),
+             FileChunks.contiguous(18, "b.txt", 10, [1, 2, 3, 4])],
+        )
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual(len(files_requests.files), 1)
         self.assertEqual(files_requests.files[0].id, 17)
-        self.assertEqual(files_requests.files[0].path, "a.txt")
-        self.assertEqual(files_requests.files[0].offset, 10)
-        self.assertEqual(files_requests.files[0].chunks, [1, 2, 3])
+        self.assertEqual(files_requests.files[0].offsets, [10, 11, 13])
+        self.assertEqual(files_requests.files[0].sizes, [1, 2, 3])
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual(len(files_requests.files), 2)
         self.assertEqual(files_requests.files[0].id, 17)
-        self.assertEqual(files_requests.files[0].path, "a.txt")
-        self.assertEqual(files_requests.files[0].offset, 16)
-        self.assertEqual(files_requests.files[0].chunks, [4])
+        self.assertEqual(files_requests.files[0].offsets, [16])
+        self.assertEqual(files_requests.files[0].sizes, [4])
         self.assertEqual(files_requests.files[1].id, 18)
         self.assertEqual(files_requests.files[1].path, "b.txt")
-        self.assertEqual(files_requests.files[1].offset, 10)
-        self.assertEqual(files_requests.files[1].chunks, [1, 2])
+        self.assertEqual(files_requests.files[1].offsets, [10, 11])
+        self.assertEqual(files_requests.files[1].sizes, [1, 2])
+        # file_base makes (file index, range index) -> flat position O(1)
+        self.assertEqual(files_requests.file_base, [0, 1])
+        self.assertEqual(files_requests.num_ranges, 3)
+        self.assertEqual(files_requests.flat_index(1, 1), 2)
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual(len(files_requests.files), 1)
         self.assertEqual(files_requests.files[0].id, 18)
-        self.assertEqual(files_requests.files[0].path, "b.txt")
-        self.assertEqual(files_requests.files[0].offset, 13)
-        self.assertEqual(files_requests.files[0].chunks, [3, 4])
+        self.assertEqual(files_requests.files[0].offsets, [13, 16])
+        self.assertEqual(files_requests.files[0].sizes, [3, 4])
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNone(files_requests)
-    
+
     def test_next_request_multi_file_block_on_file(self):
-        files_requests_iterator = FilesRequestsIterator(5, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4]), FileChunks(18, "b.txt", 10, [1, 2, 3, 4])])
+        files_requests_iterator = FilesRequestsIterator(
+            5,
+            [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4]),
+             FileChunks.contiguous(18, "b.txt", 10, [1, 2, 3, 4])],
+        )
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual(len(files_requests.files), 1)
         self.assertEqual(files_requests.files[0].id, 17)
-        self.assertEqual(files_requests.files[0].path, "a.txt")
-        self.assertEqual(files_requests.files[0].offset, 10)
-        self.assertEqual(files_requests.files[0].chunks, [1, 2])
+        self.assertEqual(files_requests.files[0].sizes, [1, 2])
 
         files_requests = files_requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual(len(files_requests.files), 1)
         self.assertEqual(files_requests.files[0].id, 17)
-        self.assertEqual(files_requests.files[0].path, "a.txt")
-        self.assertEqual(files_requests.files[0].offset, 13)
-        self.assertEqual(files_requests.files[0].chunks, [3])
+        self.assertEqual(files_requests.files[0].sizes, [3])
 
     def test_get_global_file_and_chunk(self):
-        files_requests_iterator = FilesRequestsIterator(3, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4])])
+        files_requests_iterator = FilesRequestsIterator(3, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])])
 
         files_requests_iterator.next_request()
 
@@ -181,22 +211,24 @@ class TestFilesRequestsIterator(unittest.TestCase):
         file_id, chunk_index = files_requests_iterator.get_global_file_and_chunk(0, 0)
         self.assertEqual(file_id, 17)
         self.assertEqual(chunk_index, 2)
-    
+
     def test_file_chunks_zero_chunks(self):
-        requests_iterator = FilesRequestsIterator(10, [FileChunks(17, "a.txt", 10, [])])
+        requests_iterator = FilesRequestsIterator(10, [FileChunks(17, "a.txt", [], [])])
 
         res = requests_iterator.next_request()
         self.assertIsNone(res)
 
     def test_next_request_empty_file_first_does_not_terminate(self):
+        # regression for issue #157: an empty shard at the head of the queue used to close the request,
+        # which get_chunks reads as end of stream, silently dropping every remaining file
         requests_iterator = FilesRequestsIterator(
-            100, [FileChunks(17, "empty.txt", 0, []), FileChunks(18, "a.txt", 10, [5])]
+            100, [FileChunks(17, "empty.txt", [], []), FileChunks.contiguous(18, "a.txt", 10, [5])]
         )
 
         files_requests = requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
         self.assertEqual([f.id for f in files_requests.files], [18])
-        self.assertEqual(files_requests.files[0].chunks, [5])
+        self.assertEqual(files_requests.files[0].sizes, [5])
 
         self.assertIsNone(requests_iterator.next_request())
 
@@ -204,10 +236,10 @@ class TestFilesRequestsIterator(unittest.TestCase):
         requests_iterator = FilesRequestsIterator(
             100,
             [
-                FileChunks(17, "a.txt", 10, [1, 2]),
-                FileChunks(18, "empty1.txt", 0, []),
-                FileChunks(19, "empty2.txt", 0, []),
-                FileChunks(20, "b.txt", 10, [3]),
+                FileChunks.contiguous(17, "a.txt", 10, [1, 2]),
+                FileChunks(18, "empty1.txt", [], []),
+                FileChunks(19, "empty2.txt", [], []),
+                FileChunks.contiguous(20, "b.txt", 10, [3]),
             ],
         )
 
@@ -217,65 +249,164 @@ class TestFilesRequestsIterator(unittest.TestCase):
 
         self.assertIsNone(requests_iterator.next_request())
 
+    def test_file_of_only_zero_sized_ranges_is_streamed(self):
+        # A file whose tensors are all zero sized is NOT an empty shard: it has header entries, and
+        # safetensors yields those tensors (shape preserved, data_offsets [x, x]). They are submitted
+        # so the C++ layer answers one response per range and the caller's tensor indexing lines up.
+        requests_iterator = FilesRequestsIterator(
+            100,
+            [FileChunks.contiguous(17, "zeros.txt", 10, [0, 0]),
+             FileChunks.contiguous(18, "a.txt", 10, [5])],
+        )
+
+        files_requests = requests_iterator.next_request()
+        self.assertIsNotNone(files_requests)
+        self.assertEqual([f.id for f in files_requests.files], [17, 18])
+        self.assertEqual(files_requests.files[0].sizes, [0, 0])
+        self.assertEqual(files_requests.num_ranges, 3)
+
+        self.assertIsNone(requests_iterator.next_request())
+
+    def test_zero_sized_range_among_non_zero(self):
+        requests_iterator = FilesRequestsIterator(100, [FileChunks.contiguous(17, "a.txt", 10, [5, 0, 3])])
+
+        files_requests = requests_iterator.next_request()
+        self.assertIsNotNone(files_requests)
+        self.assertEqual(files_requests.files[0].sizes, [5, 0, 3])
+        self.assertEqual(files_requests.files[0].offsets, [10, 15, 15])
+        self.assertEqual(files_requests.num_ranges, 3)
+
+    def test_only_zero_sized_ranges_in_the_whole_request(self):
+        # every range is zero sized, so the memory limit is 0 - the request must still be produced,
+        # with one range (and so one response) each
+        requests_iterator = FilesRequestsIterator(0, [FileChunks.contiguous(17, "zeros.txt", 10, [0, 0, 0])])
+
+        files_requests = requests_iterator.next_request()
+        self.assertIsNotNone(files_requests)
+        self.assertEqual(files_requests.num_ranges, 3)
+
+        self.assertIsNone(requests_iterator.next_request())
+
+
 class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
     def test_memory_cap_unlimited(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
-            MemoryCapMode.unlimited, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4])], 100
+            MemoryCapMode.unlimited, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])], 100
         )
         self.assertEqual(len(requests_iterator.buffer), 10)
 
     def test_memory_cap_limited(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
-            MemoryCapMode.limited, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4])], 5
+            MemoryCapMode.limited, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])], 5
         )
         self.assertEqual(len(requests_iterator.buffer), 5)
-    
+
     def test_memory_cap_largest_chunk(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
-            MemoryCapMode.largest_chunk, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4])], 5
+            MemoryCapMode.largest_chunk, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])], 5
         )
         self.assertEqual(len(requests_iterator.buffer), 4)
-    
+
     def test_memory_cap_largest_chunk_multi_file(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
-            MemoryCapMode.largest_chunk, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4]), FileChunks(18, "b.txt", 10, [1, 2, 7, 4])], 5
+            MemoryCapMode.largest_chunk,
+            [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4]),
+             FileChunks.contiguous(18, "b.txt", 10, [1, 2, 7, 4])],
+            5,
         )
         self.assertEqual(len(requests_iterator.buffer), 7)
-    
-    def test_files_buffers(self):
+
+    def test_memory_cap_largest_chunk_no_files(self):
+        # the largest_chunk branch used to call a bare max() and raise on an empty sequence, while the
+        # limited branch guarded with default=0. Both go through _largest_range now.
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
-            MemoryCapMode.largest_chunk, [FileChunks(17, "a.txt", 10, [1, 2, 3, 4]), FileChunks(18, "b.txt", 10, [1, 2, 7, 4])], 5
+            MemoryCapMode.largest_chunk, [], None
         )
-        self.assertEqual(len(requests_iterator.buffer), 7)
+        self.assertEqual(len(requests_iterator.buffer), 0)
+        self.assertIsNone(requests_iterator.next_request())
 
-        requests_iterator.next_request()
-        self.assertEqual(len(requests_iterator.file_buffers), 1)
-        self.assertEqual(len(requests_iterator.file_buffers[0]), 6)
+    def test_memory_cap_largest_chunk_empty_shard(self):
+        requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.largest_chunk,
+            [FileChunks(17, "empty.txt", [], []), FileChunks.contiguous(18, "a.txt", 10, [4])],
+            None,
+        )
+        self.assertEqual(len(requests_iterator.buffer), 4)
 
-        requests_iterator.next_request()
-        self.assertEqual(len(requests_iterator.file_buffers), 2)
-        self.assertEqual(len(requests_iterator.file_buffers[0]), 4)
-        self.assertEqual(len(requests_iterator.file_buffers[1]), 3)
+    def test_memory_cap_largest_chunk_only_zero_sized_ranges(self):
+        requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.largest_chunk, [FileChunks.contiguous(17, "zeros.txt", 10, [0, 0])], None
+        )
+        self.assertEqual(len(requests_iterator.buffer), 0)
+
+        files_requests = requests_iterator.next_request()
+        self.assertIsNotNone(files_requests)
+        self.assertEqual(files_requests.num_ranges, 2)
 
     def test_limited_memory_cap_and_smaller_chunks(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
-            MemoryCapMode.limited, [FileChunks(17, "a.txt", 10, [1, 2]), FileChunks(18, "b.txt", 10, [3, 4])], 50
+            MemoryCapMode.limited,
+            [FileChunks.contiguous(17, "a.txt", 10, [1, 2]), FileChunks.contiguous(18, "b.txt", 10, [3, 4])],
+            50,
         )
         self.assertEqual(len(requests_iterator.buffer), 10)
 
-    
-    def test_files_buffers_as_big_buffer(self):
+    def test_range_dsts_pack_the_request(self):
+        # replaces the old per-file file_buffers: destinations are per range now, packed back to back
+        # across the whole request, and handed to runai_request as absolute addresses.
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
-            MemoryCapMode.unlimited, [FileChunks(17, "a.txt", 10, [1, 2]), FileChunks(18, "b.txt", 10, [3, 4])], 5
+            MemoryCapMode.largest_chunk,
+            [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4]),
+             FileChunks.contiguous(18, "b.txt", 10, [1, 2, 7, 4])],
+            5,
+        )
+        self.assertEqual(len(requests_iterator.buffer), 7)
+        base = requests_iterator.buffer_address
+
+        files_requests = requests_iterator.next_request()
+        self.assertEqual([f.id for f in files_requests.files], [17])
+        self.assertEqual(files_requests.range_dsts, [base, base + 1, base + 3])
+
+        files_requests = requests_iterator.next_request()
+        self.assertEqual([f.id for f in files_requests.files], [17, 18])
+        # a.txt's remaining 4 bytes, then b.txt's 1 and 2 - one destination per range, and the buffer
+        # is reused from its start for every request
+        self.assertEqual(files_requests.range_dsts, [base, base + 4, base + 5])
+        self.assertEqual(files_requests.file_base, [0, 1])
+
+    def test_get_global_file_and_chunk_aliases_the_buffer(self):
+        requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.unlimited,
+            [FileChunks.contiguous(17, "a.txt", 10, [1, 2]), FileChunks.contiguous(18, "b.txt", 10, [3, 4])],
+            5,
         )
         self.assertEqual(len(requests_iterator.buffer), 10)
 
         requests_iterator.next_request()
-        self.assertEqual(len(requests_iterator.file_buffers), 2)
         requests_iterator.buffer[0] = 9
         requests_iterator.buffer[3] = 8
-        self.assertEqual(requests_iterator.file_buffers[0][0], 9)
-        self.assertEqual(requests_iterator.file_buffers[1][0], 8)
 
-if __name__ == "__main__":
-    unittest.main()
+        file_id, chunk_index, view = requests_iterator.get_global_file_and_chunk(0, 0)
+        self.assertEqual((file_id, chunk_index), (17, 0))
+        self.assertEqual(len(view), 1)
+        self.assertEqual(view[0], 9)
+
+        file_id, chunk_index, view = requests_iterator.get_global_file_and_chunk(1, 0)
+        self.assertEqual((file_id, chunk_index), (18, 0))
+        self.assertEqual(len(view), 3)
+        self.assertEqual(view[0], 8)
+
+    def test_get_global_file_and_chunk_zero_sized_range(self):
+        requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.unlimited, [FileChunks.contiguous(17, "a.txt", 10, [5, 0, 3])], None
+        )
+
+        requests_iterator.next_request()
+
+        file_id, chunk_index, view = requests_iterator.get_global_file_and_chunk(0, 1)
+        self.assertEqual((file_id, chunk_index), (17, 1))
+        self.assertEqual(len(view), 0)
+
+        # the zero sized range consumes no buffer, so the range after it starts where it did
+        _, _, view = requests_iterator.get_global_file_and_chunk(0, 2)
+        self.assertEqual(len(view), 3)

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
@@ -38,11 +38,10 @@ class LibstreamerDLLWrapper:
             ctypes.POINTER(ctypes.c_uint64),                 # out_submission_id
             ctypes.c_uint32,                                 # num_files
             ctypes.POINTER(ctypes.c_char_p),                 # paths
-            ctypes.POINTER(ctypes.c_size_t),                 # file_offsets
-            ctypes.POINTER(ctypes.c_size_t),                 # bytesizes
-            ctypes.POINTER(ctypes.c_void_p),                 # dsts
-            ctypes.POINTER(ctypes.c_uint32),                 # num_sizes
-            ctypes.POINTER(ctypes.POINTER(ctypes.c_size_t)), # internal_sizes
+            ctypes.POINTER(ctypes.c_uint32),                 # num_ranges
+            ctypes.POINTER(ctypes.c_size_t),                 # range_offsets
+            ctypes.POINTER(ctypes.c_size_t),                 # range_sizes
+            ctypes.POINTER(ctypes.c_void_p),                 # range_dsts
         ]
         self.fn_runai_request.restype = ctypes.c_int
 

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -11,6 +11,12 @@ FINISHED_ERROR_CODE = 1
 # common::ResponseCode::TimedOut (see cpp/common/response_code/response_code.h)
 TIMED_OUT_ERROR_CODE = 16
 
+# Widths of the C types the range arrays are converted to (unsigned num_ranges, size_t offsets/sizes,
+# void* destinations). ctypes wraps out-of-range values silently, so runai_request range-checks against
+# these before converting.
+UINT32_LIMIT = 1 << 32
+UINT64_LIMIT = 1 << 64
+
 
 def _credentials_param_arrays(s3_credentials: Optional[S3Credentials]):
     # Marshal S3Credentials into the (param_keys, param_values, num_params) key/value form used by
@@ -108,10 +114,33 @@ def runai_request(
             f"range_offsets ({len(range_offsets)}), range_sizes ({total_ranges}) and range_dsts "
             f"({len(range_dsts)}) must be parallel"
         )
+
+    # Range-check the VALUES before trusting them, because ctypes does not: it converts out-of-range
+    # integers silently, so a Python-side check of the original list can agree while the C side sees
+    # something else entirely. c_uint32(-1) becomes 4294967295 and c_uint32(2**32) becomes 0.
+    # num_ranges is the dangerous one: [-1, 1] sums to 0 in Python - matching an empty range array and
+    # passing the total check below - while C reads ~4 billion ranges for that file and indexes far past
+    # the arrays. Checked per element; num_ranges is one entry per file, so this is tens of comparisons.
+    if any(not (0 <= n < UINT32_LIMIT) for n in num_ranges):
+        raise ValueError(
+            f"every num_ranges value must fit an unsigned 32-bit integer, got {list(num_ranges)}"
+        )
     if sum(num_ranges) != total_ranges:
         raise ValueError(
             f"sum(num_ranges) is {sum(num_ranges)} but the range arrays hold {total_ranges} entries"
         )
+
+    # The flat arrays are checked with min()/max() rather than a per-element loop: they run at C speed, so
+    # this stays negligible beside the ctypes conversion below even at hundreds of thousands of ranges,
+    # whereas a Python-level loop over every range would not be. A negative size wraps to an enormous read
+    # length, and a negative offset to an enormous seek.
+    if total_ranges:
+        if min(range_sizes) < 0 or max(range_sizes) >= UINT64_LIMIT:
+            raise ValueError("every range size must fit an unsigned 64-bit integer")
+        if min(range_offsets) < 0 or max(range_offsets) >= UINT64_LIMIT:
+            raise ValueError("every range offset must fit an unsigned 64-bit integer")
+        if min(range_dsts) < 0 or max(range_dsts) >= UINT64_LIMIT:
+            raise ValueError("every range destination must be a valid address")
 
     c_paths = (ctypes.c_char_p * num_files)(*[path.encode("utf-8") for path in paths])
     c_num_ranges = (ctypes.c_uint32 * num_files)(*num_ranges)

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -8,7 +8,8 @@ from runai_model_streamer.s3_utils.s3_utils import (
 
 SUCCESS_ERROR_CODE = 0
 FINISHED_ERROR_CODE = 1
-# common::ResponseCode::TimedOut (see cpp/common/response_code/response_code.h)
+# common::ResponseCode::FileAccessError / TimedOut (see cpp/common/response_code/response_code.h)
+FILE_ACCESS_ERROR_CODE = 2
 TIMED_OUT_ERROR_CODE = 16
 
 # Widths of the C types the range arrays are converted to (unsigned num_ranges, size_t offsets/sizes,

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -63,39 +63,42 @@ def runai_end(streamer: t_streamer) -> None:
 def runai_request(
     streamer: t_streamer,
     paths: List[str],
-    file_offsets: List[int],
-    bytesizes: List[int],
-    dsts: List[memoryview],
-    internal_sizes: List[List[int]],
+    num_ranges: List[int],
+    range_offsets: List[int],
+    range_sizes: List[int],
+    range_dsts: List[int],
 ) -> int:
     """Multi-request submit. Non-blocking: returns the assigned submission id; use it to demux the
     responses from runai_response. Credentials are streamer-scoped (runai_set_credentials), not passed
-    here. Many submissions may be in flight at once."""
+    here. Many submissions may be in flight at once.
+
+    A submission is a list of files, each carrying a list of RANGES. A range is an arbitrary
+    (source offset, size) within its file with its own destination: ranges need not be contiguous in the
+    file, need not be contiguous in memory, and need not be ordered. Exactly one response is issued per
+    range, including a zero-sized one.
+
+    paths carries one entry per file, however many ranges that file has. The three range arrays are flat,
+    indexed identically, and grouped by file in the order of paths: file f's ranges occupy
+    [sum(num_ranges[:f]), sum(num_ranges[:f+1])). Destinations must not overlap - that is the caller's
+    responsibility and is not verified.
+
+    range_dsts holds ABSOLUTE integer addresses - one complete pointer per range, not offsets from a
+    base, and in no required order. Deliberately not memoryviews:
+      - a destination need not be host memory at all. A CUDA device pointer has no Python buffer object,
+        so a base-buffer + offsets signature would silently restrict destinations to the host.
+      - destinations need not share a buffer, which is the same generality the range API exists for.
+      - it avoids one memoryview -> address conversion per range on the submit path (~n per submission).
+    The cost is that raw addresses keep nothing alive: THE CALLER MUST KEEP THE UNDERLYING BUFFERS ALIVE
+    for the lifetime of the submission, until its last response has been consumed."""
     num_files = len(paths)
     c_paths = (ctypes.c_char_p * num_files)(*[path.encode("utf-8") for path in paths])
-    c_file_offsets = (ctypes.c_uint64 * len(file_offsets))(*file_offsets)
-    c_bytesizes = (ctypes.c_uint64 * len(bytesizes))(*bytesizes)
-    dst_addrs = [
-        ctypes.cast(ctypes.c_void_p(ctypes.addressof(ctypes.c_char.from_buffer(dst))), ctypes.c_void_p)
-        for dst in dsts
-    ]
-    c_dsts = (ctypes.c_void_p * len(dst_addrs))(*dst_addrs)
+    c_num_ranges = (ctypes.c_uint32 * num_files)(*num_ranges)
 
-    # c_num_sizes: number of ranges for each file
-    num_ranges_per_file_list = [len(sublist) for sublist in internal_sizes]
-    c_num_sizes = (ctypes.c_uint32 * num_files)(*num_ranges_per_file_list)
-
-    # c_internal_sizes: array of pointers, one per file, each to that file's array of range sizes. The backing
-    # arrays are held in the local `internal_sizes_arrays` so they outlive the C call - c_internal_sizes stores
-    # raw pointers into them, so they must not be garbage collected before fn_runai_request returns.
-    internal_sizes_arrays = [
-        (ctypes.c_uint64 * num_ranges_for_this_file)(*actual_sublist_data)
-        for num_ranges_for_this_file, actual_sublist_data in zip(num_ranges_per_file_list, internal_sizes)
-    ]
-    PtrToUint64ArrayType = ctypes.POINTER(ctypes.c_uint64)
-    c_internal_sizes = (PtrToUint64ArrayType * num_files)()
-    for i, individual_c_array_obj in enumerate(internal_sizes_arrays):
-        c_internal_sizes[i] = ctypes.cast(individual_c_array_obj, PtrToUint64ArrayType)
+    # The flat range arrays: one allocation each, no nested pointer array to keep alive across the call
+    total_ranges = len(range_sizes)
+    c_range_offsets = (ctypes.c_uint64 * total_ranges)(*range_offsets)
+    c_range_sizes = (ctypes.c_uint64 * total_ranges)(*range_sizes)
+    c_range_dsts = (ctypes.c_void_p * total_ranges)(*range_dsts)
 
     submission_id = ctypes.c_uint64()
     error_code = dll.fn_runai_request(
@@ -103,11 +106,10 @@ def runai_request(
         ctypes.byref(submission_id),
         num_files,
         c_paths,
-        c_file_offsets,
-        c_bytesizes,
-        c_dsts,
-        c_num_sizes,
-        c_internal_sizes,
+        c_num_ranges,
+        c_range_offsets,
+        c_range_sizes,
+        c_range_dsts,
     )
     if error_code != SUCCESS_ERROR_CODE:
         raise ValueError(

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -90,12 +90,33 @@ def runai_request(
       - it avoids one memoryview -> address conversion per range on the submit path (~n per submission).
     The cost is that raw addresses keep nothing alive: THE CALLER MUST KEEP THE UNDERLYING BUFFERS ALIVE
     for the lifetime of the submission, until its last response has been consumed."""
+    # Validate the shape here, at the FFI boundary: this is the last point at which a mismatch is a Python
+    # error rather than undefined behaviour. The C side takes the range count as sum(num_ranges) and indexes
+    # all three flat arrays up to it, while the arrays below are sized from len(range_sizes) - so a
+    # sum(num_ranges) larger than the arrays reads past their end, in native code, with nothing raised.
+    # ctypes will not catch it: an array built from too FEW initializers is silently zero-padded (a short
+    # num_ranges would make a file lose all of its ranges, a short range_offsets would read from offset 0).
+    # Costs one sum over the file count - tens per submission - not per range.
     num_files = len(paths)
+    total_ranges = len(range_sizes)
+    if len(num_ranges) != num_files:
+        raise ValueError(
+            f"num_ranges has {len(num_ranges)} entries but there are {num_files} paths"
+        )
+    if not (len(range_offsets) == len(range_dsts) == total_ranges):
+        raise ValueError(
+            f"range_offsets ({len(range_offsets)}), range_sizes ({total_ranges}) and range_dsts "
+            f"({len(range_dsts)}) must be parallel"
+        )
+    if sum(num_ranges) != total_ranges:
+        raise ValueError(
+            f"sum(num_ranges) is {sum(num_ranges)} but the range arrays hold {total_ranges} entries"
+        )
+
     c_paths = (ctypes.c_char_p * num_files)(*[path.encode("utf-8") for path in paths])
     c_num_ranges = (ctypes.c_uint32 * num_files)(*num_ranges)
 
     # The flat range arrays: one allocation each, no nested pointer array to keep alive across the call
-    total_ranges = len(range_sizes)
     c_range_offsets = (ctypes.c_uint64 * total_ranges)(*range_offsets)
     c_range_sizes = (ctypes.c_uint64 * total_ranges)(*range_sizes)
     c_range_dsts = (ctypes.c_void_p * total_ranges)(*range_dsts)

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -26,6 +26,28 @@ class TestBindings(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
 
+    def _drain(self, streamer, submission_id, num_ranges):
+        """Consume a submission's responses, asserting each succeeded, and return the range indices seen.
+
+        Every accepted submission must be drained before its destination buffer goes out of scope:
+        runai_request is non-blocking and range_dsts are raw addresses that keep nothing alive, so an
+        in-flight submission can be writing into memory the test has already released. Draining also
+        checks the submission_done flag is set exactly once, on the last response.
+        """
+        seen = []
+        done_count = 0
+        for _ in range(num_ranges):
+            result = runai_response(streamer)
+            self.assertIsNotNone(result)
+            ret, sub_id, _file_index, range_index, submission_done = result
+            self.assertEqual(ret, SUCCESS_ERROR_CODE)
+            self.assertEqual(sub_id, submission_id)
+            seen.append(range_index)
+            if submission_done:
+                done_count += 1
+        self.assertEqual(done_count, 1, "submission_done must be set exactly once, on the last response")
+        return sorted(seen)
+
     def test_runai_library(self):
         # Multi-request API: submit returns a submission id, and each response reports its submission id,
         # file/range and whether the submission is complete. Also exercises runai_set_credentials (streamer-
@@ -236,10 +258,14 @@ class TestBindings(unittest.TestCase):
         with self.assertRaises(ValueError):
             runai_request(streamer, [file_path], [2], [0, 4], [4, 4], [base])
 
-        # the correctly shaped version of the same submission is accepted
-        self.assertIsNotNone(
-            runai_request(streamer, [file_path], [2], [0, 4], [4, 4], [base, base + 4])
-        )
+        # The correctly shaped version of the same submission is accepted - and is DRAINED before the test
+        # returns. runai_request is non-blocking and the destinations are raw addresses that keep nothing
+        # alive, so leaving a submission in flight lets the buffer be released while the library is still
+        # writing into it.
+        submission_id = runai_request(streamer, [file_path], [2], [0, 4], [4, 4], [base, base + 4])
+        self.assertIsNotNone(submission_id)
+        self.assertEqual(self._drain(streamer, submission_id, 2), [0, 1])
+        self.assertEqual(bytes(buffer[0:8]), b"abcdefgh")
 
     def test_out_of_range_values_are_rejected(self):
         # ctypes converts out-of-range integers SILENTLY - c_uint32(-1) becomes 4294967295 and
@@ -270,10 +296,11 @@ class TestBindings(unittest.TestCase):
         with self.assertRaises(ValueError):
             runai_request(streamer, [file_path], [1], [0], [4], [-1])
 
-        # a valid submission of the same shape still goes through
-        self.assertIsNotNone(
-            runai_request(streamer, [file_path], [1], [0], [4], [base])
-        )
+        # a valid submission of the same shape still goes through, and is drained before returning
+        submission_id = runai_request(streamer, [file_path], [1], [0], [4], [base])
+        self.assertIsNotNone(submission_id)
+        self.assertEqual(self._drain(streamer, submission_id, 1), [0])
+        self.assertEqual(bytes(buffer[0:4]), b"abcd")
 
     def test_file_without_ranges_produces_no_response(self):
         # A file may carry no ranges at all. It is accepted and simply contributes nothing - the

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -250,18 +250,24 @@ class TestBindings(unittest.TestCase):
         base = buffer_address(buffer)
         streamer = runai_start()
 
+        # Matched on the MESSAGE, not merely on ValueError: several guards raise ValueError here, so a
+        # bare assertRaises passes when a different one fires. Removing the guard a case is named for
+        # would then leave the case green while testing nothing - deleting the uint32 check, for
+        # instance, makes that input trip the sum check instead, which is also a ValueError. The
+        # patterns are distinctive fragments, so rewording a message does not break them.
+
         # num_ranges shorter than paths - the second file would silently lose all of its ranges
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "entries but there are"):
             runai_request(streamer, [file_path, file_path], [1], [0, 4], [4, 4], [base, base + 4])
 
         # sum(num_ranges) larger than the range arrays - this is the out-of-bounds read
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "but the range arrays hold"):
             runai_request(streamer, [file_path], [3], [0], [4], [base])
 
         # the parallel arrays disagree with each other
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "must be parallel"):
             runai_request(streamer, [file_path], [2], [0], [4, 4], [base, base + 4])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "must be parallel"):
             runai_request(streamer, [file_path], [2], [0, 4], [4, 4], [base])
 
         # The correctly shaped version of the same submission is accepted - and is DRAINED before the test
@@ -285,31 +291,34 @@ class TestBindings(unittest.TestCase):
         base = buffer_address(buffer)
         streamer = runai_start()
 
+        # Matched on the MESSAGE (see test_mismatched_array_lengths_are_rejected): each case must trip
+        # the guard it is named for, or it silently stops covering that guard.
+
         # The case a sum-only check cannot catch: sum([-1, 1]) == 0 matches an empty range array, but
         # ctypes turns -1 into 4294967295 and the C side then indexes ~4 billion ranges.
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "unsigned 32-bit integer"):
             runai_request(streamer, [file_path, file_path], [-1, 1], [], [], [])
 
         # wraps to 0, silently costing the file all of its ranges
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "unsigned 32-bit integer"):
             runai_request(streamer, [file_path], [2**32], [0], [4], [base])
 
         # negative size wraps to an enormous read length; negative offset to an enormous seek
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "range size must fit"):
             runai_request(streamer, [file_path], [1], [0], [-1], [base])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "range offset must fit"):
             runai_request(streamer, [file_path], [1], [-1], [4], [base])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "range destination must be"):
             runai_request(streamer, [file_path], [1], [0], [4], [-1])
 
         # The other end of the 64-bit range, which wraps just as silently and in a different way for each
         # field: c_uint64(2**64) becomes 0, so an oversized size is a zero-length read and an oversized
         # offset reads from the start of the file; c_void_p(2**64) becomes NULL.
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "range size must fit"):
             runai_request(streamer, [file_path], [1], [0], [2**64], [base])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "range offset must fit"):
             runai_request(streamer, [file_path], [1], [2**64], [4], [base])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "range destination must be"):
             runai_request(streamer, [file_path], [1], [0], [4], [2**64])
 
         # a valid submission of the same shape still goes through, and is drained before returning

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -5,6 +5,7 @@ import os
 import mmap
 import ctypes
 from runai_model_streamer.libstreamer.libstreamer import (
+    FILE_ACCESS_ERROR_CODE,
     SUCCESS_ERROR_CODE,
     runai_start,
     runai_set_credentials,
@@ -26,20 +27,25 @@ class TestBindings(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
 
-    def _drain(self, streamer, submission_id, num_ranges):
-        """Consume a submission's responses, asserting each succeeded, and return the range indices seen.
+    def _drain(self, streamer, submission_id, num_ranges, expected_code=SUCCESS_ERROR_CODE):
+        """Consume a submission's responses, asserting each carried expected_code, and return the range
+        indices seen.
 
         Every accepted submission must be drained before its destination buffer goes out of scope:
         runai_request is non-blocking and range_dsts are raw addresses that keep nothing alive, so an
         in-flight submission can be writing into memory the test has already released. Draining also
         checks the submission_done flag is set exactly once, on the last response.
+
+        expected_code is a parameter because a FAILING submission must complete just as strictly as a
+        successful one - same count, same flag on the last response. That is the case where dropping a
+        response is easiest and hangs the caller hardest.
         """
         seen = []
         for response_number in range(num_ranges):
             result = runai_response(streamer)
             self.assertIsNotNone(result)
             ret, sub_id, _file_index, range_index, submission_done = result
-            self.assertEqual(ret, SUCCESS_ERROR_CODE)
+            self.assertEqual(ret, expected_code)
             self.assertEqual(sub_id, submission_id)
             seen.append(range_index)
 
@@ -195,10 +201,15 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(bytes(buffer[13:40]), b"\x00" * 27)
         self.assertEqual(bytes(buffer[45:64]), b"\x00" * 19)
 
-    def test_zero_sized_range_needs_no_file(self):
-        # A zero-sized range reaches no storage, so it is answered even for a path that cannot be opened.
-        # Nothing may be dropped either: the response counter is raised per range regardless, so a range
-        # whose response is never produced hangs the caller (runai_response blocks indefinitely).
+    def test_zero_sized_ranges_on_unopenable_file_are_still_answered(self):
+        # A zero-sized range reads nothing, but it does NOT skip the file: the streamer opens the file for
+        # every batch before it looks at any range size, so a range in an unopenable file fails with it -
+        # verified against the real library, which returns FileAccessError here.
+        #
+        # The point of the test is that the ranges are ANSWERED, not what they answer. The response counter
+        # is raised per range regardless of size, so a range whose response is never produced hangs the
+        # caller (runai_response blocks indefinitely), and the failing path is where dropping one is
+        # easiest.
         missing = os.path.join(self.temp_dir, "does_not_exist.bin")
         self.assertFalse(os.path.exists(missing))
 
@@ -208,10 +219,12 @@ class TestBindings(unittest.TestCase):
         streamer = runai_start()
         submission_id = runai_request(streamer, [missing], [2], [0, 0], [0, 0], [base, base])
 
-        # Both ranges must be accounted for individually: counting two successful responses would also
-        # accept the same range answered twice while the other was dropped, which is the failure this
-        # test exists to catch. _drain also checks the submission-done flag lands on the last response.
-        self.assertEqual(self._drain(streamer, submission_id, 2), [0, 1])
+        # Both ranges must be accounted for individually: counting two responses would also accept the
+        # same range answered twice while the other was dropped, which is the failure this test exists to
+        # catch. _drain also checks the submission-done flag lands on the last response.
+        self.assertEqual(
+            self._drain(streamer, submission_id, 2, expected_code=FILE_ACCESS_ERROR_CODE), [0, 1]
+        )
 
     def test_unopenable_file_reports_one_error_per_range(self):
         # A file that cannot be opened fails each of its ranges, as the real streamer does. The failure

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -165,6 +165,51 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(bytes(buffer[13:40]), b"\x00" * 27)
         self.assertEqual(bytes(buffer[45:64]), b"\x00" * 19)
 
+    def test_zero_sized_range_needs_no_file(self):
+        # A zero-sized range reaches no storage, so it is answered even for a path that cannot be opened.
+        # Nothing may be dropped either: the response counter is raised per range regardless, so a range
+        # whose response is never produced hangs the caller (runai_response blocks indefinitely).
+        missing = os.path.join(self.temp_dir, "does_not_exist.bin")
+        self.assertFalse(os.path.exists(missing))
+
+        buffer = mmap.mmap(-1, 64, mmap.MAP_ANONYMOUS | mmap.MAP_PRIVATE)
+        base = buffer_address(buffer)
+
+        streamer = runai_start()
+        submission_id = runai_request(streamer, [missing], [2], [0, 0], [0, 0], [base, base])
+
+        for _ in range(2):
+            result = runai_response(streamer)
+            self.assertIsNotNone(result)
+            ret, sub_id, _file_index, _range_index, _done = result
+            self.assertEqual(ret, SUCCESS_ERROR_CODE)
+            self.assertEqual(sub_id, submission_id)
+
+    def test_unopenable_file_reports_one_error_per_range(self):
+        # A file that cannot be opened fails each of its ranges, as the real streamer does. The failure
+        # mode being guarded is not a wrong code but a HANG: dropping the responses would leave the
+        # caller waiting on a count that can never be reached.
+        missing = os.path.join(self.temp_dir, "also_missing.bin")
+        self.assertFalse(os.path.exists(missing))
+
+        buffer = mmap.mmap(-1, 64, mmap.MAP_ANONYMOUS | mmap.MAP_PRIVATE)
+        base = buffer_address(buffer)
+
+        streamer = runai_start()
+        submission_id = runai_request(streamer, [missing], [3], [0, 8, 16], [8, 8, 8], [base, base + 8, base + 16])
+
+        seen = []
+        for _ in range(3):
+            result = runai_response(streamer)
+            self.assertIsNotNone(result)
+            ret, sub_id, _file_index, range_index, _done = result
+            self.assertEqual(sub_id, submission_id)
+            self.assertNotEqual(ret, SUCCESS_ERROR_CODE)
+            seen.append(range_index)
+
+        # exactly one response per range, none dropped and none duplicated
+        self.assertEqual(sorted(seen), [0, 1, 2])
+
     def test_mismatched_array_lengths_are_rejected(self):
         # The C side takes the range count as sum(num_ranges) and indexes all three flat arrays up to it,
         # so a mismatch here is an out-of-bounds read in native code, not an exception: ctypes silently

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -241,6 +241,40 @@ class TestBindings(unittest.TestCase):
             runai_request(streamer, [file_path], [2], [0, 4], [4, 4], [base, base + 4])
         )
 
+    def test_out_of_range_values_are_rejected(self):
+        # ctypes converts out-of-range integers SILENTLY - c_uint32(-1) becomes 4294967295 and
+        # c_uint32(2**32) becomes 0 - so a check against the Python values can agree while the C side
+        # receives something else. These must be rejected before the conversion.
+        file_path = os.path.join(self.temp_dir, "ranges.txt")
+        with open(file_path, "w") as file:
+            file.write("abcdefgh")
+
+        buffer = mmap.mmap(-1, 64, mmap.MAP_ANONYMOUS | mmap.MAP_PRIVATE)
+        base = buffer_address(buffer)
+        streamer = runai_start()
+
+        # The case a sum-only check cannot catch: sum([-1, 1]) == 0 matches an empty range array, but
+        # ctypes turns -1 into 4294967295 and the C side then indexes ~4 billion ranges.
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path, file_path], [-1, 1], [], [], [])
+
+        # wraps to 0, silently costing the file all of its ranges
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [2**32], [0], [4], [base])
+
+        # negative size wraps to an enormous read length; negative offset to an enormous seek
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [1], [0], [-1], [base])
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [1], [-1], [4], [base])
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [1], [0], [4], [-1])
+
+        # a valid submission of the same shape still goes through
+        self.assertIsNotNone(
+            runai_request(streamer, [file_path], [1], [0], [4], [base])
+        )
+
     def test_file_without_ranges_produces_no_response(self):
         # A file may carry no ranges at all. It is accepted and simply contributes nothing - the
         # submission completes on the responses of the files that do have ranges.

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -165,6 +165,37 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(bytes(buffer[13:40]), b"\x00" * 27)
         self.assertEqual(bytes(buffer[45:64]), b"\x00" * 19)
 
+    def test_mismatched_array_lengths_are_rejected(self):
+        # The C side takes the range count as sum(num_ranges) and indexes all three flat arrays up to it,
+        # so a mismatch here is an out-of-bounds read in native code, not an exception: ctypes silently
+        # zero-pads an array built from too few initializers. These must fail in Python.
+        file_path = os.path.join(self.temp_dir, "lengths.txt")
+        with open(file_path, "w") as file:
+            file.write("abcdefgh")
+
+        buffer = mmap.mmap(-1, 64, mmap.MAP_ANONYMOUS | mmap.MAP_PRIVATE)
+        base = buffer_address(buffer)
+        streamer = runai_start()
+
+        # num_ranges shorter than paths - the second file would silently lose all of its ranges
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path, file_path], [1], [0, 4], [4, 4], [base, base + 4])
+
+        # sum(num_ranges) larger than the range arrays - this is the out-of-bounds read
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [3], [0], [4], [base])
+
+        # the parallel arrays disagree with each other
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [2], [0], [4, 4], [base, base + 4])
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [2], [0, 4], [4, 4], [base])
+
+        # the correctly shaped version of the same submission is accepted
+        self.assertIsNotNone(
+            runai_request(streamer, [file_path], [2], [0, 4], [4, 4], [base, base + 4])
+        )
+
     def test_file_without_ranges_produces_no_response(self):
         # A file may carry no ranges at all. It is accepted and simply contributes nothing - the
         # submission completes on the responses of the files that do have ranges.

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -3,6 +3,7 @@ import tempfile
 import shutil
 import os
 import mmap
+import ctypes
 from runai_model_streamer.libstreamer.libstreamer import (
     SUCCESS_ERROR_CODE,
     runai_start,
@@ -13,6 +14,12 @@ from runai_model_streamer.libstreamer.libstreamer import (
 from runai_model_streamer.s3_utils.s3_utils import (
     S3Credentials,
 )
+
+
+def buffer_address(buffer) -> int:
+    # range_dsts are absolute addresses, so the destination buffer's base has to be taken explicitly -
+    # the binding no longer accepts a Python buffer object and derives offsets from it
+    return ctypes.addressof(ctypes.c_char.from_buffer(buffer))
 
 
 class TestBindings(unittest.TestCase):
@@ -52,9 +59,17 @@ class TestBindings(unittest.TestCase):
                 region_name="us-west-2",
                 endpoint="optional_endpoint"))
 
-        items = [[10, 9], [11, 8]]
+        # Two files, two ranges each. Every range carries its own source offset and its own destination
+        # address, so the layout below is stated outright rather than derived from a base offset plus
+        # consecutive sizes: file 1 reads 10 bytes at 1 and 9 at 11, file 2 reads 11 at 1 and 8 at 12.
+        base = buffer_address(buffer)
         submission_id = runai_request(
-            streamer, [file_path_1, file_path_2], [1, 1], [19, 19], [buffer], items
+            streamer,
+            [file_path_1, file_path_2],
+            [2, 2],                                 # num_ranges per file
+            [1, 11, 1, 12],                         # range_offsets, flat and grouped by file
+            [10, 9, 11, 8],                         # range_sizes
+            [base, base + 10, base + 19, base + 30] # range_dsts, absolute addresses
         )
 
         # collect all four sub-range responses (order across files is not guaranteed)
@@ -81,6 +96,58 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(bytes(buffer[30:38]), b"TestText")
         self.assertEqual(id(buffer), buffer_ptr)
 
+    def test_zero_sized_range_is_answered(self):
+        # A zero-sized range is a range: it gets its own response, like any other. The caller's indexing
+        # counts on exactly one response per range, so swallowing it would shift every later index.
+        file_path = os.path.join(self.temp_dir, "zeros.txt")
+        with open(file_path, "w") as file:
+            file.write("abcde")
+
+        buffer = mmap.mmap(-1, 64, mmap.MAP_ANONYMOUS | mmap.MAP_PRIVATE)
+        base = buffer_address(buffer)
+
+        streamer = runai_start()
+        submission_id = runai_request(
+            streamer, [file_path], [2], [0, 0], [0, 5], [base, base]
+        )
+
+        seen = []
+        for _ in range(2):
+            result = runai_response(streamer)
+            self.assertIsNotNone(result)
+            ret, sub_id, file_index, range_index, submission_done = result
+            self.assertEqual(ret, SUCCESS_ERROR_CODE)
+            self.assertEqual(sub_id, submission_id)
+            seen.append(range_index)
+
+        self.assertEqual(sorted(seen), [0, 1])
+        self.assertEqual(bytes(buffer[0:5]), b"abcde")
+
+    def test_file_without_ranges_produces_no_response(self):
+        # A file may carry no ranges at all. It is accepted and simply contributes nothing - the
+        # submission completes on the responses of the files that do have ranges.
+        empty_path = os.path.join(self.temp_dir, "no_ranges.txt")
+        open(empty_path, "w").close()
+        data_path = os.path.join(self.temp_dir, "data.txt")
+        with open(data_path, "w") as file:
+            file.write("payload")
+
+        buffer = mmap.mmap(-1, 64, mmap.MAP_ANONYMOUS | mmap.MAP_PRIVATE)
+
+        streamer = runai_start()
+        submission_id = runai_request(
+            streamer, [empty_path, data_path], [0, 1], [0], [7], [buffer_address(buffer)]
+        )
+
+        result = runai_response(streamer)
+        self.assertIsNotNone(result)
+        ret, sub_id, file_index, range_index, submission_done = result
+        self.assertEqual(ret, SUCCESS_ERROR_CODE)
+        self.assertEqual(sub_id, submission_id)
+        self.assertEqual(file_index, 1)
+        self.assertTrue(submission_done)
+        self.assertEqual(bytes(buffer[0:7]), b"payload")
+
     def test_response_error_is_returned_not_raised(self):
         # A per-sub-range error (here EOF: asking for more bytes than the file holds) must be SURFACED by the
         # binding as data - a tuple with a non-Success response_code - NOT raised and NOT returned as None.
@@ -95,8 +162,10 @@ class TestBindings(unittest.TestCase):
         streamer = runai_start()
         self.assertNotEqual(streamer, 0)
 
-        # one sub-range asking for 20 bytes from a 5-byte file -> the read falls short (EOF error)
-        submission_id = runai_request(streamer, [file_path], [0], [20], [buffer], [[20]])
+        # one range asking for 20 bytes from a 5-byte file -> the read falls short (EOF error)
+        submission_id = runai_request(
+            streamer, [file_path], [1], [0], [20], [buffer_address(buffer)]
+        )
 
         result = runai_response(streamer)
         # not raised, and not the teardown FinishedError (which would return None)

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -123,6 +123,48 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(sorted(seen), [0, 1])
         self.assertEqual(bytes(buffer[0:5]), b"abcde")
 
+    def test_scattered_ranges_and_destinations(self):
+        # Ranges that are non-contiguous and unordered in BOTH the file and the destination buffer -
+        # the shape the per-range API exists for. Every other test here happens to submit ranges that
+        # tile one span, which a backend that seeks once per file and walks its destination forward
+        # would serve correctly by accident; this one it cannot.
+        file_path = os.path.join(self.temp_dir, "scattered.txt")
+        with open(file_path, "w") as file:
+            file.write("ABCDEFGHIJKLMNOPQRST")   # 20 bytes, every byte distinct
+
+        buffer = mmap.mmap(-1, 64, mmap.MAP_ANONYMOUS | mmap.MAP_PRIVATE)   # zero filled
+        base = buffer_address(buffer)
+
+        # last bytes first, then the first bytes, then the middle; destinations in a third order again
+        offsets = [15, 0, 8]
+        sizes = [5, 3, 2]
+        dsts = [base + 40, base + 10, base + 0]
+
+        streamer = runai_start()
+        submission_id = runai_request(streamer, [file_path], [3], offsets, sizes, dsts)
+
+        seen = []
+        for _ in range(3):
+            result = runai_response(streamer)
+            self.assertIsNotNone(result)
+            ret, sub_id, file_index, range_index, submission_done = result
+            self.assertEqual(ret, SUCCESS_ERROR_CODE)
+            self.assertEqual(sub_id, submission_id)
+            self.assertEqual(file_index, 0)
+            seen.append(range_index)
+
+        # one response per range, indexed as submitted
+        self.assertEqual(sorted(seen), [0, 1, 2])
+
+        self.assertEqual(bytes(buffer[40:45]), b"PQRST")
+        self.assertEqual(bytes(buffer[10:13]), b"ABC")
+        self.assertEqual(bytes(buffer[0:2]), b"IJ")
+
+        # nothing was written outside the requested destinations
+        self.assertEqual(bytes(buffer[2:10]), b"\x00" * 8)
+        self.assertEqual(bytes(buffer[13:40]), b"\x00" * 27)
+        self.assertEqual(bytes(buffer[45:64]), b"\x00" * 19)
+
     def test_file_without_ranges_produces_no_response(self):
         # A file may carry no ranges at all. It is accepted and simply contributes nothing - the
         # submission completes on the responses of the files that do have ranges.

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/tests/test_libstreamer.py
@@ -35,17 +35,25 @@ class TestBindings(unittest.TestCase):
         checks the submission_done flag is set exactly once, on the last response.
         """
         seen = []
-        done_count = 0
-        for _ in range(num_ranges):
+        for response_number in range(num_ranges):
             result = runai_response(streamer)
             self.assertIsNotNone(result)
             ret, sub_id, _file_index, range_index, submission_done = result
             self.assertEqual(ret, SUCCESS_ERROR_CODE)
             self.assertEqual(sub_id, submission_id)
             seen.append(range_index)
-            if submission_done:
-                done_count += 1
-        self.assertEqual(done_count, 1, "submission_done must be set exactly once, on the last response")
+
+            # Asserted against the response's POSITION, not merely counted: the flag is the caller's
+            # signal that it may release the destination buffers, so setting it early is a
+            # use-after-free, and a "set exactly once" count passes for exactly that case. Position, not
+            # range index - responses may arrive in any order, and the flag belongs to whichever is
+            # delivered last.
+            self.assertEqual(
+                submission_done,
+                response_number == num_ranges - 1,
+                f"submission_done must be set only on the last response, but response "
+                f"{response_number + 1} of {num_ranges} reported {submission_done}",
+            )
         return sorted(seen)
 
     def test_runai_library(self):
@@ -200,12 +208,10 @@ class TestBindings(unittest.TestCase):
         streamer = runai_start()
         submission_id = runai_request(streamer, [missing], [2], [0, 0], [0, 0], [base, base])
 
-        for _ in range(2):
-            result = runai_response(streamer)
-            self.assertIsNotNone(result)
-            ret, sub_id, _file_index, _range_index, _done = result
-            self.assertEqual(ret, SUCCESS_ERROR_CODE)
-            self.assertEqual(sub_id, submission_id)
+        # Both ranges must be accounted for individually: counting two successful responses would also
+        # accept the same range answered twice while the other was dropped, which is the failure this
+        # test exists to catch. _drain also checks the submission-done flag lands on the last response.
+        self.assertEqual(self._drain(streamer, submission_id, 2), [0, 1])
 
     def test_unopenable_file_reports_one_error_per_range(self):
         # A file that cannot be opened fails each of its ranges, as the real streamer does. The failure
@@ -295,6 +301,16 @@ class TestBindings(unittest.TestCase):
             runai_request(streamer, [file_path], [1], [-1], [4], [base])
         with self.assertRaises(ValueError):
             runai_request(streamer, [file_path], [1], [0], [4], [-1])
+
+        # The other end of the 64-bit range, which wraps just as silently and in a different way for each
+        # field: c_uint64(2**64) becomes 0, so an oversized size is a zero-length read and an oversized
+        # offset reads from the start of the file; c_void_p(2**64) becomes NULL.
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [1], [0], [2**64], [base])
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [1], [2**64], [4], [base])
+        with self.assertRaises(ValueError):
+            runai_request(streamer, [file_path], [1], [0], [4], [2**64])
 
         # a valid submission of the same shape still goes through, and is drained before returning
         submission_id = runai_request(streamer, [file_path], [1], [0], [4], [base])

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_pytorch.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_pytorch.py
@@ -102,7 +102,7 @@ class SafetensorsMetadata:
     @staticmethod
     def from_files(fs: DistributedStreamer, filenames: List[str], s3_credentials: Optional[S3Credentials]) -> List[SafetensorsMetadata]:
         # 1. Read the first 8 bytes (The Header Size)
-        fs.stream_files([FileChunks(i, filenames[i], 0, [SAFETENSORS_HEADER_BUFFER_SIZE]) for i in range(len(filenames))], s3_credentials, "cpu", False)
+        fs.stream_files([FileChunks.contiguous(i, filenames[i], 0, [SAFETENSORS_HEADER_BUFFER_SIZE]) for i in range(len(filenames))], s3_credentials, "cpu", False)
         
         header_sizes = {}
         
@@ -127,7 +127,7 @@ class SafetensorsMetadata:
 
         # 2. Read the JSON Header Body
         metadatas = {}
-        fs.stream_files([FileChunks(i, filenames[i], SAFETENSORS_HEADER_BUFFER_SIZE, [header_size]) for i, header_size in header_sizes.items()], s3_credentials, "cpu", False)
+        fs.stream_files([FileChunks.contiguous(i, filenames[i], SAFETENSORS_HEADER_BUFFER_SIZE, [header_size]) for i, header_size in header_sizes.items()], s3_credentials, "cpu", False)
         
         # Wrap the second loop to catch truncation during JSON read
         try:

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_pytorch.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_pytorch.py
@@ -74,7 +74,11 @@ class SafetensorsMetadata:
                 tensor_metadata = SafetensorMetadata(name, safetensor_metadata)
                 self.tensors_metadata.append(tensor_metadata)
 
-        self.tensors_metadata.sort(key=lambda x: x.offsets.start)
+        # Size breaks ties so a ZERO ELEMENT tensor sorts before a real tensor that starts at the same
+        # offset - data_offsets [16, 16] and [16, 48] share a start. Without the tie-break the order comes
+        # from the header's key order via the stable sort, and if the real tensor happened to come first
+        # the gap check below would compute 16 + 32 > 16 and reject a perfectly good file as overlapping.
+        self.tensors_metadata.sort(key=lambda x: (x.offsets.start, x.get_bytesize()))
 
         for i in range(len(self.tensors_metadata)):
             current_tensor = self.tensors_metadata[i]

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_pytorch.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_pytorch.py
@@ -4,6 +4,7 @@ import struct
 import json
 from typing import List, Tuple, Optional, Any
 from runai_model_streamer.distributed_streamer.distributed_streamer import (DistributedStreamer, FileChunks)
+from runai_model_streamer.s3_utils.s3_utils import S3Credentials
 
 SAFETENSORS_DATA_OFFSETS_KEY = "data_offsets"
 SAFETENSORS_NAME_KEY = "name"

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -264,7 +264,7 @@ class SafetensorsStreamer:
             path = paths[i]
             self.files_to_tensors_metadata[i] = tensors_metadata
             self.total_size += sum(tensor_sizes)
-            file_stream_requests.append(FileChunks(i, path, file_offset, tensor_sizes))
+            file_stream_requests.append(FileChunks.contiguous(i, path, file_offset, tensor_sizes))
 
         self.file_streamer.stream_files(
             file_stream_requests,

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_metadata_ordering.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_metadata_ordering.py
@@ -1,0 +1,71 @@
+import json
+import os
+import shutil
+import struct
+import tempfile
+import unittest
+
+import torch
+
+from runai_model_streamer.safetensors_streamer.safetensors_streamer import SafetensorsStreamer
+
+
+def write_safetensors(path, header_entries, data):
+    """Write a safetensors file with the header keys in EXACTLY the given order.
+
+    Hand-built rather than produced by the reference library, which assigns data_offsets in key order and
+    so can never emit the ordering this test is about. The header is padded to an 8 byte boundary, as the
+    reference writer does.
+    """
+    header = json.dumps(dict(header_entries)).encode("utf-8")
+    header += b" " * (-len(header) % 8)
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header)))
+        f.write(header)
+        f.write(data)
+
+
+class TestMetadataOrdering(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_zero_element_tensor_sharing_a_start_offset_is_not_rejected(self):
+        """A zero element tensor shares its start offset with whatever follows it.
+
+        data_offsets [16, 16] and [16, 48] both start at 16, so sorting by start alone leaves the order to
+        the header's key order via Python's stable sort. With the real tensor first, the gap check computes
+        16 + 32 = 48 against a next start of 16 and rejects the file as overlapping - a valid file refused
+        because of key order. Sorting by (start, size) puts the empty tensor first, where it belongs.
+
+        The keys below are deliberately in the order the reference writer would never produce.
+        """
+        values = torch.arange(12, dtype=torch.float32)
+        data = values[:4].numpy().tobytes() + values[4:].numpy().tobytes()   # 16 + 32 = 48 bytes
+        path = os.path.join(self.temp_dir, "model.safetensors")
+
+        write_safetensors(
+            path,
+            [
+                ("first", {"dtype": "F32", "shape": [4], "data_offsets": [0, 16]}),
+                ("second", {"dtype": "F32", "shape": [8], "data_offsets": [16, 48]}),
+                ("empty", {"dtype": "F32", "shape": [0, 3], "data_offsets": [16, 16]}),
+            ],
+            data,
+        )
+
+        with SafetensorsStreamer() as streamer:
+            streamer.stream_file(path)
+            tensors = {name: tensor for name, tensor in streamer.get_tensors()}
+
+        self.assertEqual(sorted(tensors), ["empty", "first", "second"])
+        self.assertEqual(tuple(tensors["empty"].shape), (0, 3))
+        self.assertEqual(tensors["empty"].numel(), 0)
+        self.assertTrue(torch.equal(tensors["first"], values[:4]))
+        self.assertTrue(torch.equal(tensors["second"], values[4:]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/runai_model_streamer/runai_model_streamer/tests/test_annotations.py
+++ b/py/runai_model_streamer/runai_model_streamer/tests/test_annotations.py
@@ -23,12 +23,32 @@ class TestAnnotationsResolve(unittest.TestCase):
     every annotation so the next one fails here instead.
     """
 
+    # Modules allowed to fail to import, mapped to why. Empty on purpose: every module in the package
+    # imports cleanly in the environment the suite runs in. An entry here means "this module is not
+    # annotation-checked", so adding one should be a conscious trade, not a side effect of a broad except.
+    OPTIONAL_MODULES = {}
+
     def _import_package_modules(self):
-        """Import every module in the package. Returns (modules, skipped)."""
+        """Import every module in the package. Returns (modules, failures).
+
+        A module that fails to import is a FAILURE, not something to skip: it is never annotation-checked,
+        so tolerating it would let this test quietly stop covering whatever broke - which is the same
+        silent-degradation the test exists to prevent. Every module in the package imports cleanly today,
+        so there is nothing to tolerate.
+
+        If a genuinely optional dependency is introduced later, add the module to OPTIONAL_MODULES with a
+        reason. That is a deliberate, reviewable decision; broadening the except clause is not.
+        """
         modules = []
-        skipped = []
+        failures = []
+
+        # walk_packages swallows ImportError from a package's __init__ unless onerror is given, which
+        # would silently drop that package AND every module under it.
+        def onerror(name):
+            failures.append(f"{name}: package failed to import while walking (its submodules were skipped)")
+
         for module_info in pkgutil.walk_packages(
-            runai_model_streamer.__path__, prefix=f"{runai_model_streamer.__name__}."
+            runai_model_streamer.__path__, prefix=f"{runai_model_streamer.__name__}.", onerror=onerror
         ):
             name = module_info.name
             if ".tests" in name:
@@ -36,11 +56,11 @@ class TestAnnotationsResolve(unittest.TestCase):
             try:
                 modules.append(importlib.import_module(name))
             except Exception as error:
-                # Optional backends (boto3, torch.distributed, a plugin .so) may be absent in this
-                # environment. An import failure is not this test's subject and would fail loudly in the
-                # tests that actually use the module.
-                skipped.append(f"{name}: {type(error).__name__}: {error}")
-        return modules, skipped
+                if name in self.OPTIONAL_MODULES:
+                    continue
+                failures.append(f"{name}: {type(error).__name__}: {error}")
+
+        return modules, failures
 
     def _annotated_targets(self, module):
         """Functions and classes DEFINED in this module, plus the classes' own methods."""
@@ -60,9 +80,26 @@ class TestAnnotationsResolve(unittest.TestCase):
                     if callable(member):
                         yield f"{attr_name}.{member_name}", member
 
+    def test_every_module_imports(self):
+        """A module that cannot be imported is never annotation-checked, so guard that separately.
+
+        Asserted in its own test so a broken import is reported as a broken import, rather than as a
+        missing annotation failure or - worse - as a pass.
+        """
+        modules, import_failures = self._import_package_modules()
+
+        self.assertEqual(
+            import_failures,
+            [],
+            "modules in the package failed to import, so their annotations were never checked:\n  "
+            + "\n  ".join(import_failures),
+        )
+        self.assertTrue(modules, "no modules were discovered in the package - the walk found nothing")
+
     def test_every_annotation_resolves(self):
-        modules, skipped = self._import_package_modules()
-        self.assertTrue(modules, f"no modules could be imported; skipped: {skipped}")
+        modules, import_failures = self._import_package_modules()
+        self.assertEqual(import_failures, [], "see test_every_module_imports")
+        self.assertTrue(modules, "no modules were discovered in the package - the walk found nothing")
 
         failures = []
         for module in modules:

--- a/py/runai_model_streamer/runai_model_streamer/tests/test_annotations.py
+++ b/py/runai_model_streamer/runai_model_streamer/tests/test_annotations.py
@@ -1,0 +1,85 @@
+import importlib
+import pkgutil
+import typing
+import unittest
+
+import runai_model_streamer
+
+
+class TestAnnotationsResolve(unittest.TestCase):
+    """Every annotation in the package must actually resolve.
+
+    These modules use `from __future__ import annotations`, which stores annotations as STRINGS and never
+    evaluates them. That hides two classes of bug from the test suite and from import itself:
+
+      - a type used in an annotation but never imported (`Tuple` without `from typing import Tuple`);
+      - syntax the target interpreter cannot evaluate, e.g. PEP 604 `str | None` on Python 3.8.
+
+    Neither shows up when the code runs. They surface only when something resolves the annotations - a type
+    checker, `typing.get_type_hints`, a docs generator, pydantic - or the moment someone deletes the
+    `from __future__ import annotations` line, at which point the module fails at IMPORT.
+
+    Both bugs were present in this package and invisible until a reviewer read them. This test resolves
+    every annotation so the next one fails here instead.
+    """
+
+    def _import_package_modules(self):
+        """Import every module in the package. Returns (modules, skipped)."""
+        modules = []
+        skipped = []
+        for module_info in pkgutil.walk_packages(
+            runai_model_streamer.__path__, prefix=f"{runai_model_streamer.__name__}."
+        ):
+            name = module_info.name
+            if ".tests" in name:
+                continue
+            try:
+                modules.append(importlib.import_module(name))
+            except Exception as error:
+                # Optional backends (boto3, torch.distributed, a plugin .so) may be absent in this
+                # environment. An import failure is not this test's subject and would fail loudly in the
+                # tests that actually use the module.
+                skipped.append(f"{name}: {type(error).__name__}: {error}")
+        return modules, skipped
+
+    def _annotated_targets(self, module):
+        """Functions and classes DEFINED in this module, plus the classes' own methods."""
+        for attr_name in dir(module):
+            obj = getattr(module, attr_name, None)
+            # __module__ filters out names merely imported into this module - those belong to whichever
+            # module defines them, and are checked when that module is swept.
+            if getattr(obj, "__module__", None) != module.__name__:
+                continue
+
+            if callable(obj) or isinstance(obj, type):
+                yield attr_name, obj
+
+            if isinstance(obj, type):
+                for member_name in vars(obj):
+                    member = getattr(obj, member_name, None)
+                    if callable(member):
+                        yield f"{attr_name}.{member_name}", member
+
+    def test_every_annotation_resolves(self):
+        modules, skipped = self._import_package_modules()
+        self.assertTrue(modules, f"no modules could be imported; skipped: {skipped}")
+
+        failures = []
+        for module in modules:
+            for label, target in self._annotated_targets(module):
+                try:
+                    typing.get_type_hints(target)
+                except Exception as error:
+                    failures.append(f"{module.__name__}.{label}: {type(error).__name__}: {error}")
+
+        self.assertEqual(
+            failures,
+            [],
+            "annotations that do not resolve - a missing import, or syntax this interpreter cannot "
+            "evaluate. They are silent today only because of `from __future__ import annotations`, and "
+            "would become import errors without it:\n  " + "\n  ".join(failures),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cases/testcases.py
+++ b/tests/cases/testcases.py
@@ -40,8 +40,15 @@ def positional_bytes(nbytes, seed):
     Position-sensitive on purpose: with a constant or random-but-uniform filler, a range read from the
     wrong offset, two ranges whose destinations were swapped, or a chunk written at the wrong place
     inside its range all still compare equal. Here each of those changes the bytes.
+
+    Returns exactly nbytes, whether or not that is a multiple of 4: a whole number of words is generated
+    and the tail trimmed, so the last word may be partial. Truncating `nbytes // 4` instead would return
+    a SHORT buffer for any size that is not a multiple of 4, and the resulting file would be shorter than
+    the fixture believes - surfacing later as an EOF error from whichever range reaches the end, which
+    says nothing about the real cause.
     """
-    return (np.arange(nbytes // 4, dtype=np.uint32) + np.uint32(seed)).tobytes()
+    num_words = -(-nbytes // 4)   # ceil, so the buffer covers nbytes before trimming
+    return (np.arange(num_words, dtype=np.uint32) + np.uint32(seed)).tobytes()[:nbytes]
 
 def random_letters(x):
     return ''.join(random.choices(string.ascii_letters, k=x))

--- a/tests/cases/testcases.py
+++ b/tests/cases/testcases.py
@@ -204,8 +204,8 @@ def compatibility_test_cases(backend_class, scheme, bucket_name):
                 contiguous transfers (hence several batches) rather than a single span;
               - a range larger than the object-storage chunk size, so it is split across several
                 backend reads that must land back to back at the right place;
-              - a zero-sized range, which does no backend read at all yet must still produce exactly
-                one response, in order;
+              - zero-sized ranges FIRST, in the middle and LAST in a file's list, each doing no backend
+                read at all yet still producing exactly one response, in order;
               - two ranges reading the SAME source bytes into DIFFERENT destinations, which nothing
                 can satisfy by aliasing or by reusing a destination;
               - two files in one submission, so a response must be attributed to the right file.
@@ -221,19 +221,25 @@ def compatibility_test_cases(backend_class, scheme, bucket_name):
                 f"scattered_small_{random_letters(5)}.bin", SCATTERED_SMALL_FILE_BYTESIZE, seed=1 << 20
             )
 
+            # Zero-sized ranges appear FIRST, in the middle, and LAST. Position matters on its own: the
+            # first range seeds the destination cursor and the coalescing pass, and the last one is the
+            # range whose response carries submission-done - so a zero-sized range dropped or mis-indexed
+            # at either edge fails differently than one in the middle.
             big_ranges = [
-                (11 * MIB, 1024),      # near EOF, requested first: not in file order
+                (3 * MIB, 0),          # zero-sized, FIRST
+                (11 * MIB, 1024),      # near EOF: not in file order
                 (64, 1024),            # far earlier in the file
                 (2 * MIB, 9 * MIB),    # spans several object-storage chunks
                 (1 * MIB, 4096),
-                (5 * MIB, 0),          # zero-sized: no backend read, but still one response
+                (5 * MIB, 0),          # zero-sized, MIDDLE
                 (1 * MIB, 4096),       # same source bytes as above, different destination
-                (0, 4),                # the very first bytes, requested last
+                (0, 4),                # the very first bytes, requested late
             ]
             small_ranges = [
                 (SCATTERED_SMALL_FILE_BYTESIZE - 512, 512),   # the tail
                 (0, SCATTERED_SMALL_FILE_BYTESIZE),           # the whole file
                 (4096, 8192),
+                (SCATTERED_SMALL_FILE_BYTESIZE, 0),           # zero-sized, LAST, and at EOF
             ]
             files = [
                 (big_url, big_content, big_ranges),

--- a/tests/cases/testcases.py
+++ b/tests/cases/testcases.py
@@ -8,6 +8,8 @@ import random
 import string
 import subprocess
 import resource
+import numpy as np
+from unittest.mock import patch
 from safetensors.torch import safe_open
 from tests.safetensors.generator import create_random_safetensors, create_sized_safetensors
 from tests.safetensors.comparison import tensor_maps_are_equal
@@ -17,9 +19,29 @@ from runai_model_streamer.safetensors_streamer.safetensors_streamer import (
     pull_files
 )
 from runai_model_streamer.file_streamer.file_streamer import FileStreamer
+from runai_model_streamer.file_streamer.requests_iterator import (
+    FileChunks,
+    RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME,
+)
 
 METADATA_SUFFIX = ['safetensors', 'json', 'config', 'xml', 'pt', 'bin']
 FILE_COUNT = 5
+
+# Object storage splits a range into chunks of RUNAI_STREAMER_CHUNK_BYTESIZE (default 8 MiB, minimum
+# 5 MiB), so the scattered-ranges file is sized to hold one range that spans several of them.
+MIB = 1024 * 1024
+SCATTERED_BIG_FILE_BYTESIZE = 12 * MIB
+SCATTERED_SMALL_FILE_BYTESIZE = 1 * MIB
+
+
+def positional_bytes(nbytes, seed):
+    """Content in which every 4-byte word encodes its own position (offset/4, plus a per-file seed).
+
+    Position-sensitive on purpose: with a constant or random-but-uniform filler, a range read from the
+    wrong offset, two ranges whose destinations were swapped, or a chunk written at the wrong place
+    inside its range all still compare equal. Here each of those changes the bytes.
+    """
+    return (np.arange(nbytes // 4, dtype=np.uint32) + np.uint32(seed)).tobytes()
 
 def random_letters(x):
     return ''.join(random.choices(string.ascii_letters, k=x))
@@ -105,7 +127,122 @@ def compatibility_test_cases(backend_class, scheme, bucket_name):
             equal, message = tensor_maps_are_equal(our, their)
             if not equal:
                 self.fail(f"Tensor mismatch: {message}")
-        
+
+        def _upload_positional_file(self, filename, bytesize, seed):
+            """Write a position-encoded file locally, upload it, and return (url, local content)."""
+            content = positional_bytes(bytesize, seed)
+            path = os.path.join(self.temp_dir, filename)
+            with open(path, "wb") as f:
+                f.write(content)
+            self.server.upload_file(self.bucket_name, "", path)
+            return f"{self.scheme}://{self.bucket_name}/{filename}", content
+
+        def _stream_and_check_ranges(self, files, memory_limit):
+            """Stream the given scattered ranges and assert every range delivered the exact bytes.
+
+            files: list of (url, local_content, [(offset, size), ...]) - the ranges in the order they
+            are submitted, which is deliberately NOT the order they appear in the file.
+            """
+            requests = [
+                FileChunks(
+                    id=i,
+                    path=url,
+                    offsets=[offset for offset, _ in ranges],
+                    sizes=[size for _, size in ranges],
+                )
+                for i, (url, _content, ranges) in enumerate(files)
+            ]
+
+            got = {}
+            with patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: str(memory_limit)}):
+                with FileStreamer() as streamer:
+                    streamer.stream_files(requests)
+                    for file_id, range_index, tensor in streamer.get_chunks():
+                        key = (file_id, range_index)
+                        self.assertNotIn(key, got, f"range {key} was delivered twice")
+                        # uint8 tensor of shape (1, size) viewing the streamer's buffer; copy the bytes
+                        # out now, since the buffer is reused once the next request is submitted
+                        got[key] = tensor.numpy().tobytes()
+
+            expected_keys = {
+                (i, j)
+                for i, (_url, _content, ranges) in enumerate(files)
+                for j in range(len(ranges))
+            }
+            self.assertEqual(
+                set(got),
+                expected_keys,
+                "every range must produce exactly one response, including zero-sized ones",
+            )
+
+            for i, (url, content, ranges) in enumerate(files):
+                for j, (offset, size) in enumerate(ranges):
+                    expected = content[offset:offset + size]
+                    self.assertEqual(
+                        got[(i, j)],
+                        expected,
+                        f"wrong bytes for range {j} of {url} (offset={offset}, size={size}, "
+                        f"memory_limit={memory_limit})",
+                    )
+
+        def test_scattered_ranges(self):
+            """Read arbitrary, non-contiguous, unordered ranges into scattered destinations.
+
+            This is the per-range destinations API used as a caller would use it, rather than through
+            the safetensors path - which only ever submits one contiguous, ascending span per file and
+            so never produces the shapes this exercises. Each awkward shape below targets a specific
+            position-based assumption:
+
+              - ranges NOT in file order, and with gaps between them, so one file yields several
+                contiguous transfers (hence several batches) rather than a single span;
+              - a range larger than the object-storage chunk size, so it is split across several
+                backend reads that must land back to back at the right place;
+              - a zero-sized range, which does no backend read at all yet must still produce exactly
+                one response, in order;
+              - two ranges reading the SAME source bytes into DIFFERENT destinations, which nothing
+                can satisfy by aliasing or by reusing a destination;
+              - two files in one submission, so a response must be attributed to the right file.
+
+            Run twice: once with an unlimited memory cap (the whole thing is one submission) and once
+            with a cap smaller than the total (the ranges are split across several submissions, so the
+            buffer is reused and the per-request destination packing is re-done).
+            """
+            big_url, big_content = self._upload_positional_file(
+                f"scattered_big_{random_letters(5)}.bin", SCATTERED_BIG_FILE_BYTESIZE, seed=0
+            )
+            small_url, small_content = self._upload_positional_file(
+                f"scattered_small_{random_letters(5)}.bin", SCATTERED_SMALL_FILE_BYTESIZE, seed=1 << 20
+            )
+
+            big_ranges = [
+                (11 * MIB, 1024),      # near EOF, requested first: not in file order
+                (64, 1024),            # far earlier in the file
+                (2 * MIB, 9 * MIB),    # spans several object-storage chunks
+                (1 * MIB, 4096),
+                (5 * MIB, 0),          # zero-sized: no backend read, but still one response
+                (1 * MIB, 4096),       # same source bytes as above, different destination
+                (0, 4),                # the very first bytes, requested last
+            ]
+            small_ranges = [
+                (SCATTERED_SMALL_FILE_BYTESIZE - 512, 512),   # the tail
+                (0, SCATTERED_SMALL_FILE_BYTESIZE),           # the whole file
+                (4096, 8192),
+            ]
+            files = [
+                (big_url, big_content, big_ranges),
+                (small_url, small_content, small_ranges),
+            ]
+
+            # -1 = unlimited: one submission holding every range.
+            self._stream_and_check_ranges(files, memory_limit=-1)
+
+            # Just above the largest single range - the smallest cap that can still make progress. It
+            # splits even ONE file's ranges across submissions, so the buffer is reused between them and
+            # the responses of the later submissions have to be mapped back to the right global range
+            # index. A cap large enough to split only at a file boundary would not cover that.
+            largest_range = max(size for _offset, size in big_ranges + small_ranges)
+            self._stream_and_check_ranges(files, memory_limit=largest_range + 2048)
+
         def test_teardown_while_streaming(self):
             """
             Kill the streamer (context-manager __exit__ -> runai_end) while object-storage

--- a/tests/fuzzing/test_file_streamer.py
+++ b/tests/fuzzing/test_file_streamer.py
@@ -59,7 +59,7 @@ def random_file_chunks(i, dir):
         expected_id_to_results[j] = {
             "expected_content": expected_content,
         }
-    return expected_id_to_results, FileChunks(i, file_path, initial_offset, request_sizes)
+    return expected_id_to_results, FileChunks.contiguous(i, file_path, initial_offset, request_sizes)
 
 class TestFuzzing(unittest.TestCase):
     def setUp(self):
@@ -76,7 +76,7 @@ class TestFuzzing(unittest.TestCase):
             file_to_file_chunks[file_chunks.id] = file_chunks
             files_chunks.append(file_chunks)
 
-        random_memory_mode([chunk for chunk in file_chunks.chunks for file_chunks in files_chunks])
+        random_memory_mode([size for file_chunks in files_chunks for size in file_chunks.sizes])
 
         with FileStreamer() as fs:
             fs.stream_files(files_chunks)

--- a/tests/fuzzing/test_file_streamer.py
+++ b/tests/fuzzing/test_file_streamer.py
@@ -29,11 +29,19 @@ def random_chunks():
 
 
 def random_memory_mode(chunks):
-    memory_mode = random.choice([-1])
-    os.environ[RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME] = str(memory_mode)
+    # -1 unlimited (a single request holds everything), 0 largest-chunk (a request holds one range),
+    # anything else is a byte limit. Only the latter two exercise the multi-request packing loop, the
+    # per-file range bookkeeping across requests, and buffer reuse.
+    #
+    # chunks can legitimately be empty: a file whose generated chunk list has a single entry contributes
+    # only an initial_offset and no ranges at all, so max()/sum() would have nothing to work with.
+    memory_mode = random.choice([-1, 0, 1]) if chunks else -1
     if memory_mode == 1:
+        # never below the largest range, or no request could hold it and packing would stall
         memory_limit = random.randint(max(chunks), sum(chunks))
-        os.environ[RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME] = str(memory_limit)
+    else:
+        memory_limit = memory_mode
+    os.environ[RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME] = str(memory_limit)
 
 def random_file_chunks(i, dir):
     file_content, chunk_sizes = random_chunks()
@@ -78,6 +86,7 @@ class TestFuzzing(unittest.TestCase):
 
         random_memory_mode([size for file_chunks in files_chunks for size in file_chunks.sizes])
 
+        received = set()
         with FileStreamer() as fs:
             fs.stream_files(files_chunks)
             for file, id, dst in fs.get_chunks():
@@ -91,6 +100,16 @@ class TestFuzzing(unittest.TestCase):
                     dst.numpy().tobytes(),
                     expected_id_to_results[id]["expected_content"],
                 )
+                received.add((file, id))
+
+        # Checking the content of whatever arrived is not enough: a request that silently ends the
+        # stream early (issue #157) delivers only correct chunks and would pass. Assert the exact set.
+        expected = {
+            (file_id, range_index)
+            for file_id, results in expected_file_to_id_to_results.items()
+            for range_index in results
+        }
+        self.assertEqual(received, expected)
 
     def tearDown(self):
         os.environ.pop(RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME, None)

--- a/tests/fuzzing/test_file_streamer.py
+++ b/tests/fuzzing/test_file_streamer.py
@@ -12,7 +12,10 @@ MIN_NUM_FILES = 1
 MAX_NUM_FILES = 20
 MIN_CHUNK_NUM = 1
 MAX_CHUNK_NUM = 500
-MIN_CHUNK_SIZE = 16
+# 0, not 16: a zero sized range is legal and is what a zero element tensor produces, so the fuzzer has to
+# be able to generate one. It reaches no storage yet still owes exactly one response, which is where
+# off-by-one indexing shows up - and at 0 it lands anywhere in a file's list, including first and last.
+MIN_CHUNK_SIZE = 0
 MAX_CHUNK_SIZE = 2048
 
 

--- a/tests/fuzzing/test_recovery.py
+++ b/tests/fuzzing/test_recovery.py
@@ -1,0 +1,84 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from runai_model_streamer.file_streamer import (FileStreamer, FileChunks)
+
+
+class TestRecoveryAfterRangeError(unittest.TestCase):
+    """A per-range error must not break the streamer for everything after it.
+
+    Runs against the REAL library on purpose. The mock cannot express this: it serves one submission at a
+    time and resets its state on every runai_request, so responses abandoned by a previous submission simply
+    vanish and the streamer always appears to recover.
+
+    Nothing here is filesystem specific. The drain lives in FileStreamer.request_ready_chunks, above the
+    backend, so an object-storage submission fails and recovers through the very same code - the filesystem
+    is used only because it needs no emulator. Object storage differs in severity, not behaviour: its reads
+    are genuinely in flight when the error fires, so more ranges are still writing into a buffer the next
+    stream_files is about to free.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.path = os.path.join(self.temp_dir, "data.bin")
+        self.size = 4096
+        with open(self.path, "wb") as f:
+            f.write(bytes(i % 256 for i in range(self.size)))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _failing_request(self):
+        # One range reads past EOF and fails; the others are valid, so the submission still owes their
+        # responses when the fail-fast raise abandons the iteration.
+        return [
+            FileChunks(id=0, path=self.path, offsets=[0], sizes=[self.size * 100]),
+            FileChunks(id=1, path=self.path, offsets=[0, 1024], sizes=[1024, 1024]),
+        ]
+
+    def _valid_request(self):
+        return [FileChunks(id=0, path=self.path, offsets=[512], sizes=[512])]
+
+    def test_streamer_recovers_after_a_range_error(self):
+        with FileStreamer() as streamer:
+            streamer.stream_files(self._failing_request())
+            with self.assertRaisesRegex(ValueError, "End of file"):
+                for _ in streamer.get_chunks():
+                    pass
+
+            # Several times, not once: before the fix each retry abandoned its OWN responses in turn, so the
+            # backlog sustained itself and the streamer never recovered. A single retry would also fail
+            # without the fix, but only repetition shows recovery is durable rather than a one-off catch-up.
+            for attempt in range(3):
+                streamer.stream_files(self._valid_request())
+                delivered = [
+                    bytes(tensor.numpy().tobytes()) for _path, _index, tensor in streamer.get_chunks()
+                ]
+                self.assertEqual(
+                    delivered,
+                    [bytes(i % 256 for i in range(512, 1024))],
+                    f"retry {attempt} returned the wrong bytes",
+                )
+
+    def test_streamer_recovers_after_an_abandoned_iteration(self):
+        # The other way out of the generator: the caller stops early with no error at all. Closing the
+        # generator has to drain just as a raise does - safetensors_pytorch raises inside its own
+        # `for ... in get_chunks()` loop, which is this same exit.
+        with FileStreamer() as streamer:
+            streamer.stream_files(
+                [FileChunks(id=0, path=self.path, offsets=[0, 1024, 2048], sizes=[1024, 1024, 1024])]
+            )
+            for _path, _index, _tensor in streamer.get_chunks():
+                break   # two ranges left unconsumed
+
+            streamer.stream_files(self._valid_request())
+            delivered = [
+                bytes(tensor.numpy().tobytes()) for _path, _index, tensor in streamer.get_chunks()
+            ]
+            self.assertEqual(delivered, [bytes(i % 256 for i in range(512, 1024))])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/safetensors/generator.py
+++ b/tests/safetensors/generator.py
@@ -120,6 +120,15 @@ def generate_random_data(min_tensors, max_tensors):
         dtype = random.choice(all_available)
         shape = tuple(random.randint(1, 10) for _ in range(random.randint(1, 4)))
 
+        # Sometimes a ZERO ELEMENT tensor (one dimension is 0). It is a real safetensors entry - the
+        # reference implementation writes it with data_offsets [x, x] and yields it on read - and it is
+        # where a zero sized range comes from in production. Every layer has to carry it: one response is
+        # still owed for it, its shape must survive, and the distributed path must not drop it.
+        if random.randint(1, 6) == 1:
+            dims = list(shape)
+            dims[random.randrange(len(dims))] = 0
+            shape = tuple(dims)
+
         try:
             if dtype == torch.bool:
                 t = torch.rand(shape) > 0.5


### PR DESCRIPTION
# Per-range destinations: a general scatter-gather read API

Closes #162 

Each read range now carries its own source offset, size **and destination pointer**. Ranges need not
be contiguous in the file, contiguous in memory, or ordered. This removes the "one contiguous span
per file into one buffer" assumption that was baked into the C signature and, from there, into the
C++ internals.

The driver is making the C++ library usable on its own, without Python — **checkpoint restore** being
the first such caller: it reads tensors into destinations that are already allocated and scattered,
in an order it does not control.

## API change

`runai_request` is the only public signature that changes. It is a **breaking change**; the sole
in-tree caller (the Python layer) is updated in this PR.

```diff
 int runai_request(
     void * streamer,
     SubmissionId * out_submission_id,
     unsigned num_files,
     const char ** paths,
-    size_t * file_offsets,     // ONE start offset per file
-    size_t * bytesizes,        // total bytes per file
-    void ** dsts,              // for CPU: dsts[0] ONLY - one buffer for everything
-    unsigned * num_sizes,      // number of sub-requests per file
-    size_t ** internal_sizes   // sizes only; each began where the previous ended
+    unsigned * num_ranges,     // number of ranges for each file
+    size_t * range_offsets,    // flat, sum(num_ranges) source offsets
+    size_t * range_sizes,      // flat, sum(num_ranges) sizes
+    void ** range_dsts         // flat, sum(num_ranges) destination pointers
 );
```

The three flat arrays are indexed identically and grouped by file in the order of `paths`: file `f`'s
ranges occupy `[sum(num_ranges[0..f)), sum(num_ranges[0..f]))`. Parallel flat arrays rather than an
array of structs, so the Python layer hands its lists over with no per-range object allocated — that
matters at a few hundred thousand tensors per model.

Source ranges may overlap freely; **destinations must not overlap**.

`runai_response` keeps its signature, but `index` now means the index of the range within its file
*as submitted*, so a caller that submitted out of file order maps responses straight back to its own
array.

## Review guide

Suggested order — the first three carry the design, the rest follow from them.

| Order | File | What to look at |
| --- | --- | --- |
| 1 | `cpp/streamer/streamer.h` | The contract: the new argument block and its indexing rule |
| 2 | `cpp/streamer/impl/request/request.h` | `ReadRange` / `FileRanges` — the internal shape |
| 3 | `cpp/streamer/impl/assigner/assigner.{h,cc}` | `ContiguousTransfer` and the two-step coalesce → assign |
| 4 | `cpp/streamer/impl/workload/workload.{h,cc}` | Batches in a vector; why no key is needed |
| 5 | `cpp/streamer/impl/streamer/streamer.cc` | Building batches per transfer rather than per file |
| 6 | `py/.../file_streamer/requests_iterator.py` | `FileChunks`, and destination packing as a running cursor |
| 7 | `py/.../distributed_streamer/partition.py` | The re-coalescing loop that is now unnecessary |

### 1-3. Keeping reads sequential

One read per range would be a disaster for the common case, where hundreds of thousands of tensors
are laid out back to back. Before any work is divided between workers, the assigner coalesces into a
**`ContiguousTransfer`** — a maximal group of ranges adjacent in **both** the file and the destination
buffer, servable by one sequential read; never spanning two files.

So the contiguous case costs exactly what it did before — one sequential read per file — and a
scattered request degrades into as many reads as it genuinely has disjoint groups. Coalescing runs
before work division, so a single-worker streamer benefits too. Ranges coalesce in caller-supplied
order; unordered arrival is logged at DEBUG so lost coalescing is visible rather than silent.

### 4. Several batches per file

A file now yields one `ContiguousTransfer` per contiguous group, so it can contribute **several
batches to one workload**. `Workload` keyed batches by `file_index` and asserted the key was unique —
and `ASSERT` here is fatal and always active, so the first submission with non-contiguous ranges in a
single file aborted.

Batches are now a `std::vector` in insertion order. Nothing looked one up by key: responses route by
`Batch` pointer and errors are attributed by `batch.file_index`. The key only invited conflating
position with file identity — which `report_workload` was in fact doing, fixed here.

Pointer stability is safe by construction: `&batch` is taken in `enqueue` only *after* the workload
has been moved into its node-stable `_inflight` entry, and no batch is added to a dispatched
workload, so the vector is never grown again afterwards. `Batch` has `const` members, so it is
move-constructible but not move-assignable — fine for `push_back`, and the same pattern
`Batches::_batches` already uses.

### 6-7. Python layer

- `FileChunks` takes parallel `offsets` / `sizes`; `FileChunks.contiguous()` is the convenience
  constructor for the common case.
- Destination packing is now a running cursor — placement is free once each range names its own
  destination, so there is no per-file sub-buffer and no requirement that a file's ranges be adjacent.
- `range_dsts` doubles as the response-time lookup table, which removed the prefix-sum walk per
  response (`get_global_file_and_chunk` is now O(1); it was quadratic in the file count).
- `partition.py` no longer re-coalesces: one `FileChunks` per path per rank, 16,308 → 66 on a
  66-shard model.

## Testing

Two tests were added that do what nothing else did. This matters: **the entire suite stayed green
while the new capability was broken outright**, because every existing caller still submitted one
contiguous span per file. Tests that adapt old arguments into the new shape exercise the shim, not
the feature.

- `streamer_test.cc` — `Async.Scattered_Ranges_And_Destinations`: descending file order, gaps, a
  zero-sized range, two ranges reading identical source bytes, a **separate allocation per
  destination**, and a guard byte past each destination to catch over-long writes.
- `tests/cases/testcases.py` — `test_scattered_ranges`, in the shared object-storage suite, so it runs
  against **MinIO, fake-GCS and Azurite**. Uses `FileStreamer.stream_files` directly rather than the
  safetensors path. File content encodes its own position, so a wrong offset or a swapped destination
  changes the bytes. Covers ranges out of file order, a range larger than the object-storage chunk
  size (split across several backend reads), a zero-sized range (no backend read, still exactly one
  response), duplicate source ranges to different destinations, and two files in one submission — run
  under both an unlimited memory cap and a cap tight enough to split one file's ranges across
  submissions.

A mock-backed test could not have caught the bug: `cpp/mock/streamer-mock.cc` reads each file as one
contiguous span, so it would have passed while doing the wrong thing.

### Results

| Scope | Runs | Failures |
| --- | --- | --- |
| C++ `//...` (37 targets) | 100 each = 3,700 executions | 0 |
| Python unit tests | 100 | 0 |
| Fuzzing | 100 | 0 |
| GCS (fake-gcs, 14 tests) | 100 | 0 |
| Azure (Azurite, 16 tests) | 100 | 0 |
| S3 (MinIO, 17 tests) | 10 | 0 |

C++ runs used `--flaky_test_attempts=1 --nocache_test_results`, so nothing was silently retried or
replayed from cache. MinIO is 10 rather than 100 because each iteration takes ~5m16s.

## Also in this PR

**A pre-existing S3 test flake (~20%), fixed in the harness only.** `Multiple_Files_Error` left
`RUNAI_STREAMER_S3_MOCK_RESPONSE_CODE` set across `runai_end`, so the mock refused to close the
backend during teardown; the wrapper then forgot the handle anyway, leaving the plugin open while the
wrapper believed it closed. Every later object-storage operation in that process failed
`UnknownError`, permanently. Two independent fixes: the mock no longer applies read-failure injection
to the lifecycle, and the test releases the env before `runai_end`. **No production code changed** —
measured 0/60 before #160, 8/40 after, 0/100 with the fixes.

There is a residual product weakness this exposes but does not fix: a genuinely failed
`close_backend` still leaves the two sides disagreeing, silently and permanently. It is unreachable
from the tests now. A first attempt at fixing it was reverted because closing from `DESTROY` violates
the refcount contract asserted at `s3_wrapper_test.cc:150` — closing out from under a live client is
worse than the latent bug. Worth its own issue.

## Not in this PR

- **Packing policy.** The requests iterator still uses Next-Fit. Analysed as bin packing: the gain
  from a better policy is nil at the default 40 GB limit, and the ring buffer changes the problem.
- **Sorting batches within a workload.** Behavioural, needs measurement and a sort-key decision;
  only matters once a worker holds several transfers of one file. Belongs with contiguous-span
  partitioning.
- **Allocation helpers.** Callers supply their own destinations. That is what makes checkpoint
  restore work.

## Compatibility

- **Breaking** at the C API. `runai_request` loses two arguments and changes the meaning of two more;
  a caller built against the old header will not compile.
- `runai_response`, `runai_start`, `runai_end`, `runai_set_credentials` and `runai_list_files` are
  unchanged.
- No environment-variable or behavioural change for existing safetensors callers: they submit the
  same contiguous spans, which coalesce back into the same single sequential read per file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for arbitrary, non-contiguous, reordered ranges across multiple files.
  * Added independently addressed destination buffers and per-range response tracking.
  * Zero-byte ranges now produce successful responses.
  * Improved concurrent multi-file streaming and memory-limited request handling.

* **Bug Fixes**
  * Empty files and submissions no longer interrupt streaming.
  * Improved validation, error isolation, and backend lifecycle handling.
  * Preserved accurate response ordering and indexing for scattered ranges.
  * File access errors now report specific per-range status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->