### PR TITLE
Support custom process groups in distributed streamer

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -63,6 +63,31 @@ with SafetensorsStreamer() as streamer:
        tensors[name] = tensor.clone().detach() # returning tensors on the specified device, which is CUDA:0
 ```
 
+To restrict streaming to a subset of the default process group, pass an
+existing process group to the streamer constructor. Only members of that group
+need to create and use the streamer:
+
+```python
+import torch.distributed as dist
+from runai_model_streamer import SafetensorsStreamer
+
+streaming_group = dist.new_group(ranks=[8, 9, 10, 11, 12, 13, 14, 15])
+
+with SafetensorsStreamer(process_group=streaming_group) as streamer:
+    streamer.stream_files(
+        file_paths,
+        s3_credentials=None,
+        device="cuda:0",
+        is_distributed=True,
+    )
+    for name, tensor in streamer.get_tensors():
+        tensors[name] = tensor.clone().detach()
+```
+
+The provided process group defines the exact set of streaming participants and
+takes precedence over the local/global mode environment variables. The caller
+retains ownership of the group; closing the streamer does not destroy it.
+
 ##### Requirements
 
 Distributed streaming allocates reusable staging buffers on each device, which hold the data of the yielded tensors

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -56,10 +56,17 @@ def aligned_offset(base_ptr: int, current_offset: int, alignment: int) -> int:
 DEFAULT_BROADCAST_TIMEOUT = timedelta(seconds=600)
 
 class DistributedStreamer:
-    def __init__(self) -> None:
+    def __init__(self, process_group: Optional[dist.ProcessGroup] = None) -> None:
+        """Create a streamer, optionally scoped to an existing process group.
+
+        When ``process_group`` is provided, all distributed streaming collectives
+        use that exact group. The caller retains ownership of the group.
+        """
         self.file_streamer = FileStreamer()
-        self.params = _distributedStreamerParams()
-        self.distributed_streamer = _distributedStreamer(self.file_streamer)
+        self.params = _distributedStreamerParams(process_group)
+        self.distributed_streamer = _distributedStreamer(
+            self.file_streamer, process_group
+        )
         self.is_distributed = False
 
     def __enter__(self) -> DistributedStreamer:
@@ -78,7 +85,7 @@ class DistributedStreamer:
     def get_group_size(self) -> int:
         if not dist.is_initialized():
             return 1
-        return dist.get_world_size()
+        return dist.get_world_size(group=self.params.process_group)
 
     def get_cuda_free_memory(self) -> int:
         if not torch.cuda.is_available():
@@ -115,7 +122,7 @@ class DistributedStreamer:
         # Do not distribute if backend type does not match device type
         # In auto mode, do not distribute if backend is not nccl
         if self.is_distributed:
-            backend_name = dist.get_backend()
+            backend_name = dist.get_backend(group=self.params.process_group)
             if backend_name == "nccl" and device == "cpu":
                 logger.info("[RunAI Streamer][Distributed] Note: Torch distributed backend %s is not supported for CPU device - fallback to non distributed streaming", backend_name)
                 self.is_distributed = False
@@ -127,7 +134,7 @@ class DistributedStreamer:
                 self.is_distributed = False
 
         # check if there is enough free memory on the device
-        if self.is_distributed and torch.cuda.is_available() and dist.get_backend() == "nccl":
+        if self.is_distributed and torch.cuda.is_available() and dist.get_backend(group=self.params.process_group) == "nccl":
             free_memory = self.get_cuda_free_memory()
             if free_memory < 2 * self.params.max_chunk:
                 logger.warning(f"[RunAI Streamer][Distributed] Warning: Not enough memory on the device for distributed streaming - fallback to non distributed streaming, free memory: {free_memory} bytes, required minimun: {2 * self.params.max_chunk} bytes")
@@ -164,7 +171,8 @@ class DistributedStreamer:
         return
 
 class _distributedStreamerParams:
-    def __init__(self) -> None:
+    def __init__(self, process_group: Optional[dist.ProcessGroup] = None) -> None:
+        self.process_group = process_group
         self.num_processes_on_node = None
         self.my_global_rank = 0
         self.groups_by_ranks = []
@@ -174,7 +182,16 @@ class _distributedStreamerParams:
     def get_group_size(self) -> int:
         if not dist.is_initialized():
             return 1
-        return dist.get_world_size()
+        return dist.get_world_size(group=self.process_group)
+
+    def get_process_group_ranks(self) -> List[int]:
+        group_size = self.get_group_size()
+        if self.process_group is None:
+            return list(range(group_size))
+        return [
+            dist.get_global_rank(self.process_group, group_rank)
+            for group_rank in range(group_size)
+        ]
 
     def get_broadcast_timeout(self) -> timedelta:
         timeout_val = os.environ.get("RUNAI_STREAMER_DIST_TIMEOUT")
@@ -193,12 +210,16 @@ class _distributedStreamerParams:
         if not dist.is_initialized():
             return 1, 0, [[0]]
 
-        world_size = dist.get_world_size()
-
-        if world_size == 1:
-            return 1, 0, [[0]]
+        world_size = self.get_group_size()
 
         my_global_rank = dist.get_rank()
+
+        if self.process_group is not None:
+            group_ranks = self.get_process_group_ranks()
+            return world_size, my_global_rank, [group_ranks]
+
+        if world_size == 1:
+            return 1, my_global_rank, [[my_global_rank]]
 
         # 1. Discover all peers on all nodes (this is a global collective)
         # create global group just for discovering the local ranks
@@ -243,8 +264,10 @@ class _distributedStreamerParams:
             os.environ["RUNAI_STREAMER_PROCESS_GROUP_SIZE"] = str(self.num_processes_on_node)
 
 class _distributedStreamer:
-    def __init__(self, file_streamer : FileStreamer) -> None:
+    def __init__(self, file_streamer : FileStreamer, process_group: Optional[dist.ProcessGroup] = None) -> None:
         self.file_streamer = file_streamer
+        self.process_group = process_group
+        self.owns_distribution_group = process_group is None
         self.device = None
         self.partitions = {} # partitions of all the input file_stream_requests
         self.rank_file_chunks_list = {} # post Partitioning FileChunks to be streamed by this rank
@@ -265,21 +288,25 @@ class _distributedStreamer:
         return self
 
     def __exit__(self, exc_type: any, exc_value: any, traceback: any) -> None:
-        if self.distribution_group:
+        if self.distribution_group is not None:
             try:
                 # Only attempt a barrier if there was no exception.
                 if exc_type is None:
                     torch.distributed.barrier(group=self.distribution_group)
             finally:
-                # ALWAYS destroy the group.
-                torch.distributed.destroy_process_group(group=self.distribution_group)
+                if self.owns_distribution_group:
+                    torch.distributed.destroy_process_group(group=self.distribution_group)
                 del self.distribution_group
                 self.distribution_group = None
         return
 
     def create_distribution_group(self) -> Optional[dist.ProcessGroup]:
-        if self.distribution_group:
+        if self.distribution_group is not None:
             return self.distribution_group
+
+        if self.process_group is not None:
+            self.local_group_global_ranks = self.groups_by_ranks[0]
+            return self.process_group
 
         is_global_group = int(os.environ.get("RUNAI_STREAMER_DIST_GLOBAL", "0")) == 1
 
@@ -352,7 +379,7 @@ class _distributedStreamer:
         # set rank in the new distribution group
         self.set_rank()
 
-        if self.original_group_rank == 0:
+        if self.rank == 0:
             logger.info(f"[RunAI Streamer][Distributed] Using distributed streaming between {self.group_size} processes")
 
         # partition tensors between processes in the distribution group

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/dist_test_distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/dist_test_distributed_streamer.py
@@ -82,6 +82,76 @@ class TestDistributedStreamer(unittest.TestCase):
             if self.rank == 0:
                 print(f"\n✅ Success test verified on all {self.world_size} ranks.")
 
+    def test_1_success_with_borrowed_process_group(self):
+        if self.world_size < 2:
+            self.skipTest("This test requires at least 2 processes.")
+
+        requests = self._prepare_file_requests(
+            [{"size": 1024, "chunks": [256, 256, 256, 256]}]
+        )
+        process_group = dist.new_group(ranks=list(range(self.world_size)))
+        with open(requests[0].path, "rb") as file:
+            original_data = file.read()
+        chunks = [None] * len(requests[0].chunks)
+
+        env_vars = {
+            "RUNAI_STREAMER_DIST": "1",
+            "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0",
+        }
+        with patch.dict(os.environ, env_vars):
+            with patch.object(
+                dist,
+                "destroy_process_group",
+                wraps=dist.destroy_process_group,
+            ) as destroy_process_group:
+                with DistributedStreamer(process_group=process_group) as streamer:
+                    streamer.stream_files(requests, None, "cpu", True)
+                    for _req_id, chunk_idx, data_tensor in streamer.get_chunks():
+                        chunks[chunk_idx] = data_tensor.cpu().numpy().tobytes()
+
+                destroy_process_group.assert_not_called()
+
+        self.assertEqual(original_data, b"".join(chunks))
+        dist.barrier(group=process_group)
+        dist.destroy_process_group(process_group)
+
+    def test_1_success_with_subset_process_group(self):
+        if self.world_size < 3:
+            self.skipTest("This test requires at least 3 processes.")
+
+        requests = self._prepare_file_requests(
+            [{"size": 1024, "chunks": [256, 256, 256, 256]}]
+        )
+        process_group = dist.new_group(ranks=[1, 2])
+
+        if self.rank == 0:
+            return
+
+        with open(requests[0].path, "rb") as file:
+            original_data = file.read()
+        chunks = [None] * len(requests[0].chunks)
+
+        env_vars = {
+            "RUNAI_STREAMER_DIST": "1",
+            "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0",
+        }
+        with patch.dict(os.environ, env_vars):
+            with patch.object(
+                dist,
+                "destroy_process_group",
+                wraps=dist.destroy_process_group,
+            ) as destroy_process_group:
+                with DistributedStreamer(process_group=process_group) as streamer:
+                    streamer.stream_files(requests, None, "cpu", True)
+                    for _req_id, chunk_idx, data_tensor in streamer.get_chunks():
+                        chunks[chunk_idx] = data_tensor.cpu().numpy().tobytes()
+
+                destroy_process_group.assert_not_called()
+
+        self.assertEqual(original_data, b"".join(chunks))
+        dist.barrier(group=process_group)
+        dist.destroy_process_group(process_group)
+
     def test_1_success_empty_file_list(self):
         requests = []
         env_vars = {"RUNAI_STREAMER_DIST": "1"}

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/test_distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/test_distributed_streamer.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import torch.distributed as dist
+
+from runai_model_streamer.distributed_streamer.distributed_streamer import (
+    _distributedStreamer,
+    _distributedStreamerParams,
+)
+
+
+class TestBorrowedProcessGroup(unittest.TestCase):
+    def test_rank_discovery_is_scoped_to_process_group(self):
+        process_group = Mock(spec=dist.ProcessGroup)
+        params = _distributedStreamerParams(process_group)
+
+        with (
+            patch.object(dist, "is_initialized", return_value=True),
+            patch.object(dist, "get_world_size", return_value=2) as get_world_size,
+            patch.object(dist, "get_rank", return_value=8),
+            patch.object(dist, "get_global_rank", side_effect=[8, 9]),
+            patch.object(dist, "new_group") as new_group,
+            patch.object(dist, "all_gather_object") as all_gather_object,
+        ):
+            result = params.find_local_ranks()
+
+        self.assertEqual(result, (2, 8, [[8, 9]]))
+        get_world_size.assert_called_with(group=process_group)
+        new_group.assert_not_called()
+        all_gather_object.assert_not_called()
+
+    def test_single_rank_group_preserves_global_rank(self):
+        process_group = Mock(spec=dist.ProcessGroup)
+        params = _distributedStreamerParams(process_group)
+
+        with (
+            patch.object(dist, "is_initialized", return_value=True),
+            patch.object(dist, "get_world_size", return_value=1),
+            patch.object(dist, "get_rank", return_value=7),
+            patch.object(dist, "get_global_rank", return_value=7),
+        ):
+            result = params.find_local_ranks()
+
+        self.assertEqual(result, (1, 7, [[7]]))
+
+    def test_borrowed_process_group_is_not_destroyed(self):
+        process_group = Mock(spec=dist.ProcessGroup)
+        streamer = _distributedStreamer(Mock(), process_group)
+        streamer.distribution_group = process_group
+
+        with (
+            patch.object(dist, "barrier") as barrier,
+            patch.object(dist, "destroy_process_group") as destroy_process_group,
+        ):
+            streamer.__exit__(None, None, None)
+
+        barrier.assert_called_once_with(group=process_group)
+        destroy_process_group.assert_not_called()
+        self.assertIsNone(streamer.distribution_group)
+
+    def test_borrowed_process_group_is_used_without_creating_a_group(self):
+        process_group = Mock(spec=dist.ProcessGroup)
+        streamer = _distributedStreamer(Mock(), process_group)
+        streamer.groups_by_ranks = [[8, 9]]
+
+        with patch.object(dist, "new_group") as new_group:
+            result = streamer.create_distribution_group()
+
+        self.assertIs(result, process_group)
+        self.assertEqual(streamer.local_group_global_ranks, [8, 9])
+        new_group.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -198,8 +198,8 @@ class ObjectStorageModel:
 
 
 class SafetensorsStreamer:
-    def __init__(self) -> None:
-        self.file_streamer = DistributedStreamer()
+    def __init__(self, process_group: Optional[torch.distributed.ProcessGroup] = None) -> None:
+        self.file_streamer = DistributedStreamer(process_group=process_group)
         self.files_to_tensors_metadata = {}
         self.total_size = 0
         self.device_str = None

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/streamer_mock.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/streamer_mock.py
@@ -178,12 +178,12 @@ class StreamerPatcher:
     # === Shim for SafetensorsStreamer ===
        
     def create_mock_streamer(self, *args, **kwargs):
-        return self.MockSafetensorsStreamer(self)
+        return self.MockSafetensorsStreamer(self, *args, **kwargs)
 
     class MockSafetensorsStreamer:
-        def __init__(self, patcher: StreamerPatcher):
+        def __init__(self, patcher: StreamerPatcher, *args, **kwargs):
             self.patcher = patcher
-            self.original_streamer = OriginalSafetensorsStreamer()
+            self.original_streamer = OriginalSafetensorsStreamer(*args, **kwargs)
             self.files_to_tensors_metadata = {}
 
         def __enter__(self) -> "MockSafetensorsStreamer":


### PR DESCRIPTION
## Summary

add an optional custom process group to `SafetensorsStreamer` and `DistributedStreamer`;
scope distributed rank discovery, backend checks, partitioning, barriers, and broadcasts to the provided group; 
treat a provided process group as borrowed and leave its lifecycle to the caller; 
add document explaining how to use it.

When no process group is provided, the existing global/host-local group selection behavior is preserved.

Fixes #165

## Tests

- added unit tests for process-group-scoped rank discovery, direct group reuse, and caller ownership;
- added a distributed test that streams through a borrowed all-rank process group;
- added a distributed test where only a subset process group participates.
