### PR TITLE
Ring Buffer : Bound Host RAM by Storage Bandwidth Instead of Model Size 

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -22,8 +22,13 @@ build_azure_test:
 		"--config=${ARCH}" \
 		--config=azurite
 
+# --config=${ARCH} matches the `build` target above. Without it this lands in a DIFFERENT output tree and
+# repoints the bazel-bin symlink there, where libstreamer.so and the backend plugins are stale or absent -
+# every later run then fails with `OSError: ... cannot open shared object file`, which reads like a
+# product regression and is not one.
 build_mock:
-	bazel build mock:libstreamer-mock.so
+	bazel build mock:libstreamer-mock.so \
+		"--config=${ARCH}"
 
 test:
 	bazel test //...:all

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <cstring>
 #include <filesystem>
+#include <map>
 #include <vector>
 #include "utils/fd/fd.h"
 #include "utils/logging/logging.h"
@@ -33,15 +34,23 @@ struct State {
     int error = 0;
 };
 
-State __state;
-std::vector<State> __multi_state;
-unsigned __multi_file_count = 0;
-unsigned __current_multi_file = 0;
+// One submission in flight. The caller may have several at once, so each owns its files, its cursor and
+// its response counters - sharing any of them attributes one submission's progress to another, and a
+// shared file list means a second request destroys the first one's pending work.
+struct Submission {
+    std::vector<State> files;
+    unsigned current_file = 0;
+    unsigned response_total = 0;
+    unsigned response_given = 0;
 
-// multi-request bookkeeping: the mock serves one submission at a time, so a single id/counter suffices.
-SubmissionId __submission_id = 0;
-unsigned __response_total = 0;   // total sub-range responses expected for the current submission
-unsigned __response_given = 0;   // responses handed out so far
+    bool drained() const { return response_given >= response_total; }
+};
+
+// Live submissions, keyed by the id responses are attributed to and erased once drained. A map (rather
+// than a list walked per response) because the id is the lookup key and ids are handed out in order.
+std::map<SubmissionId, Submission> __submissions;
+SubmissionId __last_submission_id = 0;    // monotonic for the process, so a stale id is never reused
+SubmissionId __round_robin_cursor = 0;    // id served last, so the next response comes from another submission
 
 
 // Record one file's ranges. The seek is deliberately NOT done here: each range seeks to its own offset
@@ -125,7 +134,11 @@ int response(void * streamer, unsigned * index, State * state)
 
 extern "C" int runai_start(void ** streamer)
 {
-    __state = State{};
+    // A new streamer starts with nothing in flight. runai_request now ACCUMULATES submissions rather than
+    // replacing the single one, so without a reset here a test that abandons a submission undrained would
+    // leak it into the next test's responses.
+    __submissions.clear();
+    __round_robin_cursor = 0;
     *streamer = reinterpret_cast<void*>(0x123456789ABCDEF0);
     return 0;
 }
@@ -134,23 +147,21 @@ extern "C" void runai_end(void * streamer)
 {
 }
 
-// Pull the next ready sub-range across the multi-file state (shared by runai_response). Returns -1 when
-// every file is drained.
-static int mock_next_response(void * streamer, unsigned * file_index, unsigned * index)
+// Serve the next range of ONE submission. Returns -1 when that submission has no range left.
+static int submission_next_response(void * streamer, Submission & submission, unsigned * file_index, unsigned * index)
 {
-    if (__current_multi_file >= __multi_state.size()) {
-        return -1; // All files processed
+    while (submission.current_file < submission.files.size())
+    {
+        State & state = submission.files[submission.current_file];
+        if (state.current_item >= state.total_items)
+        {
+            ++submission.current_file;
+            continue;
+        }
+        *file_index = submission.current_file;
+        return response(streamer, index, &state);
     }
-
-    State& state = __multi_state[__current_multi_file];
-
-    if (state.current_item >= state.total_items) {
-        ++__current_multi_file;
-        return mock_next_response(streamer, file_index, index); // recurse to next file
-    }
-
-    *file_index = __current_multi_file;
-    return response(streamer, index, &state);
+    return -1;
 }
 
 extern "C" int runai_set_credentials(
@@ -173,11 +184,7 @@ extern "C" int runai_request(
     void ** range_dsts
 )
 {
-    __multi_state.clear();
-    __current_multi_file = 0;
-    __multi_file_count = num_files;
-    __response_total = 0;
-    __response_given = 0;
+    Submission submission;
 
     // The range arrays are flat and grouped by file in the order of paths; base walks that grouping.
     // Each file's ranges are handed over as they were submitted - every range keeps its own offset,
@@ -196,14 +203,20 @@ extern "C" int runai_request(
                 range_dsts + base,
                 &state);
 
-        __response_total += n;
-        __multi_state.push_back(std::move(state));
+        submission.response_total += n;
+        submission.files.push_back(std::move(state));
         base += n;
     }
 
-    __submission_id += 1;
+    const SubmissionId id = ++__last_submission_id;
     if (out_submission_id != nullptr) {
-        *out_submission_id = __submission_id;
+        *out_submission_id = id;
+    }
+
+    // A submission owing no responses is never made live: it can never be drained, so it would stall the
+    // round robin forever. It is simply complete on arrival, which is what no responses means.
+    if (submission.response_total > 0) {
+        __submissions.emplace(id, std::move(submission));
     }
     return 0;
 }
@@ -217,19 +230,41 @@ extern "C" int runai_response(
     unsigned timeout_ms
 )
 {
-    int r = mock_next_response(streamer, file_index, index);
-    if (r < 0) {
-        return r;   // no more sub-ranges (drained) - not a real response
+    if (__submissions.empty()) {
+        return -1;   // everything drained - not a real response
     }
+
+    // Round robin across the live submissions so responses INTERLEAVE. The real streamer makes no ordering
+    // promise across submissions - its responder is demuxed by submission id for exactly that reason - so a
+    // mock that drained them in order would certify a caller that wrongly assumes ordering. Deterministic,
+    // and with one submission in flight it is the previous file-by-file order.
+    auto it = __submissions.upper_bound(__round_robin_cursor);
+    if (it == __submissions.end()) {
+        it = __submissions.begin();
+    }
+
+    const SubmissionId id = it->first;
+    Submission & submission = it->second;
+
+    int r = submission_next_response(streamer, submission, file_index, index);
+    if (r < 0) {
+        return r;   // a live submission always has a range left; defensive
+    }
+
+    __round_robin_cursor = id;
+    submission.response_given += 1;
 
     // r is a real sub-range result: 0 (Success) or a per-range error code. Set the out-params in both cases
     // (like the real C API), so a per-range error still carries its submission id and submission_done.
     if (out_submission_id != nullptr) {
-        *out_submission_id = __submission_id;
+        *out_submission_id = id;
     }
-    __response_given += 1;
+    const bool done = submission.drained();
     if (submission_done != nullptr) {
-        *submission_done = (__response_given >= __response_total) ? 1 : 0;
+        *submission_done = done ? 1 : 0;
+    }
+    if (done) {
+        __submissions.erase(it);
     }
     return r;
 }

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -259,7 +259,12 @@ extern "C" int runai_response(
 {
     StreamerState & state = state_of(streamer);
     if (state.submissions.empty()) {
-        return -1;   // everything drained - not a real response
+        // Unreachable: the caller only asks while it has a live request, and every request owes at least
+        // one response. Deliberately NOT FinishedError - that maps to None in libstreamer.py, so an
+        // accounting bug would look like a clean teardown and silently truncate the stream. -1 is no
+        // ResponseCode, and the out-params are left zeroed, so submission id 0 - never issued, since
+        // SubmissionsMgr::_next_id starts at 1 - makes get_chunks raise on the first iteration.
+        return -1;
     }
 
     // Round robin across the live submissions so responses INTERLEAVE. The real streamer makes no ordering

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -46,11 +46,27 @@ struct Submission {
     bool drained() const { return response_given >= response_total; }
 };
 
-// Live submissions, keyed by the id responses are attributed to and erased once drained. A map (rather
-// than a list walked per response) because the id is the lookup key and ids are handed out in order.
-std::map<SubmissionId, Submission> __submissions;
-SubmissionId __last_submission_id = 0;    // monotonic for the process, so a stale id is never reused
-SubmissionId __round_robin_cursor = 0;    // id served last, so the next response comes from another submission
+// ONE STREAMER's state, owned by the handle. The real library makes runai_start `new impl::Streamer`
+// and runai_end `delete` it (streamer/streamer.cc:22-56), so submissions and ids belong to a handle,
+// not to the process. Holding them in globals instead let a second runai_start wipe the submissions a
+// live streamer was still draining - and that is reachable, not hypothetical: FileStreamer.list_files
+// starts a temporary streamer when used outside its context manager, so listing during a stream would
+// corrupt it here while working in production. A mock that disagrees with the product about this
+// certifies nothing either way.
+struct StreamerState {
+    // Live submissions, keyed by the id responses are attributed to and erased once drained. A map
+    // (rather than a list walked per response) because the id is the lookup key and ids are ordered.
+    std::map<SubmissionId, Submission> submissions;
+    SubmissionId next_id = 1;              // 0 is reserved, matching impl SubmissionsMgr::_next_id
+    SubmissionId round_robin_cursor = 0;   // id served last, so the next response comes from another submission
+};
+
+// The handle IS the state. Every entry point casts it back, so a stale handle faults here exactly as it
+// would in the real library, rather than quietly working against shared globals.
+StreamerState & state_of(void * streamer)
+{
+    return *static_cast<StreamerState *>(streamer);
+}
 
 
 // Record one file's ranges. The seek is deliberately NOT done here: each range seeks to its own offset
@@ -134,17 +150,27 @@ int response(void * streamer, unsigned * index, State * state)
 
 extern "C" int runai_start(void ** streamer)
 {
-    // A new streamer starts with nothing in flight. runai_request now ACCUMULATES submissions rather than
-    // replacing the single one, so without a reset here a test that abandons a submission undrained would
-    // leak it into the next test's responses.
-    __submissions.clear();
-    __round_robin_cursor = 0;
-    *streamer = reinterpret_cast<void*>(0x123456789ABCDEF0);
+    // A fresh state per streamer, so a new one cannot disturb another that is still draining. No reset of
+    // anything shared is needed (or possible) any more - there is nothing shared.
+    try
+    {
+        *streamer = new StreamerState;
+    }
+    catch (...)
+    {
+        // Literal rather than the enum, following this file's convention: mock/BUILD deps are only
+        // //utils/fd and //common/submission, so common/response_code is not on the include path.
+        return 11;   // common::ResponseCode::UnknownError
+    }
     return 0;
 }
 
 extern "C" void runai_end(void * streamer)
 {
+    // Really free it, like the real runai_end. A leaked state would be harmless in a test process, but
+    // then a handle used after runai_end would keep working here and fault in production - which is the
+    // bug FileStreamer.__exit__ clears self.streamer to avoid.
+    delete static_cast<StreamerState *>(streamer);
 }
 
 // Serve the next range of ONE submission. Returns -1 when that submission has no range left.
@@ -208,7 +234,8 @@ extern "C" int runai_request(
         base += n;
     }
 
-    const SubmissionId id = ++__last_submission_id;
+    StreamerState & state = state_of(streamer);
+    const SubmissionId id = state.next_id++;
     if (out_submission_id != nullptr) {
         *out_submission_id = id;
     }
@@ -216,7 +243,7 @@ extern "C" int runai_request(
     // A submission owing no responses is never made live: it can never be drained, so it would stall the
     // round robin forever. It is simply complete on arrival, which is what no responses means.
     if (submission.response_total > 0) {
-        __submissions.emplace(id, std::move(submission));
+        state.submissions.emplace(id, std::move(submission));
     }
     return 0;
 }
@@ -230,7 +257,8 @@ extern "C" int runai_response(
     unsigned timeout_ms
 )
 {
-    if (__submissions.empty()) {
+    StreamerState & state = state_of(streamer);
+    if (state.submissions.empty()) {
         return -1;   // everything drained - not a real response
     }
 
@@ -238,9 +266,9 @@ extern "C" int runai_response(
     // promise across submissions - its responder is demuxed by submission id for exactly that reason - so a
     // mock that drained them in order would certify a caller that wrongly assumes ordering. Deterministic,
     // and with one submission in flight it is the previous file-by-file order.
-    auto it = __submissions.upper_bound(__round_robin_cursor);
-    if (it == __submissions.end()) {
-        it = __submissions.begin();
+    auto it = state.submissions.upper_bound(state.round_robin_cursor);
+    if (it == state.submissions.end()) {
+        it = state.submissions.begin();
     }
 
     const SubmissionId id = it->first;
@@ -251,7 +279,7 @@ extern "C" int runai_response(
         return r;   // a live submission always has a range left; defensive
     }
 
-    __round_robin_cursor = id;
+    state.round_robin_cursor = id;
     submission.response_given += 1;
 
     // r is a real sub-range result: 0 (Success) or a per-range error code. Set the out-params in both cases
@@ -264,7 +292,7 @@ extern "C" int runai_response(
         *submission_done = done ? 1 : 0;
     }
     if (done) {
-        __submissions.erase(it);
+        state.submissions.erase(it);
     }
     return r;
 }

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -11,6 +11,11 @@ from runai_model_streamer.file_streamer import (
     FileChunks,
 )
 
+from runai_model_streamer.file_streamer.requests_iterator import (
+    RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME,
+    DEFAULT_MEMORY_LIMIT_STRING,
+)
+
 from runai_model_streamer.distributed_streamer.partition import (
     partition,
     get_total_number_of_chunks,
@@ -260,6 +265,8 @@ class _distributedStreamer:
         self.my_global_rank = 0
         self.groups_by_ranks = []
         self.broadcast_timeout = DEFAULT_BROADCAST_TIMEOUT
+        self.num_processes_on_node = 1
+        self.max_chunk = 0
 
     def __enter__(self) -> _distributedStreamer:
         return self
@@ -343,6 +350,8 @@ class _distributedStreamer:
         self.groups_by_ranks = params.groups_by_ranks
         self.broadcast_timeout = params.broadcast_timeout
         self.max_chunk = params.max_chunk
+        # the ranks sharing this host: the divisor for the node-total memory limit (see rank_memory_limit)
+        self.num_processes_on_node = params.num_processes_on_node
 
         # create distribution group for configuring timeout and possibly broadcast locally in each node 
         # The group must be created before partitioning the tensors, in case the group will be local
@@ -377,22 +386,47 @@ class _distributedStreamer:
             return
 
         # read files
-        original_memory_limit = os.environ.get("RUNAI_STREAMER_MEMORY_LIMIT")
-        try:
-            # for distributed streaming only - change default memory limit to unlimited
-            if self.original_group_rank == 0:
-                logger.debug(f"[RunAI Streamer][Distributed] Setting memory limit to unlimited")
-            if original_memory_limit == None:
-                os.environ["RUNAI_STREAMER_MEMORY_LIMIT"] = "-1"
-            self.file_streamer.stream_files(self.rank_file_chunks_list, credentials, "cpu")
-        except Exception as e:
-            raise e
-        finally:
-            if original_memory_limit is None:
-                os.environ.pop("RUNAI_STREAMER_MEMORY_LIMIT", None)
-            else:
-                os.environ["RUNAI_STREAMER_MEMORY_LIMIT"] = original_memory_limit
+        self.file_streamer.stream_files(
+            self.rank_file_chunks_list, credentials, "cpu", memory_limit=self.rank_memory_limit()
+        )
         self.reading_from_storage = True
+
+    def rank_memory_limit(self) -> int:
+        """This rank's share of RUNAI_STREAMER_MEMORY_LIMIT, which is a NODE total.
+
+        The ranks sharing a host share its RAM, so reading the variable per rank silently multiplies it
+        by the number of ranks on the node - which is how a 40 GB setting becomes hundreds of GB
+        resident. Divide by the ranks on THIS node, not the world size: with tensor parallelism spanning
+        hosts, world size counts ranks whose RAM sits on other machines, and every buffer would be
+        shrunk by the number of nodes for no benefit. It is also the denominator that matches the
+        partitioning, which is done within the node group - so the ranks sharing a host are exactly the
+        set that collectively reads one copy of the data.
+
+        -1 (unlimited) and 0 (largest range) are modes rather than quantities, and pass through unchanged.
+
+        This replaces the previous forced -1. Unlimited sized the host buffer to the whole of this rank's
+        share, which is the model-sized allocation the ring buffer exists to remove; the ring makes a
+        bounded limit cheap, so there is no longer a reason to opt out of one by default."""
+        configured = os.environ.get(RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME)
+        limit = int(configured) if configured is not None else int(DEFAULT_MEMORY_LIMIT_STRING)
+        if limit <= 0:
+            return limit
+
+        ranks = max(1, self.num_processes_on_node or 1)
+        # Floored at the largest range: a rank has to be able to buffer one whole tensor or streaming
+        # cannot progress, and with many ranks on a node the plain share can fall below that. A rank at
+        # that floor gets exactly ONE buffer - the ring never exceeds its budget, so a share that pays
+        # for a single buffer buys a single buffer, i.e. the sequential drain-then-refill path. Ring
+        # depth on such a node needs a larger node total, not a larger floor.
+        per_rank = max(limit // ranks, self.max_chunk)
+
+        if self.original_group_rank == 0:
+            logger.info(
+                f"[RunAI Streamer][Distributed] CPU memory limit "
+                f"{humanize.naturalsize(limit, binary=True)} is a node total: {ranks} rank(s) on this "
+                f"node -> {humanize.naturalsize(per_rank, binary=True)} per rank"
+            )
+        return per_rank
 
     def get_chunks(self) -> Iterator:
         if not self.file_streamer:

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -156,6 +156,27 @@ class DistributedStreamer:
         else:
             self.distributed_streamer.stream_files(file_stream_requests, credentials, device, self.params)
 
+    def ring_info(self) -> Optional[Tuple[int, int, int]]:
+        """(rank, num_buffers, buffer_size) for the ring the last stream_files built, or None if it
+        built none.
+
+        An accessor rather than letting callers walk into the streamer, because the ring is two layers
+        down and which layer owns it depends on is_distributed - though both paths share the one
+        FileStreamer created in __init__, so the walk itself is short. The rank belongs here too: it is
+        the piece FileStreamer cannot know, which is why the ring is reported at INFO from the session
+        boundary (SafetensorsStreamer) and only at DEBUG where it is built.
+
+        None is normal, not an error: a rank whose share of the partition is empty returns from
+        stream_files before building an iterator, and list_files-only use never builds one either."""
+        requests_iterator = getattr(self.file_streamer, "requests_iterator", None)
+        if requests_iterator is None:
+            return None
+        return (
+            self.params.my_global_rank,
+            requests_iterator.num_buffers,
+            requests_iterator.buffer_size,
+        )
+
     def get_chunks(self) -> Iterator:
         if not self.file_streamer:
             raise ValueError("Streamer not initialized")

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -66,6 +66,7 @@ class DistributedStreamer:
         self.params = _distributedStreamerParams()
         self.distributed_streamer = _distributedStreamer(self.file_streamer)
         self.is_distributed = False
+        self._ring_info: Optional[Tuple[int, int, int]] = None
 
     def __enter__(self) -> DistributedStreamer:
         self.file_streamer.__enter__()
@@ -146,6 +147,10 @@ class DistributedStreamer:
             is_distributed: bool,
     ) -> None:
 
+        # Cleared before dispatch, so a call that builds no ring - or raises before it does - reports
+        # nothing rather than whatever the previous call left behind.
+        self._ring_info = None
+
         self.params.set_params(file_stream_requests)
 
         # check if distributed streaming can be used
@@ -153,29 +158,40 @@ class DistributedStreamer:
 
         if not self.is_distributed:
             self.file_streamer.stream_files(file_stream_requests, credentials, device)
+            built_ring = True
         else:
             self.distributed_streamer.stream_files(file_stream_requests, credentials, device, self.params)
+            # A rank whose share of the partition is empty returns before building anything, leaving the
+            # iterator from the safetensors metadata read in place. Reporting THAT as the model ring is
+            # worse than reporting nothing: `1 x 8 Bytes` against the model's byte total reads exactly
+            # like a ring clamped to a single buffer, which is the failure this report exists to expose.
+            built_ring = self.distributed_streamer.reading_from_storage
+
+        requests_iterator = getattr(self.file_streamer, "requests_iterator", None)
+        if built_ring and requests_iterator is not None:
+            self._ring_info = (
+                self.params.my_global_rank,
+                requests_iterator.num_buffers,
+                requests_iterator.buffer_size,
+            )
 
     def ring_info(self) -> Optional[Tuple[int, int, int]]:
         """(rank, num_buffers, buffer_size) for the ring the last stream_files built, or None if it
         built none.
 
-        An accessor rather than letting callers walk into the streamer, because the ring is two layers
-        down and which layer owns it depends on is_distributed - though both paths share the one
-        FileStreamer created in __init__, so the walk itself is short. The rank belongs here too: it is
-        the piece FileStreamer cannot know, which is why the ring is reported at INFO from the session
-        boundary (SafetensorsStreamer) and only at DEBUG where it is built.
+        Captured during stream_files rather than read from the streamer on demand. The FileStreamer is
+        shared with the safetensors metadata reads, so its requests_iterator outlives the call that
+        created it: asking it later answers "the last ring anyone built", which is a different question
+        and gives a wrong answer on exactly the rank that read no model data.
 
-        None is normal, not an error: a rank whose share of the partition is empty returns from
-        stream_files before building an iterator, and list_files-only use never builds one either."""
-        requests_iterator = getattr(self.file_streamer, "requests_iterator", None)
-        if requests_iterator is None:
-            return None
-        return (
-            self.params.my_global_rank,
-            requests_iterator.num_buffers,
-            requests_iterator.buffer_size,
-        )
+        An accessor rather than letting callers walk into the streamer, because which layer performs the
+        read depends on is_distributed. The rank belongs here too: it is the piece FileStreamer cannot
+        know, which is why the ring is reported at INFO from the session boundary (SafetensorsStreamer)
+        and only at DEBUG where it is built.
+
+        None is normal, not an error: a rank whose share of the partition is empty reads nothing, and
+        list_files-only use never streams at all."""
+        return self._ring_info
 
     def get_chunks(self) -> Iterator:
         if not self.file_streamer:

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -435,10 +435,12 @@ class _distributedStreamer:
 
         ranks = max(1, self.num_processes_on_node or 1)
         # Floored at the largest range: a rank has to be able to buffer one whole tensor or streaming
-        # cannot progress, and with many ranks on a node the plain share can fall below that. A rank at
-        # that floor gets exactly ONE buffer - the ring never exceeds its budget, so a share that pays
-        # for a single buffer buys a single buffer, i.e. the sequential drain-then-refill path. Ring
-        # depth on such a node needs a larger node total, not a larger floor.
+        # cannot progress, and with many ranks on a node the plain share can fall below that. A rank
+        # driven down to that floor usually gets exactly ONE buffer - its share pays for a single
+        # largest-range buffer and no more, i.e. the sequential drain-then-refill path - so ring depth on
+        # such a node needs a larger node total, not a larger floor. "Usually" because max_chunk is the
+        # largest range across ALL ranks: a rank holding nothing that big, or less data than the floor,
+        # can still get a deeper ring.
         per_rank = max(limit // ranks, self.max_chunk)
 
         if self.original_group_rank == 0:

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/dist_test_distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/dist_test_distributed_streamer.py
@@ -15,6 +15,10 @@ from runai_model_streamer.distributed_streamer.distributed_streamer import (
     RUNAI_STREAMER_CUDA_ALIGNMENT_ENV_VAR,
 )
 from runai_model_streamer.file_streamer import FileChunks
+from runai_model_streamer.file_streamer.requests_iterator import (
+    RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME,
+    RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME,
+)
 
 class TestDistributedStreamer(unittest.TestCase):
     
@@ -24,6 +28,9 @@ class TestDistributedStreamer(unittest.TestCase):
         cls.world_size = dist.get_world_size()
 
     def setUp(self):
+        # No buffer-size override is needed any more. The buffer size is now derived as budget // N, so
+        # it scales with the fixture instead of being a fixed 1 GiB minimum that collapsed onto the whole
+        # stream and left every test with a single request and a ring that never cycled.
         if self.rank == 0:
             self.temp_dir = tempfile.mkdtemp()
         else:
@@ -81,6 +88,47 @@ class TestDistributedStreamer(unittest.TestCase):
                 self.assertEqual(original_data_map[req.id], reconstructed_bytes)
             if self.rank == 0:
                 print(f"\n✅ Success test verified on all {self.world_size} ranks.")
+
+    def test_1_success_deep_ring_buffer(self):
+        # Pins the ring exactly, rather than letting it fall out of whatever the fixture happens to be:
+        # a rank with several submissions in flight, recycling buffers between them.
+        #
+        # RUNAI_STREAMER_MEMORY_LIMIT is a NODE total, so it is divided by the ranks on this host: the
+        # limit below is sized for 4 buffers PER RANK (4 x 260 x world_size). The buffer size is not set
+        # at all - budget // 4 lands on the chunk size on its own, which is the point of the new rule.
+        chunk = 260
+        num_chunks = 20
+        buffers_per_rank = 4
+        file_specs = [{"size": chunk * num_chunks, "chunks": [chunk] * num_chunks}]
+        requests = self._prepare_file_requests(file_specs)
+
+        original_data_map = {}
+        for req in requests:
+            with open(req.path, "rb") as f:
+                original_data_map[req.id] = f.read()
+        reconstructed_data_map = {req.id: [None] * len(req.sizes) for req in requests}
+
+        env_vars = {
+            "RUNAI_STREAMER_DIST": "1",
+            "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0",
+            RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: str(buffers_per_rank),
+            RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: str(chunk * buffers_per_rank * self.world_size),
+        }
+        with patch.dict(os.environ, env_vars):
+            with DistributedStreamer() as streamer:
+                streamer.stream_files(requests, None, "cpu", True)
+                for req_id, chunk_idx, data_tensor in streamer.get_chunks():
+                    reconstructed_data_map[req_id][chunk_idx] = data_tensor.cpu().numpy().tobytes()
+
+                # the per-rank share really did buy a deep ring, not the floor of 2
+                requests_iterator = streamer.distributed_streamer.file_streamer.requests_iterator
+                self.assertEqual(requests_iterator.buffer_size, chunk)
+                self.assertEqual(requests_iterator.num_buffers, buffers_per_rank)
+
+            for req_id, chunks in reconstructed_data_map.items():
+                self.assertEqual(original_data_map[req_id], b"".join(chunks))
+            if self.rank == 0:
+                print(f"\n✅ Deep ring buffer test verified on all {self.world_size} ranks.")
 
     def test_1_success_empty_file_list(self):
         requests = []

--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/test_rank_memory_limit.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/tests/test_rank_memory_limit.py
@@ -1,0 +1,60 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from runai_model_streamer.distributed_streamer.distributed_streamer import _distributedStreamer
+from runai_model_streamer.file_streamer.requests_iterator import (
+    RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME,
+    DEFAULT_MEMORY_LIMIT_STRING,
+)
+
+
+class TestRankMemoryLimit(unittest.TestCase):
+    """RUNAI_STREAMER_MEMORY_LIMIT is a NODE total: the ranks sharing a host share its RAM, so each
+    rank gets the total divided by the ranks on THAT host."""
+
+    def streamer(self, num_processes_on_node: int, max_chunk: int = 0) -> _distributedStreamer:
+        streamer = _distributedStreamer(None)
+        streamer.num_processes_on_node = num_processes_on_node
+        streamer.max_chunk = max_chunk
+        return streamer
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "8000"})
+    def test_divides_the_node_total_between_the_ranks_on_the_node(self):
+        self.assertEqual(self.streamer(8).rank_memory_limit(), 1000)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "8000"})
+    def test_single_rank_gets_the_whole_total(self):
+        self.assertEqual(self.streamer(1).rank_memory_limit(), 8000)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_the_default_is_a_node_total_too(self):
+        # the default has to be divided as well, or an unset variable means 40 GB PER RANK - which is
+        # the multiplication this change exists to remove
+        self.assertEqual(self.streamer(8).rank_memory_limit(), int(DEFAULT_MEMORY_LIMIT_STRING) // 8)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "8000"})
+    def test_largest_range_floors_the_share(self):
+        # a rank must be able to buffer one whole tensor or streaming cannot progress; with many ranks
+        # on a node the plain share falls below that
+        self.assertEqual(self.streamer(8, max_chunk=2500).rank_memory_limit(), 2500)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "-1"})
+    def test_unlimited_passes_through(self):
+        # -1 and 0 are modes, not quantities: dividing them would turn a mode into nonsense
+        self.assertEqual(self.streamer(8).rank_memory_limit(), -1)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "0"})
+    def test_largest_chunk_mode_passes_through(self):
+        self.assertEqual(self.streamer(8).rank_memory_limit(), 0)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "8000"})
+    def test_unknown_rank_count_is_treated_as_one(self):
+        # find_local_ranks has not run (or returned nothing): fall back to the whole total rather than
+        # dividing by zero
+        self.assertEqual(self.streamer(None).rank_memory_limit(), 8000)
+        self.assertEqual(self.streamer(0).rank_memory_limit(), 8000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -194,6 +194,11 @@ class FileStreamer:
         while True:
             yield from self.request_ready_chunks()
 
+            # The request is drained and the consumer has resumed past its last yield, so every view
+            # into its buffer has been used. Returning it to the pool before building the next request
+            # is what lets a ring of N buffers serve an arbitrarily long stream.
+            self.requests_iterator.release(self.active_request)
+
             self.active_request = self.requests_iterator.next_request()
             if self.active_request is None:
                 break

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -153,8 +153,30 @@ class FileStreamer:
             device: Optional[str] = "cpu",
             memory_limit: Optional[int] = None,
 ) -> None:
+        # The previous stream has to be drained before another can start, because two things here are
+        # single slots rather than per submission:
+        #
+        #   1. self.requests_iterator. Assigning the new one below drops the ONLY reference to the
+        #      previous ring's pool - live_requests, which holds the other handle, is reset on the same
+        #      line - so numpy frees it while the C++ workers still hold raw range_dsts pointers into
+        #      it. That is a use after free into reallocated heap, not merely a lost response.
+        #   2. get_global_file_and_range resolves a response through self.requests_iterator. Even with
+        #      the old pool kept alive, an earlier submission's buffer_index would be looked up against
+        #      the NEW ring's buffer list: a different buffer, plausible looking bytes, and no error.
+        #
+        # Submission ids are unique and the responder demuxes by them, so attribution is not what
+        # breaks - lifetime and ownership are. To lift this restriction and allow overlapping streams
+        # (see design_multiple_requests.md): keep live_requests and outstanding across calls, hang the
+        # owning iterator off the FilesRequest instead of off self, release buffers to that owner, and
+        # let each iterator live until its last submission drains. Then delete this check.
+        if self.outstanding > 0:
+            raise ValueError(
+                f"cannot start a new stream while {self.outstanding} response(s) are outstanding from "
+                f"the previous one - consume or close get_chunks() before calling stream_files again"
+            )
+
         if not homogeneous_paths([file_stream_request.path for file_stream_request in file_stream_requests]):
-            raise RunaiStreamerInvalidInputException("Cannot stream files from multiple source types in parallel") 
+            raise RunaiStreamerInvalidInputException("Cannot stream files from multiple source types in parallel")
 
         self.device_str = device
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -157,9 +157,9 @@ class FileStreamer:
         # single slots rather than per submission:
         #
         #   1. self.requests_iterator. Assigning the new one below drops the ONLY reference to the
-        #      previous ring's pool - live_requests, which holds the other handle, is reset on the same
-        #      line - so numpy frees it while the C++ workers still hold raw range_dsts pointers into
-        #      it. That is a use after free into reallocated heap, not merely a lost response.
+        #      previous ring's pool - live_requests, which holds the other handle, is cleared a few
+        #      lines after it - so numpy frees it while the C++ workers still hold raw range_dsts
+        #      pointers into it. A use after free into reallocated heap, not merely a lost response.
         #   2. get_global_file_and_range resolves a response through self.requests_iterator. Even with
         #      the old pool kept alive, an earlier submission's buffer_index would be looked up against
         #      the NEW ring's buffer list: a different buffer, plausible looking bytes, and no error.
@@ -196,9 +196,16 @@ class FileStreamer:
         """Fill the ring: build and submit a request for every free buffer, until the data runs out.
 
         Keeping every buffer busy is the whole point - the C++ layer then always has work queued behind
-        the submission being consumed, so the request boundary stops being a barrier. One submission
-        already spans every worker (Assigner divides its bytes across the whole pool), so this buys
-        pipelining depth, not parallelism.
+        the submission being consumed, so the request boundary stops being a barrier. It is not extra
+        parallelism: one submission already spans every worker (Assigner::assign divides its bytes across
+        _num_workers).
+
+        Removing that barrier is not the whole story, though, and the comment used to claim it was.
+        Depth also helps when there is NO barrier to remove - a model small enough that the ring spans it
+        and never recycles. Measured on Llama-3-8B over S3, 4 buffers beat 1 by 2.06% (n=11/10,
+        permutation p=0.0043). The mechanism is not established; candidates are per-worker work
+        granularity and interleaving at workload boundaries. Keep the depth, do not trust an argument
+        that says it cannot matter here.
 
         The three range arrays are flat and grouped by file, in the order of paths - which is the order
         the request's files are in, and the order range_dsts was built in, so they pass through as is.

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -11,6 +11,7 @@ from runai_model_streamer.libstreamer.libstreamer import (
 )
 from runai_model_streamer.file_streamer.requests_iterator import (
     FilesRequestsIteratorWithBuffer,
+    FilesRequest,
     FileChunks,
 )
 
@@ -61,7 +62,10 @@ class FileStreamer:
         self.s3_session = None
         self.s3_credentials = None    # resolved credentials (from handle_object_store)
         self._credentialed_streamer = None   # the C++ handle we already applied credentials to
-        self.submission_id = None     # id of the submission currently being drained (runai_request)
+        # Live submissions: id -> the request whose buffer it is filling. Several are in flight at once,
+        # so responses are demuxed by id rather than assumed to belong to a single current submission.
+        self.live_requests: Dict[int, FilesRequest] = {}
+        self.outstanding = 0          # responses still owed across ALL live submissions
 
     def __enter__(self) -> "FileStreamer":
         self.streamer = runai_start()
@@ -147,6 +151,7 @@ class FileStreamer:
             file_stream_requests: List[FileChunks],
             credentials: Optional[S3Credentials] = None,
             device: Optional[str] = "cpu",
+            memory_limit: Optional[int] = None,
 ) -> None:
         if not homogeneous_paths([file_stream_request.path for file_stream_request in file_stream_requests]):
             raise RunaiStreamerInvalidInputException("Cannot stream files from multiple source types in parallel") 
@@ -157,88 +162,78 @@ class FileStreamer:
             # first object-storage path resolves + applies the credentials to the streamer, once
             file_stream_request.path = self.handle_object_store(file_stream_request.path, self.streamer, credentials)
 
-        self.requests_iterator: FilesRequestsIteratorWithBuffer = FilesRequestsIteratorWithBuffer.with_memory_mode(file_stream_requests)
-
-        self.active_request = self.requests_iterator.next_request()
-        if self.active_request is None:
-            return
-
-        self.submit_active_request()
-
-    def submit_active_request(self) -> None:
-        # The three range arrays are flat and grouped by file, in the order of paths - which is the order
-        # the request's files are in, and the order range_dsts was built in, so it passes through as is.
-        #
-        # range_dsts are RAW ADDRESSES into the requests iterator's buffer: they keep nothing alive. The
-        # buffer must outlive the submission, until its last response has been consumed. That holds here
-        # because self.requests_iterator owns the buffer and is only replaced by the next stream_files,
-        # which cannot start before get_chunks has drained this one.
-        request = self.active_request
-        self.submission_id = runai_request(
-            self.streamer,
-            [file_request.path for file_request in request.files],
-            [len(file_request.sizes) for file_request in request.files],
-            [offset for file_request in request.files for offset in file_request.offsets],
-            [size for file_request in request.files for size in file_request.sizes],
-            request.range_dsts,
+        self.requests_iterator: FilesRequestsIteratorWithBuffer = FilesRequestsIteratorWithBuffer.with_memory_mode(
+            file_stream_requests, memory_limit
         )
+        self.live_requests = {}
+        self.outstanding = 0
 
+        self._submit_while_buffers_free()
+
+    def _submit_while_buffers_free(self) -> None:
+        """Fill the ring: build and submit a request for every free buffer, until the data runs out.
+
+        Keeping every buffer busy is the whole point - the C++ layer then always has work queued behind
+        the submission being consumed, so the request boundary stops being a barrier. One submission
+        already spans every worker (Assigner divides its bytes across the whole pool), so this buys
+        pipelining depth, not parallelism.
+
+        The three range arrays are flat and grouped by file, in the order of paths - which is the order
+        the request's files are in, and the order range_dsts was built in, so they pass through as is.
+
+        range_dsts are RAW ADDRESSES into the ring's buffers: they keep nothing alive. A buffer must
+        outlive its submission, until that submission's last response has been consumed - which is
+        exactly when get_chunks releases it back to the pool."""
+        while self.requests_iterator.has_free_buffer():
+            request = self.requests_iterator.next_request()
+            if request is None:
+                return    # no data left to submit; the live submissions still have to be drained
+
+            submission_id = runai_request(
+                self.streamer,
+                [file_request.path for file_request in request.files],
+                [len(file_request.sizes) for file_request in request.files],
+                [offset for file_request in request.files for offset in file_request.offsets],
+                [size for file_request in request.files for size in file_request.sizes],
+                request.range_dsts,
+            )
+            self.live_requests[submission_id] = request
+            self.outstanding += request.num_ranges
+
+    # This function iterates over the ready ranges of every live submission, in whatever order the C++
+    # layer completes them. The indexes in a response are relative to its own submission and need to be
+    # translated to the global index in the chunks list, which is what the response's request does.
     def get_chunks(self) -> Iterator:
         if not self.streamer:
             raise ValueError("Streamer not initialized")
-        
-        if self.active_request is None:
-            return 
-        
-        
-        while True:
-            yield from self.request_ready_chunks()
 
-            # The request is drained and the consumer has resumed past its last yield, so every view
-            # into its buffer has been used. Returning it to the pool before building the next request
-            # is what lets a ring of N buffers serve an arbitrarily long stream.
-            self.requests_iterator.release(self.active_request)
-
-            self.active_request = self.requests_iterator.next_request()
-            if self.active_request is None:
-                break
-
-            self.submit_active_request()
-
-    # This function iterates over indexes of ready chunks.
-    # The indexes are relative to the last request that sent
-    # And need to be translated to global index in the chunks list
-    def request_ready_chunks(self) -> Iterator:
-        # Only one submission is in flight at a time (get_chunks fully drains the active request before
-        # submitting the next), so every response here belongs to self.submission_id and the count loop is
-        # exact. runai_response blocks indefinitely (timeout 0) and returns None only on teardown.
-        num_ranges = self.active_request.num_ranges
-        consumed = 0
         try:
-            for i in range(num_ranges):
+            while self.live_requests:
+                # runai_response blocks indefinitely (timeout 0) and returns None only on teardown. It
+                # serves whichever submission completed a range first, so responses INTERLEAVE.
                 response = runai_response(self.streamer)
                 if response is None:
-                    return
-                consumed += 1
-                ret, submission_id, file_relative_index, range_relative_index, _submission_done = response
-                # Single-submission invariant: FileStreamer drains one submission fully before starting the next,
-                # so every response must belong to self.submission_id. This catches a stale response from a prior
-                # (e.g. failed) submission being misattributed to this one and returning wrong data. Use if/raise
-                # (not assert) so this data-integrity check is not stripped under `python -O`.
-                # REMOVE THIS for the ring buffer: FileStreamer will then manage CONCURRENT submissions and
-                # request_ready_chunks must demux responses by submission_id instead of enforcing a single one.
-                if submission_id != self.submission_id:
-                    raise ValueError(
-                        f"response for submission {submission_id} but expected {self.submission_id}"
-                    )
-                # single-submission streaming: any per-sub-range error fails the whole stream (fail-fast)
+                    return    # teardown: no further responses are coming
+                ret, submission_id, file_relative_index, range_relative_index, submission_done = response
+                self.outstanding -= 1
+
+                # Demux: the response names its own submission, and that submission names the request
+                # whose frozen bases interpret it. An unknown id means a response from a submission this
+                # streamer never made or has already retired - reading it would return wrong data. Use
+                # if/raise (not assert) so this data-integrity check is not stripped under `python -O`.
+                request = self.live_requests.get(submission_id)
+                if request is None:
+                    raise ValueError(f"response for unknown submission {submission_id}")
+
+                # any per-sub-range error fails the whole stream (fail-fast); the finally below then
+                # drains every live submission, not just this one
                 if ret != SUCCESS_ERROR_CODE:
                     raise ValueError(
                         f"Could not receive response from libstreamer due to: {runai_response_str(ret)}"
                     )
 
                 file_id, range_index, range_buffer = self.requests_iterator.get_global_file_and_range(
-                    self.active_request, file_relative_index, range_relative_index
+                    request, file_relative_index, range_relative_index
                 )
                 # create one dimensional tensor from the range buffer
                 # we return a tensor of shape (1, range_buffer.size)
@@ -253,23 +248,34 @@ class FileStreamer:
                 else:
                     device_tensor = tensor.to(self.device_str)
                     yield file_id, range_index, device_tensor
-        finally:
-            # The submission must be drained however this generator ends, not only when it runs to
-            # completion. range_dsts are raw addresses into the requests iterator's buffer, so a range still
-            # in flight writes into memory the next stream_files has already freed and handed to the next
-            # submission - and its late response is then delivered to that submission's drain loop, which
-            # rejects it and abandons ITS responses in turn, so the streamer never recovers.
-            # A finally covers both exits: the fail-fast raises above, and a caller abandoning the generator
-            # (break, or raising inside its for loop - which safetensors_pytorch does), since closing a
-            # generator resumes it here.
-            self.drain_active_submission(num_ranges - consumed)
 
-    def drain_active_submission(self, remaining: int) -> None:
+                # Resumed past the yield, so the consumer is done with this tensor. If it was the
+                # submission's last response, every view into its buffer has now been consumed - which
+                # makes this the exact instant the buffer can be recycled. Refilling here is also what
+                # provides backpressure: no new I/O is issued until a buffer actually comes free, so the
+                # ring self throttles to consumer speed.
+                if submission_done:
+                    del self.live_requests[submission_id]
+                    self.requests_iterator.release(request)
+                    self._submit_while_buffers_free()
+        finally:
+            self.drain_live_submissions()
+
+    def drain_live_submissions(self) -> None:
+        """Consume the responses still owed by every live submission, however this generator ended.
+
+        range_dsts are raw addresses into the ring's buffers, so a range still in flight writes into
+        memory the next stream_files has already freed and handed to another submission - and its late
+        response is then delivered to that submission's loop, which rejects it as unknown and abandons
+        ITS responses in turn, so the streamer never recovers. A finally covers every exit: the
+        fail-fast raises above, and a caller abandoning the generator (break, or raising inside its for
+        loop - which safetensors_pytorch does), since closing a generator resumes it there."""
         # self.streamer is already cleared if the generator is collected after __exit__; runai_end has joined
         # the workers by then, so there is nothing left to wait for and the handle must not be touched.
-        if not self.streamer:
-            return
-        for _ in range(remaining):
-            if runai_response(self.streamer) is None:
-                return   # teardown: no further responses are coming
+        if self.streamer:
+            while self.outstanding > 0:
+                if runai_response(self.streamer) is None:
+                    break   # teardown: no further responses are coming
+                self.outstanding -= 1
+        self.live_requests = {}
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -306,5 +306,11 @@ class FileStreamer:
                 if runai_response(self.streamer) is None:
                     break   # teardown: no further responses are coming
                 self.outstanding -= 1
+        # Zero it even when the loop above could not run. Safe, and that needs saying, because this is
+        # the counter stream_files' use-after-free guard reads: both paths that skip the loop mean the
+        # responder is gone (runai_end has joined the workers), so no range can still be writing into
+        # the pool. Leaving a stale count instead makes the guard reject every later stream_files on
+        # this object - a FileStreamer re-entered after a generator outlived its context is bricked.
+        self.outstanding = 0
         self.live_requests = {}
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -215,7 +215,7 @@ class FileStreamer:
                 if response is None:
                     return
                 consumed += 1
-                ret, submission_id, file_relative_index, chunk_relative_index, _submission_done = response
+                ret, submission_id, file_relative_index, range_relative_index, _submission_done = response
                 # Single-submission invariant: FileStreamer drains one submission fully before starting the next,
                 # so every response must belong to self.submission_id. This catches a stale response from a prior
                 # (e.g. failed) submission being misattributed to this one and returning wrong data. Use if/raise
@@ -232,20 +232,22 @@ class FileStreamer:
                         f"Could not receive response from libstreamer due to: {runai_response_str(ret)}"
                     )
 
-                file_path, chunk_index, chunk_buffer = self.requests_iterator.get_global_file_and_chunk(file_relative_index, chunk_relative_index)
-                # create one dimensional tensor from the chunk buffer
-                # we return a tensor of shape (1, chunk_buffer.size)
-                # the data type of the original chunk_buffer, as created by the requests_iterator, is preserved (uint8)
-                tensor = torch.from_numpy(chunk_buffer).view(1, -1)
+                file_id, range_index, range_buffer = self.requests_iterator.get_global_file_and_range(
+                    self.active_request, file_relative_index, range_relative_index
+                )
+                # create one dimensional tensor from the range buffer
+                # we return a tensor of shape (1, range_buffer.size)
+                # the data type of the original range_buffer, as created by the requests_iterator, is preserved (uint8)
+                tensor = torch.from_numpy(range_buffer).view(1, -1)
 
                 # currently file streamer is always reading a cpu buffer
                 # so we don't need to move the tensor to the device
                 # for future GDS/CUDA support we will need to move the tensor to the device (cpu or different device)
                 if self.device_str == "cpu":
-                    yield file_path, chunk_index, tensor
+                    yield file_id, range_index, tensor
                 else:
                     device_tensor = tensor.to(self.device_str)
-                    yield file_path, chunk_index, device_tensor
+                    yield file_id, range_index, device_tensor
         finally:
             # The submission must be drained however this generator ends, not only when it runs to
             # completion. range_dsts are raw addresses into the requests iterator's buffer, so a range still

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -14,10 +14,8 @@ logger = logging.getLogger(__name__)
 RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME = "RUNAI_STREAMER_MEMORY_LIMIT"
 DEFAULT_MEMORY_LIMIT_STRING = "40000000000" # 40 GB (to be set to unlimited for distributed streaming)
 
-RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME = "RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES"
-DEFAULT_RING_BUFFER_SIZE_BYTES = 1024 * 1024 * 1024   # 1 GiB
-RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME = "RUNAI_STREAMER_MIN_RING_BUFFERS"
-DEFAULT_MIN_RING_BUFFERS = 2
+RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME = "RUNAI_STREAMER_RING_BUFFERS"
+DEFAULT_RING_BUFFERS = 4
 
 class RunaiStreamerMemoryLimitException(Exception):
     pass
@@ -184,15 +182,17 @@ class FilesRequestsIteratorWithBuffer:
     @staticmethod
     def with_memory_mode(
         files_chunks: List[FileChunks],
+        memory_limit: Optional[int] = None,
     ) -> FilesRequestsIteratorWithBuffer:
-        memory_limit = os.getenv(RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME)
+        """memory_limit, when given, overrides the environment.
+
+        The distributed path derives a PER RANK limit from the node total, which cannot be passed via
+        the environment without mutating process state that other ranks and later calls also read."""
         if memory_limit is None:
-            memory_limit = DEFAULT_MEMORY_LIMIT_STRING
-        memory_mode = _get_memory_mode(memory_limit)
-        if memory_limit is not None:
-            memory_limit = int(memory_limit)
+            configured = os.getenv(RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME)
+            memory_limit = int(configured if configured is not None else DEFAULT_MEMORY_LIMIT_STRING)
         return FilesRequestsIteratorWithBuffer.with_memory_cap(
-            memory_mode, files_chunks, memory_limit
+            _get_memory_mode(memory_limit), files_chunks, memory_limit
         )
 
 class FilesRequestsIterator:
@@ -302,13 +302,16 @@ def _ring_sizing(
 ) -> Tuple[int, int]:
     """(buffer_size, num_buffers) for the ring.
 
-    The BUFFER SIZE is the configured quantity and the count is derived, not the other way round.
-    A single submission is already spread across every C++ worker (Assigner divides its total bytes
-    between 16 filesystem / 8 object-storage workers), so more buffers add no parallelism - they only
-    cover the serial gap at the request boundary. What a buffer size that is too small does cost is
-    real: below roughly 32 MiB (filesystem) or 64 MiB (object storage) the workers do not even get one
-    block each. Hence a configured minimum size, floored by the largest single range, with the count
-    following from the memory limit."""
+    The DEPTH is the configured quantity and the buffer size is derived - the reverse of what this used
+    to do. Depth saturates: measured on a 207 GiB model over object storage at a fixed 10 GiB limit,
+    going from 1 buffer to 2 was worth 6.2% and 2 to 4 a further 1.5%, with nothing beyond. A saturating
+    quantity has a meaningful default; a good buffer size does not, since it depends on the model and the
+    budget. At a fixed limit the choice costs no memory either way - N x B is pinned to the budget - so
+    depth is a pure shape parameter and the memory limit alone controls how much host RAM the ring uses.
+
+    The buffer size is made as large as the depth allows (budget // N), floored by the largest single
+    range because a range carries one destination address and so cannot span two buffers. That floor is
+    what caps the reachable depth at budget // largest_range."""
     largest = _largest_range(files_chunks)
     total = sum(file_chunks.total_size() for file_chunks in files_chunks)
 
@@ -330,52 +333,43 @@ def _ring_sizing(
             )
         budget = min(user_memory_limit, total)
 
-    # min(configured, budget) so a limit tighter than the configured size is still honoured; max with
-    # largest so a buffer always holds at least one range, or the stream cannot progress.
-    buffer_size = max(largest, min(_ring_buffer_size(), budget))
+    target = _ring_buffers()
+
+    # As large as the depth allows, floored by the largest range. Both terms are <= budget (the limit is
+    # validated against largest above, and total >= largest always), so the ring can never exceed the
+    # limit - which is why there is no longer a warning for that case.
+    buffer_size = max(largest, budget // target)
 
     # Nothing to read at all (no ranges, or only zero-sized ones): one empty buffer, as before.
     if buffer_size == 0:
         return 0, 1
 
-    # The floor keeps the ring a ring - at least one buffer filling behind the one being consumed.
-    # It is a FLOOR, so it may exceed what the budget allows; that is deliberate, and the caller
-    # logs it. ceil(total/buffer_size) stops us allocating more buffers than there is data.
-    num_buffers = max(
-        _min_ring_buffers(),
-        min(budget // buffer_size, math.ceil(total / buffer_size)),
-    )
-
-    # The floor won: we are about to use more than the caller allowed. Say so with both numbers rather
-    # than exceeding a stated limit silently - an operator who set a limit and got more than they asked
-    # for has to be able to find out why from the log.
-    if num_buffers * buffer_size > budget:
-        logger.warning(
-            f"[RunAI Streamer] CPU ring needs {num_buffers} x "
-            f"{humanize.naturalsize(buffer_size, binary=True)} = "
-            f"{humanize.naturalsize(num_buffers * buffer_size, binary=True)}, which exceeds the memory "
-            f"limit of {humanize.naturalsize(budget, binary=True)}: "
-            f"{RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME}={_min_ring_buffers()} is a floor, so that "
-            f"many buffers are allocated regardless. Lower it to 1 to honour the limit exactly, at the "
-            f"cost of the pipelining the ring provides."
-        )
+    # budget // buffer_size re-derives the depth the budget can actually pay for, which drops below the
+    # target whenever the largest range lifted the buffer size above budget // target.
+    #
+    # ceil(total/buffer_size) then caps it at the number of requests there will be: a buffer that can
+    # never hold a request should not exist, and a stream fitting one buffer produces exactly one request
+    # (ceil == 1 iff total <= B) - which is precisely what the two safetensors metadata reads are on
+    # every model load. It can UNDERCOUNT when ranges pack wastefully (three 6 byte ranges in a 10 byte
+    # buffer take three requests, not two), leaving the ring a buffer shallower than it might be. That is
+    # a depth question, not a correctness one, and it can never collapse a multi-request stream to a
+    # single buffer, since ceil == 1 means the whole stream fits.
+    num_buffers = min(target, budget // buffer_size, math.ceil(total / buffer_size))
 
     return buffer_size, num_buffers
 
 
-def _ring_buffer_size() -> int:
-    return int(os.getenv(RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME, DEFAULT_RING_BUFFER_SIZE_BYTES))
-
-
-def _min_ring_buffers() -> int:
+def _ring_buffers() -> int:
     # clamped at 1 so a hostile 0 cannot produce a ring with no buffers
-    return max(1, int(os.getenv(RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME, DEFAULT_MIN_RING_BUFFERS)))
+    return max(1, int(os.getenv(RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME, DEFAULT_RING_BUFFERS)))
 
 
-def _get_memory_mode(memory_limit: Optional[str]) -> MemoryCapMode:
-    if memory_limit == "-1":
+def _get_memory_mode(memory_limit: int) -> MemoryCapMode:
+    # An int rather than the raw string, because an explicitly supplied limit never was one - and it
+    # makes " -1" or "-01" behave like -1, which the string comparison rejected.
+    if memory_limit == -1:
         return MemoryCapMode.unlimited
-    elif memory_limit == "0":
+    elif memory_limit == 0:
         return MemoryCapMode.largest_chunk
     else:
         return MemoryCapMode.limited

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from typing import List, Tuple, Optional
 from collections import deque
+import bisect
 import enum
-import math
 import numpy as np
 import os
 import humanize
@@ -107,6 +107,12 @@ class FilesRequestsIteratorWithBuffer:
         self.files_requests_iterator = FilesRequestsIterator(buffer_size, files_chunks)
         self.buffer_size = buffer_size
         self.num_buffers = num_buffers
+        # DEBUG, not INFO: this class cannot know which rank it is on, and every rank builds its own
+        # ring, so at INFO a distributed load emits one unattributable copy of this line per rank. It
+        # also runs once per stream_files, and two of the three per model load describe the safetensors
+        # metadata reads (`1 x 8 Bytes`). SafetensorsStreamer reports the ring at INFO instead - once per
+        # load, with the rank - via DistributedStreamer.ring_info(). Keep this line: it is per file list,
+        # so it is still the way to see an individual request's ring when debugging.
         logger.debug(
             f"[RunAI Streamer] CPU ring: {num_buffers} x {humanize.naturalsize(buffer_size, binary=True)} "
             f"= {humanize.naturalsize(buffer_size * num_buffers, binary=True)} for files: "
@@ -344,19 +350,107 @@ def _ring_sizing(
     if buffer_size == 0:
         return 0, 1
 
-    # budget // buffer_size re-derives the depth the budget can actually pay for, which drops below the
-    # target whenever the largest range lifted the buffer size above budget // target.
+    # A stream smaller than the limit is already meant to be spanned entirely by the ring - budget is
+    # total in that case, so N x B is the whole model and no buffer is ever recycled. It misses, always:
+    # B = total // target leaves not one byte for packing waste, and tensors are indivisible, so every
+    # request stops short of B and a remainder request is arithmetic, not bad luck. Llama-3-8B at a 40 GB
+    # limit packs into 4 x 3.660 GiB of a 3.739 GiB buffer and then needs a 5th request for the last
+    # 336 MiB, which cannot start until the consumer frees one of the four.
     #
-    # ceil(total/buffer_size) then caps it at the number of requests there will be: a buffer that can
-    # never hold a request should not exist, and a stream fitting one buffer produces exactly one request
-    # (ceil == 1 iff total <= B) - which is precisely what the two safetensors metadata reads are on
-    # every model load. It can UNDERCOUNT when ranges pack wastefully (three 6 byte ranges in a 10 byte
-    # buffer take three requests, not two), leaving the ring a buffer shallower than it might be. That is
-    # a depth question, not a correctness one, and it can never collapse a multi-request stream to a
-    # single buffer, since ceil == 1 means the whole stream fits.
-    num_buffers = min(target, budget // buffer_size, math.ceil(total / buffer_size))
+    # So spend the headroom the limit already granted on slightly larger buffers. On Llama-3-8B that is
+    # 108 MiB more (15.06 GiB against a 37.25 GiB limit) to make the intent actually hold.
+    #
+    # Only when there IS headroom, which is also what keeps this off the path where it would cost most:
+    # a 150k tensor model reaches here only if the limit exceeds its entire size. When the limit binds
+    # (every distributed rank, and any model larger than the limit) recycling is the point and there is
+    # nothing to spend.
+    if memory_mode == MemoryCapMode.limited and total < user_memory_limit:
+        spanned = _span_whole_stream(files_chunks, buffer_size, user_memory_limit // target, target)
+        if spanned is not None:
+            return spanned
+
+    # The depth the budget can actually pay for, which drops below the target whenever the largest range
+    # lifted the buffer size above budget // target. There is no separate "no more buffers than there
+    # will be requests" term: budget <= total always (it is total, or min(limit, total)), so
+    # budget // buffer_size is already <= the request count, and packing waste only pushes the real count
+    # higher. The single-request stream falls out of the same fact - total <= B implies budget <= B
+    # implies one buffer - which is what the two safetensors metadata reads are on every model load.
+    #
+    # Note N x B is an ALLOCATION, not a bytes-in-flight figure. Requests pack to roughly 80% of a buffer
+    # because tensors are indivisible, so a 40 GB limit buys about 32 GB of read-ahead. That gap is the
+    # cost of fixed-size buffers and is not recoverable by changing N: N is already the maximum over
+    # every legal buffer size, since min(target, budget // B) is non-increasing in B and B is either the
+    # smallest legal size (largest) or large enough that budget // B >= target.
+    num_buffers = min(target, budget // buffer_size)
 
     return buffer_size, num_buffers
+
+
+def _packing_prefix(files_chunks: List[FileChunks]) -> List[int]:
+    """Running byte totals over every range of every file, in the order requests are packed.
+
+    One flat sequence is faithful to FilesRequestsIterator: it takes files off a FIFO queue and carries
+    a request across a file boundary, so file boundaries never force a new request."""
+    prefix = [0]
+    running = 0
+    for file_chunks in files_chunks:
+        for size in file_chunks.sizes:
+            running += size
+            prefix.append(running)
+    return prefix
+
+
+def _requests_needed(prefix: List[int], buffer_size: int, cap: int) -> Optional[int]:
+    """How many requests greedy packing needs for the whole stream, or None if it needs more than cap.
+
+    Binary searching the prefix sums for each request's extent makes this O(cap x log R) rather than
+    O(R): deciding the shape of a 4 buffer ring must not cost a walk over 150k tensors. Bailing out at
+    cap is the other half of that - an unpackable buffer size is rejected after cap + 1 probes."""
+    index = 0
+    requests = 0
+    last = len(prefix) - 1
+    while index < last:
+        # the furthest range whose end still fits in one buffer starting at this range
+        nxt = bisect.bisect_right(prefix, prefix[index] + buffer_size) - 1
+        if nxt <= index:
+            return None    # a single range exceeds the buffer; unreachable while buffer_size >= largest
+        index = nxt
+        requests += 1
+        if requests > cap:
+            return None
+    return requests
+
+
+def _span_whole_stream(
+    files_chunks: List[FileChunks],
+    buffer_size: int,
+    max_buffer_size: int,
+    target: int,
+) -> Optional[Tuple[int, int]]:
+    """Smallest buffer in [buffer_size, max_buffer_size] that packs the whole stream into at most
+    `target` requests, with the request count it achieves - or None when even the largest cannot.
+
+    The count is returned rather than assuming `target`, so a stream that fits in fewer requests gets
+    fewer buffers: a single request stream still gets exactly one buffer, not four empty ones.
+
+    Binary search is valid because request count is non-increasing in buffer size - a bigger buffer
+    takes a prefix at least as long at every step - so "fits in target requests" is monotone."""
+    if max_buffer_size < buffer_size:
+        return None
+
+    prefix = _packing_prefix(files_chunks)
+    if _requests_needed(prefix, max_buffer_size, target) is None:
+        return None    # the limit does not stretch far enough; recycle as usual
+
+    low, high = buffer_size, max_buffer_size
+    while low < high:
+        middle = (low + high) // 2
+        if _requests_needed(prefix, middle, target) is None:
+            low = middle + 1
+        else:
+            high = middle
+
+    return low, _requests_needed(prefix, low, target)
 
 
 def _ring_buffers() -> int:

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -67,21 +67,32 @@ class FilesRequest:
     range_dsts is flat and in flattened range order (file 0's ranges, then file 1's, ...) - it IS the
     array handed to runai_request, and the same array response-time lookup indexes. file_base holds
     each file's first flat position, so mapping a response's (file_index, range_index) to a
-    destination is O(1) rather than a prefix-sum walk per response."""
+    destination is O(1) rather than a prefix-sum walk per response.
+
+    range_base is the other half of that mapping: each file's first GLOBAL range index, i.e. how many
+    of that file's ranges earlier requests already covered. Both bases are frozen when the file is
+    appended, which is what makes a request self-describing - everything needed to interpret one of
+    its responses is in the request object, not in iterator state that has since moved on. That is the
+    prerequisite for keeping several submissions in flight at once."""
 
     def __init__(self) -> None:
         self.files: List[FileChunks] = []
         self.file_base: List[int] = []
+        self.range_base: List[int] = []
         self.num_ranges = 0
         self.range_dsts: List[int] = []
 
-    def append(self, file_chunks: FileChunks) -> None:
+    def append(self, file_chunks: FileChunks, range_base: int) -> None:
         self.file_base.append(self.num_ranges)
+        self.range_base.append(range_base)
         self.num_ranges += len(file_chunks.sizes)
         self.files.append(file_chunks)
 
     def flat_index(self, file_index: int, range_index: int) -> int:
         return self.file_base[file_index] + range_index
+
+    def global_range_index(self, file_index: int, range_index: int) -> int:
+        return self.range_base[file_index] + range_index
 
 
 class FilesRequestsIteratorWithBuffer:
@@ -96,11 +107,12 @@ class FilesRequestsIteratorWithBuffer:
         # the base. That is local knowledge of its own allocation, not an assumption the range API makes.
         self.buffer_address = self.buffer.ctypes.data
 
-    def get_global_file_and_chunk(self, local_file_index: int, local_range_index: int) -> Tuple[str, int, memoryview]:
-        file_id, global_range_index = self.files_requests_iterator.get_global_file_and_chunk(
-            local_file_index, local_range_index
+    def get_global_file_and_range(
+        self, request: FilesRequest, local_file_index: int, local_range_index: int
+    ) -> Tuple[int, int, np.ndarray]:
+        file_id, global_range_index = self.files_requests_iterator.get_global_file_and_range(
+            request, local_file_index, local_range_index
         )
-        request = self.files_requests_iterator.active_request
         start = request.range_dsts[request.flat_index(local_file_index, local_range_index)] - self.buffer_address
         size = request.files[local_file_index].sizes[local_range_index]
         return file_id, global_range_index, self.buffer[start: start + size]
@@ -168,23 +180,28 @@ class FilesRequestsIterator:
         self.q = deque(FileChunksIterator(file_chunks)
             for file_chunks in files_chunks)
         
-        self.file_to_current_chunk_index = {}
+        # Per file, how many of its ranges have already been assigned to some request. Updated as each
+        # request is BUILT, so nothing reads it at response time - a request carries its own frozen
+        # range_base instead. Counting here rather than retroactively on the following call is what lets
+        # several requests be in flight: the map belongs to request construction, not to draining.
+        self.file_to_assigned_ranges = {}
         for file_chunks in files_chunks:
-            self.file_to_current_chunk_index[file_chunks.id] = 0
+            self.file_to_assigned_ranges[file_chunks.id] = 0
 
-        self.active_request: FilesRequest = None
-
-    def get_global_file_and_chunk(self, local_file_index: int, local_chunk_index: int) -> Tuple[str, int]:
-        file_id = self.active_request.files[local_file_index].id
-        return file_id, self.file_to_current_chunk_index[file_id] + local_chunk_index
+    def get_global_file_and_range(
+        self, request: FilesRequest, local_file_index: int, local_range_index: int
+    ) -> Tuple[int, int]:
+        # Answered entirely from the request, so a response can be resolved against its own submission
+        # however far the iterator has moved on since. The first element is the caller-assigned
+        # FileChunks.id, not a path.
+        return (
+            request.files[local_file_index].id,
+            request.global_range_index(local_file_index, local_range_index),
+        )
 
     def next_request(self) -> Optional[FilesRequest]:
         if not self.q:
             return None
-        
-        if self.active_request is not None:
-            for file_chunks in self.active_request.files:
-                self.file_to_current_chunk_index[file_chunks.id] += len(file_chunks.sizes)
 
         files_request = FilesRequest()
         current_request_memory_size = 0
@@ -213,12 +230,12 @@ class FilesRequestsIterator:
             # contributed only zero-sized ranges is a real contribution. The C++ layer answers a
             # zero-sized range like any other, and the caller's tensor indexing counts on exactly
             # one response per range.
-            files_request.append(file_chunks)
+            files_request.append(file_chunks, self.file_to_assigned_ranges[file_chunks.id])
+            self.file_to_assigned_ranges[file_chunks.id] += len(file_chunks.sizes)
             current_request_memory_size += file_chunks.total_size()
 
         if len(files_request.files) == 0:
             files_request = None
-        self.active_request = files_request
         return files_request
 
 class FileChunksIterator:

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -312,12 +312,17 @@ def _ring_sizing(
     to do. Depth saturates: measured on a 207 GiB model over object storage at a fixed 10 GiB limit,
     going from 1 buffer to 2 was worth 6.2% and 2 to 4 a further 1.5%, with nothing beyond. A saturating
     quantity has a meaningful default; a good buffer size does not, since it depends on the model and the
-    budget. At a fixed limit the choice costs no memory either way - N x B is pinned to the budget - so
-    depth is a pure shape parameter and the memory limit alone controls how much host RAM the ring uses.
+    budget.
 
     The buffer size is made as large as the depth allows (budget // N), floored by the largest single
     range because a range carries one destination address and so cannot span two buffers. That floor is
-    what caps the reachable depth at budget // largest_range."""
+    what caps the reachable depth at budget // largest_range.
+
+    RAM: N x B never exceeds the limit, but it is NOT pinned to it, so depth is not a free choice. Under
+    a binding limit N x B is the budget and depth really is pure shape. When the stream is SMALLER than
+    the limit the span search below buys buffers slightly larger than budget // N, and the total then
+    varies with the depth target: Llama-3-8B at a 40 GB limit (budget 14.958 GiB) allocates 14.958 GiB at
+    depth 1, 15.06 at depth 4 and 15.66 at depth 8. Raising the depth on a small model costs real RAM."""
     largest = _largest_range(files_chunks)
     total = sum(file_chunks.total_size() for file_chunks in files_chunks)
 
@@ -342,8 +347,9 @@ def _ring_sizing(
     target = _ring_buffers()
 
     # As large as the depth allows, floored by the largest range. Both terms are <= budget (the limit is
-    # validated against largest above, and total >= largest always), so the ring can never exceed the
-    # limit - which is why there is no longer a warning for that case.
+    # validated against largest above, and total >= largest always), so THIS buffer size can never take
+    # the ring past the limit - which is why there is no longer a warning for that case. The span search
+    # below can raise it, and is separately capped at limit // target for the same reason.
     buffer_size = max(largest, budget // target)
 
     # Nothing to read at all (no ranges, or only zero-sized ones): one empty buffer, as before.
@@ -376,11 +382,13 @@ def _ring_sizing(
     # higher. The single-request stream falls out of the same fact - total <= B implies budget <= B
     # implies one buffer - which is what the two safetensors metadata reads are on every model load.
     #
-    # Note N x B is an ALLOCATION, not a bytes-in-flight figure. Requests pack to roughly 80% of a buffer
-    # because tensors are indivisible, so a 40 GB limit buys about 32 GB of read-ahead. That gap is the
-    # cost of fixed-size buffers and is not recoverable by changing N: N is already the maximum over
-    # every legal buffer size, since min(target, budget // B) is non-increasing in B and B is either the
-    # smallest legal size (largest) or large enough that budget // B >= target.
+    # Note N x B is an ALLOCATION, not a bytes-in-flight figure. On THIS path - a binding limit, so the
+    # ring recycles - requests pack to roughly 80% of a buffer because tensors are indivisible, making a
+    # 40 GB limit about 32 GB of read-ahead. (The span path above is different: sizing the buffer to fit
+    # the stream also happens to pack it well, measured at 97-99% on Llama-3-8B.) That gap is the cost of
+    # fixed-size buffers and is not recoverable by changing N: N is already the maximum over every legal
+    # buffer size, since min(target, budget // B) is non-increasing in B and B is either the smallest
+    # legal size (largest) or large enough that budget // B >= target.
     num_buffers = min(target, budget // buffer_size)
 
     return buffer_size, num_buffers

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List, Tuple, Optional
 from collections import deque
 import enum
+import math
 import numpy as np
 import os
 import humanize
@@ -12,6 +13,11 @@ logger = logging.getLogger(__name__)
 
 RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME = "RUNAI_STREAMER_MEMORY_LIMIT"
 DEFAULT_MEMORY_LIMIT_STRING = "40000000000" # 40 GB (to be set to unlimited for distributed streaming)
+
+RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME = "RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES"
+DEFAULT_RING_BUFFER_SIZE_BYTES = 1024 * 1024 * 1024   # 1 GiB
+RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME = "RUNAI_STREAMER_MIN_RING_BUFFERS"
+DEFAULT_MIN_RING_BUFFERS = 2
 
 class RunaiStreamerMemoryLimitException(Exception):
     pass
@@ -81,6 +87,9 @@ class FilesRequest:
         self.range_base: List[int] = []
         self.num_ranges = 0
         self.range_dsts: List[int] = []
+        # Which ring buffer this request was packed into. None once released - a request outlives its
+        # buffer, since the caller may still hold the request object after the data has been consumed.
+        self.buffer_index: Optional[int] = None
 
     def append(self, file_chunks: FileChunks, range_base: int) -> None:
         self.file_base.append(self.num_ranges)
@@ -96,16 +105,36 @@ class FilesRequest:
 
 
 class FilesRequestsIteratorWithBuffer:
-    def __init__(self, buffer_size: int, files_chunks: List[FileChunks]) -> None:
+    def __init__(self, buffer_size: int, num_buffers: int, files_chunks: List[FileChunks]) -> None:
         self.files_requests_iterator = FilesRequestsIterator(buffer_size, files_chunks)
+        self.buffer_size = buffer_size
+        self.num_buffers = num_buffers
         logger.debug(
-            f"[RunAI Streamer] CPU Buffer size: {humanize.naturalsize(buffer_size, binary=True)} for files: {[file_chunks.path for file_chunks in files_chunks]}"
+            f"[RunAI Streamer] CPU ring: {num_buffers} x {humanize.naturalsize(buffer_size, binary=True)} "
+            f"= {humanize.naturalsize(buffer_size * num_buffers, binary=True)} for files: "
+            f"{[file_chunks.path for file_chunks in files_chunks]}"
         )
-        self.buffer = np.empty(buffer_size, dtype=np.uint8)
-        # The buffer's base address. Destinations are absolute addresses (that is the C contract), and
-        # this class packs them itself, so it can recover a range's slice of the buffer by subtracting
-        # the base. That is local knowledge of its own allocation, not an assumption the range API makes.
-        self.buffer_address = self.buffer.ctypes.data
+        # ONE allocation sliced into num_buffers views. The pool is fixed at construction and never
+        # grows, so a single contiguous region is simpler for the OS to manage than N separate ones -
+        # and it is the shape the O_DIRECT work needs, where the base has to be page aligned.
+        self.pool = np.empty(buffer_size * num_buffers, dtype=np.uint8)
+        self.buffers = [self.pool[i * buffer_size: (i + 1) * buffer_size] for i in range(num_buffers)]
+        # Destinations are absolute addresses (that is the C contract), and this class packs them
+        # itself, so it can recover a range's slice by subtracting its buffer's base. That is local
+        # knowledge of its own allocation, not an assumption the range API makes.
+        self.buffer_addresses = [buffer.ctypes.data for buffer in self.buffers]
+        self._free_buffers = deque(range(num_buffers))
+
+    def has_free_buffer(self) -> bool:
+        return len(self._free_buffers) > 0
+
+    def release(self, request: FilesRequest) -> None:
+        """Return a drained request's buffer to the pool. The caller must not touch any view handed
+        out for that request afterwards - the next request will overwrite it."""
+        if request.buffer_index is None:
+            raise ValueError("request has no buffer to release (released twice?)")
+        self._free_buffers.append(request.buffer_index)
+        request.buffer_index = None
 
     def get_global_file_and_range(
         self, request: FilesRequest, local_file_index: int, local_range_index: int
@@ -113,20 +142,28 @@ class FilesRequestsIteratorWithBuffer:
         file_id, global_range_index = self.files_requests_iterator.get_global_file_and_range(
             request, local_file_index, local_range_index
         )
-        start = request.range_dsts[request.flat_index(local_file_index, local_range_index)] - self.buffer_address
+        buffer = self.buffers[request.buffer_index]
+        start = (request.range_dsts[request.flat_index(local_file_index, local_range_index)]
+                 - self.buffer_addresses[request.buffer_index])
         size = request.files[local_file_index].sizes[local_range_index]
-        return file_id, global_range_index, self.buffer[start: start + size]
+        return file_id, global_range_index, buffer[start: start + size]
 
     def next_request(self) -> Optional[FilesRequest]:
+        if not self._free_buffers:
+            raise RuntimeError("no free ring buffer - release a drained request before building another")
+
         request = self.files_requests_iterator.next_request()
         if request is None or len(request.files) == 0:
             return None
 
-        # Pack this request's ranges back to back into the buffer, one absolute address per range.
+        # Take the buffer only once there is a request to put in it, so end of stream does not consume one.
+        request.buffer_index = self._free_buffers.popleft()
+
+        # Pack this request's ranges back to back into its buffer, one absolute address per range.
         # Placement is free now (each range carries its own destination), so packing is just a running
         # cursor - no per-file sub-buffer, and no requirement that a file's ranges be adjacent.
         dsts = []
-        cursor = self.buffer_address
+        cursor = self.buffer_addresses[request.buffer_index]
         for file_chunks in request.files:
             for size in file_chunks.sizes:
                 dsts.append(cursor)
@@ -141,24 +178,8 @@ class FilesRequestsIteratorWithBuffer:
         files_chunks: List[FileChunks],
         user_memory_limit: Optional[int] = None,
     ) -> FilesRequestsIteratorWithBuffer:
-        memory_limit = 0
-        if memory_mode == MemoryCapMode.unlimited:
-            memory_limit = sum(file.total_size() for file in files_chunks)
-        elif memory_mode == MemoryCapMode.largest_chunk:
-            memory_limit = _largest_range(files_chunks)
-        elif memory_mode == MemoryCapMode.limited:
-            if user_memory_limit is None:
-                raise RunaiStreamerMemoryLimitException(
-                    f"MemoryCapMode is Limited, but no limit supplied"
-                )
-            largest_chunk = _largest_range(files_chunks)
-            if user_memory_limit < largest_chunk:
-                raise RunaiStreamerMemoryLimitException(
-                    f"Memory limit supplied: {user_memory_limit} cannot be smaller than: {largest_chunk}"
-                )
-            memory_limit = min(user_memory_limit, sum(file.total_size() for file in files_chunks))
- 
-        return FilesRequestsIteratorWithBuffer(memory_limit, files_chunks)
+        buffer_size, num_buffers = _ring_sizing(memory_mode, files_chunks, user_memory_limit)
+        return FilesRequestsIteratorWithBuffer(buffer_size, num_buffers, files_chunks)
 
     @staticmethod
     def with_memory_mode(
@@ -272,6 +293,83 @@ def _largest_range(files_chunks: List[FileChunks]) -> int:
     request must be able to hold at least one range, or next_request would return an empty request,
     which the caller reads as end of stream."""
     return max((max(file_chunks.sizes, default=0) for file_chunks in files_chunks), default=0)
+
+
+def _ring_sizing(
+    memory_mode: MemoryCapMode,
+    files_chunks: List[FileChunks],
+    user_memory_limit: Optional[int],
+) -> Tuple[int, int]:
+    """(buffer_size, num_buffers) for the ring.
+
+    The BUFFER SIZE is the configured quantity and the count is derived, not the other way round.
+    A single submission is already spread across every C++ worker (Assigner divides its total bytes
+    between 16 filesystem / 8 object-storage workers), so more buffers add no parallelism - they only
+    cover the serial gap at the request boundary. What a buffer size that is too small does cost is
+    real: below roughly 32 MiB (filesystem) or 64 MiB (object storage) the workers do not even get one
+    block each. Hence a configured minimum size, floored by the largest single range, with the count
+    following from the memory limit."""
+    largest = _largest_range(files_chunks)
+    total = sum(file_chunks.total_size() for file_chunks in files_chunks)
+
+    # Explicit minimal-memory mode: one buffer holding exactly one range. Deriving a ring here would
+    # defeat the only reason to ask for this mode.
+    if memory_mode == MemoryCapMode.largest_chunk:
+        return largest, 1
+
+    if memory_mode == MemoryCapMode.unlimited:
+        budget = total
+    else:
+        if user_memory_limit is None:
+            raise RunaiStreamerMemoryLimitException(
+                f"MemoryCapMode is Limited, but no limit supplied"
+            )
+        if user_memory_limit < largest:
+            raise RunaiStreamerMemoryLimitException(
+                f"Memory limit supplied: {user_memory_limit} cannot be smaller than: {largest}"
+            )
+        budget = min(user_memory_limit, total)
+
+    # min(configured, budget) so a limit tighter than the configured size is still honoured; max with
+    # largest so a buffer always holds at least one range, or the stream cannot progress.
+    buffer_size = max(largest, min(_ring_buffer_size(), budget))
+
+    # Nothing to read at all (no ranges, or only zero-sized ones): one empty buffer, as before.
+    if buffer_size == 0:
+        return 0, 1
+
+    # The floor keeps the ring a ring - at least one buffer filling behind the one being consumed.
+    # It is a FLOOR, so it may exceed what the budget allows; that is deliberate, and the caller
+    # logs it. ceil(total/buffer_size) stops us allocating more buffers than there is data.
+    num_buffers = max(
+        _min_ring_buffers(),
+        min(budget // buffer_size, math.ceil(total / buffer_size)),
+    )
+
+    # The floor won: we are about to use more than the caller allowed. Say so with both numbers rather
+    # than exceeding a stated limit silently - an operator who set a limit and got more than they asked
+    # for has to be able to find out why from the log.
+    if num_buffers * buffer_size > budget:
+        logger.warning(
+            f"[RunAI Streamer] CPU ring needs {num_buffers} x "
+            f"{humanize.naturalsize(buffer_size, binary=True)} = "
+            f"{humanize.naturalsize(num_buffers * buffer_size, binary=True)}, which exceeds the memory "
+            f"limit of {humanize.naturalsize(budget, binary=True)}: "
+            f"{RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME}={_min_ring_buffers()} is a floor, so that "
+            f"many buffers are allocated regardless. Lower it to 1 to honour the limit exactly, at the "
+            f"cost of the pipelining the ring provides."
+        )
+
+    return buffer_size, num_buffers
+
+
+def _ring_buffer_size() -> int:
+    return int(os.getenv(RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME, DEFAULT_RING_BUFFER_SIZE_BYTES))
+
+
+def _min_ring_buffers() -> int:
+    # clamped at 1 so a hostile 0 cannot produce a ring with no buffers
+    return max(1, int(os.getenv(RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME, DEFAULT_MIN_RING_BUFFERS)))
 
 
 def _get_memory_mode(memory_limit: Optional[str]) -> MemoryCapMode:

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
@@ -81,6 +81,40 @@ class TestRingConcurrency(unittest.TestCase):
 
     @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "64",
                              RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "8"})
+    def test_a_second_streamer_does_not_disturb_one_still_streaming(self):
+        # Streamer state belongs to the HANDLE, not the process: starting a second streamer must not
+        # touch the submissions a live one is still draining. Reachable in the product, not just here -
+        # FileStreamer.list_files starts a temporary streamer when used outside its context manager, so
+        # listing during a stream takes this path.
+        #
+        # This is a MOCK-FIDELITY test as much as a product one. The mock used to keep submissions in
+        # process-wide globals that runai_start cleared, so this failed against the mock ("response for
+        # unknown submission 0") while passing against the real library - the direction that makes a
+        # green suite meaningless.
+        path, expected = self.write_ranges("two_streamers.txt", 8)
+        with FileStreamer() as first:
+            first.stream_files([FileChunks.contiguous(17, path, 0, [self.RANGE_SIZE] * 8)])
+            chunks = first.get_chunks()
+            results = {}
+            file_id, range_index, buffer = next(chunks)
+            results[range_index] = buffer.numpy().tobytes().decode("utf-8")
+            self.assertGreater(len(first.live_requests), 1)
+
+            with FileStreamer() as second:
+                # a whole independent stream on the second streamer, start to finish
+                second.stream_files([FileChunks.contiguous(18, path, 0, [self.RANGE_SIZE] * 8)])
+                second_results = {}
+                for _file_id, index, second_buffer in second.get_chunks():
+                    second_results[index] = second_buffer.numpy().tobytes().decode("utf-8")
+                self.assertEqual(second_results, expected)
+
+            # the first streamer must still deliver every remaining range, correctly
+            for _file_id, index, buffer in chunks:
+                results[index] = buffer.numpy().tobytes().decode("utf-8")
+            self.assertEqual(results, expected)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "64",
+                             RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "8"})
     def test_abandoning_the_generator_drains_every_live_submission(self):
         # the consumer walks away with several submissions still in flight. Every one of them must be
         # drained before the streamer is torn down, or a late write lands in freed memory.
@@ -93,6 +127,52 @@ class TestRingConcurrency(unittest.TestCase):
             chunks.close()     # resumes the generator at its yield, running the finally
             self.assertEqual(fs.outstanding, 0)
             self.assertEqual(fs.live_requests, {})
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "64",
+                             RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "8"})
+    def test_streaming_again_before_draining_is_rejected(self):
+        # stream_files replaces the requests iterator, which drops the only reference to the previous
+        # ring's pool while the C++ layer still holds raw destination pointers into it. Left unguarded
+        # that is a use after free, and it surfaces (if at all) as a confusing unknown-submission error
+        # much later, so it has to fail here instead - see the comment on stream_files.
+        path, _ = self.write_ranges("undrained.txt", 8)
+        request = [FileChunks.contiguous(17, path, 0, [self.RANGE_SIZE] * 8)]
+        with FileStreamer() as fs:
+            fs.stream_files(request)
+            # bind the generator: an unreferenced one is collected as soon as next() returns, and
+            # closing it runs the drain - which would leave nothing for the guard to catch
+            chunks = fs.get_chunks()
+            next(chunks)                   # submissions live, nothing drained
+            self.assertGreater(fs.outstanding, 0)
+
+            with self.assertRaises(ValueError) as caught:
+                fs.stream_files(request)
+            self.assertIn("outstanding", str(caught.exception))
+
+            # the rejected call must leave the streamer exactly as it was, or the guard would turn a
+            # recoverable mistake into the corruption it exists to prevent
+            self.assertGreater(fs.outstanding, 0)
+            self.assertGreater(len(fs.live_requests), 0)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "64",
+                             RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "8"})
+    def test_streaming_again_after_draining_is_allowed(self):
+        # The other half of the guard: abandoning a stream is legitimate, because closing the generator
+        # runs the drain. A guard that also blocked THIS would make an abandoned stream unrecoverable.
+        path, expected = self.write_ranges("redrained.txt", 8)
+        request = [FileChunks.contiguous(17, path, 0, [self.RANGE_SIZE] * 8)]
+        with FileStreamer() as fs:
+            fs.stream_files(request)
+            chunks = fs.get_chunks()
+            next(chunks)
+            chunks.close()
+
+            fs.stream_files(request)       # drained, so this is fine
+            results = {}
+            for _file_id, range_index, buffer in fs.get_chunks():
+                results[range_index] = buffer.numpy().tobytes().decode("utf-8")
+            # and the second stream is correct, not just accepted
+            self.assertEqual(results, expected)
 
 
 class TestBindings(unittest.TestCase):

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
@@ -4,7 +4,95 @@ import shutil
 import os
 from unittest.mock import patch
 from runai_model_streamer.file_streamer.file_streamer import FileStreamer
-from runai_model_streamer.file_streamer.requests_iterator import (MemoryCapMode, FileChunks)
+from runai_model_streamer.file_streamer.requests_iterator import (
+    MemoryCapMode,
+    FileChunks,
+    RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME,
+    RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME,
+)
+
+
+class TestRingConcurrency(unittest.TestCase):
+    """Several submissions in flight at once. Each range carries a distinct, position-encoding payload,
+    so a response attributed to the wrong submission or the wrong buffer produces the wrong text rather
+    than passing by luck."""
+
+    RANGE_SIZE = 8
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def write_ranges(self, name: str, count: int):
+        """A file of `count` ranges, range i holding exactly "rng{i:05d}"."""
+        expected = {i: f"rng{i:05d}" for i in range(count)}
+        path = os.path.join(self.temp_dir, name)
+        with open(path, "w") as handle:
+            handle.write("".join(expected[i] for i in range(count)))
+        return path, expected
+
+    def stream(self, path: str, count: int):
+        """Stream the file one range at a time, returning (results, max concurrently live submissions)."""
+        results = {}
+        max_live = 0
+        with FileStreamer() as fs:
+            fs.stream_files([FileChunks.contiguous(17, path, 0, [self.RANGE_SIZE] * count)])
+            for file_id, range_index, buffer in fs.get_chunks():
+                self.assertEqual(file_id, 17)
+                # read the payload BEFORE resuming the generator: once we resume, the submission may
+                # complete and its buffer be recycled under us
+                results[range_index] = buffer.numpy().tobytes().decode("utf-8")
+                max_live = max(max_live, len(fs.live_requests))
+        return results, max_live
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "64",
+                             RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "8"})
+    def test_many_submissions_in_flight_deliver_every_range(self):
+        # 8 ranges of 8 bytes and a 64 byte budget over 8 buffers: 8 bytes each, so all 8 requests are
+        # submitted up front and every response has to be attributed to its own submission.
+        path, expected = self.write_ranges("concurrent.txt", 8)
+        results, max_live = self.stream(path, 8)
+        self.assertEqual(results, expected)
+        self.assertGreater(max_live, 1, "expected several submissions in flight at once")
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "16",
+                             RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_ring_recycles_buffers_across_many_requests(self):
+        # a ring of 2 serving 10 ranges: buffers must be released and refilled 5 times over, and a range
+        # must never be read out of a buffer that a later request has already overwritten
+        path, expected = self.write_ranges("recycled.txt", 10)
+        results, max_live = self.stream(path, 10)
+        self.assertEqual(results, expected)
+        self.assertEqual(max_live, 2)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "32",
+                             RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
+    def test_deep_ring_recycles_while_other_submissions_are_still_in_flight(self):
+        # The steady state of a real load, which neither of the tests above reaches: a ring of 4 serving
+        # 20 ranges, so buffers are handed back and immediately re-submitted while three other
+        # submissions are still filling. Covers depth AND recycling at once - a refill that stops
+        # keeping the ring full stays correct, so only the max_live assertion catches it.
+        path, expected = self.write_ranges("deep.txt", 20)
+        results, max_live = self.stream(path, 20)
+        self.assertEqual(results, expected)
+        self.assertEqual(max_live, 4)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "64",
+                             RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "8"})
+    def test_abandoning_the_generator_drains_every_live_submission(self):
+        # the consumer walks away with several submissions still in flight. Every one of them must be
+        # drained before the streamer is torn down, or a late write lands in freed memory.
+        path, _ = self.write_ranges("abandoned.txt", 8)
+        with FileStreamer() as fs:
+            fs.stream_files([FileChunks.contiguous(17, path, 0, [self.RANGE_SIZE] * 8)])
+            chunks = fs.get_chunks()
+            next(chunks)
+            self.assertGreater(len(fs.live_requests), 1)
+            chunks.close()     # resumes the generator at its yield, running the finally
+            self.assertEqual(fs.outstanding, 0)
+            self.assertEqual(fs.live_requests, {})
 
 
 class TestBindings(unittest.TestCase):
@@ -67,12 +155,12 @@ class TestBindings(unittest.TestCase):
             # every range produced exactly one response (full drain)
             self.assertEqual(seen, set(id_to_results))
 
-    @patch("os.getenv")
-    @patch("runai_model_streamer.file_streamer.requests_iterator._get_memory_mode")
-    def test_limited_memory_cap(self, mock_get_memory_mode, mock_getenv):
-        mock_get_memory_mode.return_value = MemoryCapMode.limited
-        mock_getenv.return_value = 6
-
+    # Patch the ENVIRONMENT, not os.getenv itself. Patching the lookup function makes every variable
+    # answer the same value, so this test used to set the ring's buffer size and buffer-count floor to 6
+    # as well as the memory limit - silently, and only because requests_iterator grew more variables.
+    # The real _get_memory_mode derives `limited` from 6 on its own, so it needs no patch either.
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "6"})
+    def test_limited_memory_cap(self):
         file_content = "XABBCCCDDDDEEEEEFFFFGGGHHI"
         file_id = 17
         file_path = os.path.join(self.temp_dir, "limited_test_file.txt")

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
@@ -174,6 +174,34 @@ class TestRingConcurrency(unittest.TestCase):
             # and the second stream is correct, not just accepted
             self.assertEqual(results, expected)
 
+    @patch.dict(os.environ, {RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME: "64",
+                             RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "8"})
+    def test_a_generator_outliving_its_context_does_not_brick_the_streamer(self):
+        # The drain cannot consume anything once __exit__ has cleared the handle, so it returns with
+        # the counter still raised. stream_files reads that same counter and sets it only AFTER the
+        # guard, so a stale value rejects every later stream on this object - permanently. Zeroing is
+        # safe here precisely because runai_end has already joined the workers: nothing is in flight.
+        path, expected = self.write_ranges("outlived.txt", 8)
+        request = [FileChunks.contiguous(17, path, 0, [self.RANGE_SIZE] * 8)]
+
+        fs = FileStreamer()
+        with fs:
+            fs.stream_files(request)
+            chunks = fs.get_chunks()
+            next(chunks)
+            self.assertGreater(fs.outstanding, 0)
+        # the context is gone and the handle with it; the generator is still alive, and closing it now
+        # runs the finally against a streamer that no longer exists
+        chunks.close()
+        self.assertEqual(fs.outstanding, 0)
+
+        with fs:
+            fs.stream_files(request)       # re-entered, so this must be accepted
+            results = {}
+            for _file_id, range_index, buffer in fs.get_chunks():
+                results[range_index] = buffer.numpy().tobytes().decode("utf-8")
+            self.assertEqual(results, expected)
+
 
 class TestBindings(unittest.TestCase):
     def setUp(self):

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -193,24 +193,29 @@ class TestFilesRequestsIterator(unittest.TestCase):
         self.assertEqual(files_requests.files[0].id, 17)
         self.assertEqual(files_requests.files[0].sizes, [3])
 
-    def test_get_global_file_and_chunk(self):
+    def test_get_global_file_and_range(self):
         files_requests_iterator = FilesRequestsIterator(3, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])])
 
-        files_requests_iterator.next_request()
+        first = files_requests_iterator.next_request()
 
-        file_id, chunk_index = files_requests_iterator.get_global_file_and_chunk(0, 0)
+        file_id, range_index = files_requests_iterator.get_global_file_and_range(first, 0, 0)
         self.assertEqual(file_id, 17)
-        self.assertEqual(chunk_index, 0)
+        self.assertEqual(range_index, 0)
 
-        file_id, chunk_index = files_requests_iterator.get_global_file_and_chunk(0, 1)
+        file_id, range_index = files_requests_iterator.get_global_file_and_range(first, 0, 1)
         self.assertEqual(file_id, 17)
-        self.assertEqual(chunk_index, 1)
+        self.assertEqual(range_index, 1)
 
-        files_requests_iterator.next_request()
+        second = files_requests_iterator.next_request()
 
-        file_id, chunk_index = files_requests_iterator.get_global_file_and_chunk(0, 0)
+        file_id, range_index = files_requests_iterator.get_global_file_and_range(second, 0, 0)
         self.assertEqual(file_id, 17)
-        self.assertEqual(chunk_index, 2)
+        self.assertEqual(range_index, 2)
+
+        # The earlier request is still resolvable now that a later one has been built - each request
+        # carries its own range_base rather than reading iterator state that has moved on. This is what
+        # allows a response to arrive while a subsequent submission is already in flight.
+        self.assertEqual(files_requests_iterator.get_global_file_and_range(first, 0, 1), (17, 1))
 
     def test_file_chunks_zero_chunks(self):
         requests_iterator = FilesRequestsIterator(10, [FileChunks(17, "a.txt", [], [])])
@@ -374,7 +379,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         self.assertEqual(files_requests.range_dsts, [base, base + 4, base + 5])
         self.assertEqual(files_requests.file_base, [0, 1])
 
-    def test_get_global_file_and_chunk_aliases_the_buffer(self):
+    def test_get_global_file_and_range_aliases_the_buffer(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.unlimited,
             [FileChunks.contiguous(17, "a.txt", 10, [1, 2]), FileChunks.contiguous(18, "b.txt", 10, [3, 4])],
@@ -382,31 +387,31 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         )
         self.assertEqual(len(requests_iterator.buffer), 10)
 
-        requests_iterator.next_request()
+        request = requests_iterator.next_request()
         requests_iterator.buffer[0] = 9
         requests_iterator.buffer[3] = 8
 
-        file_id, chunk_index, view = requests_iterator.get_global_file_and_chunk(0, 0)
-        self.assertEqual((file_id, chunk_index), (17, 0))
+        file_id, range_index, view = requests_iterator.get_global_file_and_range(request, 0, 0)
+        self.assertEqual((file_id, range_index), (17, 0))
         self.assertEqual(len(view), 1)
         self.assertEqual(view[0], 9)
 
-        file_id, chunk_index, view = requests_iterator.get_global_file_and_chunk(1, 0)
-        self.assertEqual((file_id, chunk_index), (18, 0))
+        file_id, range_index, view = requests_iterator.get_global_file_and_range(request, 1, 0)
+        self.assertEqual((file_id, range_index), (18, 0))
         self.assertEqual(len(view), 3)
         self.assertEqual(view[0], 8)
 
-    def test_get_global_file_and_chunk_zero_sized_range(self):
+    def test_get_global_file_and_range_zero_sized_range(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.unlimited, [FileChunks.contiguous(17, "a.txt", 10, [5, 0, 3])], None
         )
 
-        requests_iterator.next_request()
+        request = requests_iterator.next_request()
 
-        file_id, chunk_index, view = requests_iterator.get_global_file_and_chunk(0, 1)
-        self.assertEqual((file_id, chunk_index), (17, 1))
+        file_id, range_index, view = requests_iterator.get_global_file_and_range(request, 0, 1)
+        self.assertEqual((file_id, range_index), (17, 1))
         self.assertEqual(len(view), 0)
 
         # the zero sized range consumes no buffer, so the range after it starts where it did
-        _, _, view = requests_iterator.get_global_file_and_chunk(0, 2)
+        _, _, view = requests_iterator.get_global_file_and_range(request, 0, 2)
         self.assertEqual(len(view), 3)

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -42,8 +42,12 @@ class TestRingSizing(unittest.TestCase):
         # a range carries one destination and cannot span two buffers, so a 250 byte range forces a 250
         # byte buffer even though budget // 4 is 87 - and a 350 byte budget then pays for only one.
         # This is the mechanism that caps reachable depth at budget // largest_range.
+        #
+        # The limit is the stream size on purpose. A limit ABOVE the stream leaves headroom, and the
+        # sizing spends it on bigger buffers (see test_headroom_grows_the_buffer_...) - which escapes
+        # the very cap this test is about, so the fixture would no longer be testing its own name.
         self.assertEqual(
-            _ring_sizing(MemoryCapMode.limited, self.files([250], [10] * 10), 1000), (250, 1)
+            _ring_sizing(MemoryCapMode.limited, self.files([250], [10] * 10), 350), (250, 1)
         )
 
     @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
@@ -106,6 +110,96 @@ class TestRingSizing(unittest.TestCase):
                     f"{num_buffers} x {buffer_size}",
                 )
                 self.assertGreaterEqual(num_buffers, 1)
+
+    def requests_to_stream(self, files, buffer_size):
+        """How many requests the real packer needs - the thing the sizing is trying to predict."""
+        iterator = FilesRequestsIterator(buffer_size, files)
+        requests = 0
+        while iterator.next_request() is not None:
+            requests += 1
+        return requests
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
+    def test_headroom_grows_the_buffer_so_the_ring_spans_the_stream(self):
+        # 7 ranges of 30 against a limit far above the 210 byte stream. budget // 4 is 52, which holds
+        # only ONE range (two would be 60), so the stream needs 7 requests behind a ring of 4 and the
+        # tail waits for a buffer to come back. This is Llama-3-8B in miniature: 4 buffers sized to
+        # exactly total // 4 stranded a 5th request, because tensors are indivisible and B left no room
+        # for the waste. The limit has room, so the buffer grows until the ring spans the whole stream.
+        buffer_size, num_buffers = _ring_sizing(MemoryCapMode.limited, self.files([30] * 7), 1000)
+        self.assertEqual((buffer_size, num_buffers), (60, 4))
+        self.assertLessEqual(buffer_size * num_buffers, 1000)
+        # the point of the exercise: every request has its own buffer, so nothing is ever recycled
+        self.assertEqual(self.requests_to_stream(self.files([30] * 7), buffer_size), num_buffers)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
+    def test_a_binding_limit_is_left_alone(self):
+        # The same stream under a limit BELOW it. There is no headroom to spend, recycling is the whole
+        # point, and the sizing must not go walking the ranges - a 150k tensor model would pay for it.
+        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([30] * 7), 120), (30, 4))
+
+    def test_the_span_search_is_skipped_whenever_there_is_no_headroom(self):
+        """The search must not RUN when the stream is not smaller than the limit - not merely return
+        the same answer.
+
+        Asserting the answer is not enough: with a binding limit the search would find nothing and fall
+        back, so every outcome-based test still passes with the guard deleted (verified). The guard is
+        there for COST - a model with 150k tensors would pay for a prefix sum over every one of them to
+        decide the shape of a four buffer ring - so the call itself is what has to be asserted.
+        """
+        cases = [
+            ("limit below the stream",  MemoryCapMode.limited,       210 // 2),
+            ("limit equal to the stream", MemoryCapMode.limited,     210),
+            ("unlimited",               MemoryCapMode.unlimited,     -1),
+            ("largest_chunk",           MemoryCapMode.largest_chunk, 0),
+        ]
+        for name, mode, limit in cases:
+            with self.subTest(name):
+                with patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"}):
+                    with patch(
+                        "runai_model_streamer.file_streamer.requests_iterator._span_whole_stream"
+                    ) as span:
+                        _ring_sizing(mode, self.files([30] * 7), limit)
+                span.assert_not_called()
+
+        # ... and it DOES run when there is headroom, so the assertions above cannot pass vacuously
+        with patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"}):
+            with patch(
+                "runai_model_streamer.file_streamer.requests_iterator._span_whole_stream"
+            ) as span:
+                span.return_value = None
+                _ring_sizing(MemoryCapMode.limited, self.files([30] * 7), 1000)
+        span.assert_called_once()
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
+    def test_headroom_too_small_to_help_changes_nothing(self):
+        # A limit only just above the stream: 220 // 4 = 55 still holds one range, so no reachable
+        # buffer size spans the stream in 4 requests. Growing to 55 would cost memory and fix nothing,
+        # so the sizing keeps the ordinary answer and recycles.
+        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([30] * 7), 220), (52, 4))
+
+    def test_growth_never_exceeds_the_limit(self):
+        """The invariant the growth must not break: the ring is still bounded by what was asked for."""
+        for depth in ("1", "2", "4", "8"):
+            for sizes, limit in (
+                ([30] * 7, 1000),          # generous headroom - growth applies
+                ([30] * 7, 220),           # marginal headroom
+                ([7] * 13, 5_000),         # nothing divides evenly
+                ([1000], 1_000_000),       # one range, enormous limit
+                ([3] * 100, 100_000),
+            ):
+                with patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: depth}):
+                    buffer_size, num_buffers = _ring_sizing(
+                        MemoryCapMode.limited, self.files(sizes), limit
+                    )
+                self.assertLessEqual(
+                    buffer_size * num_buffers, limit,
+                    f"depth={depth} sizes={sizes[:3]}... limit={limit} -> {num_buffers} x {buffer_size}",
+                )
+                # and the ring never has more buffers than there are requests to put in them
+                self.assertLessEqual(
+                    num_buffers, self.requests_to_stream(self.files(sizes), buffer_size)
+                )
 
     @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "0"})
     def test_zero_ring_buffers_still_yields_a_ring(self):

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import unittest
 from unittest.mock import patch
@@ -8,15 +9,16 @@ from runai_model_streamer.file_streamer.requests_iterator import (
     FileChunks,
     MemoryCapMode,
     RunaiStreamerMemoryLimitException,
-    RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME,
-    RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME,
+    RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME,
     _ring_sizing,
 )
 
 
 class TestRingSizing(unittest.TestCase):
-    """The ring's (buffer_size, num_buffers). Ranges are sized in bytes, and the configured minimum
-    buffer size is overridden per test so the fixtures stay small and readable."""
+    """The ring's (buffer_size, num_buffers). The DEPTH is configured and the buffer size follows from
+    it: B = max(largest_range, budget // N), then N is clamped by what the budget affords and by how
+    many requests there will be. Ranges are sized in bytes and the depth is overridden per test so the
+    fixtures stay small and readable."""
 
     def files(self, *sizes_per_file):
         return [
@@ -24,54 +26,49 @@ class TestRingSizing(unittest.TestCase):
             for i, sizes in enumerate(sizes_per_file)
         ]
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
-    def test_limited_derives_count_from_budget(self):
-        # budget 500, buffer 100 -> 5 buffers, and there is data for all 5
-        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([100] * 5), 500), (100, 5))
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
+    def test_depth_is_the_target_and_the_buffer_follows(self):
+        # budget 400 over 4 buffers -> 100 each, and 500 bytes of data means all 4 get used
+        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([100] * 5), 400), (100, 4))
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
-    def test_limit_tighter_than_configured_size_shrinks_the_buffer(self):
-        # the user's cap wins over the configured minimum size: a 60 byte budget must not hand out
-        # a 100 byte buffer. The MIN_RING_BUFFERS floor then exceeds the budget, which is deliberate.
-        buffer_size, num_buffers = _ring_sizing(MemoryCapMode.limited, self.files([10] * 20), 60)
-        self.assertEqual(buffer_size, 60)
-        self.assertEqual(num_buffers, 2)
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_the_depth_target_is_honoured(self):
+        # same data and budget as above, but asking for 2 buffers gives 2 twice the size - the whole
+        # point of the knob is that it decides the shape while the limit decides the memory
+        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([100] * 5), 400), (200, 2))
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
-    def test_largest_range_floors_the_buffer_size(self):
-        # a single range larger than the configured size must still fit, or the stream cannot progress
-        buffer_size, _ = _ring_sizing(MemoryCapMode.limited, self.files([250], [10]), 1000)
-        self.assertEqual(buffer_size, 250)
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
+    def test_largest_range_floors_the_buffer_and_so_caps_the_depth(self):
+        # a range carries one destination and cannot span two buffers, so a 250 byte range forces a 250
+        # byte buffer even though budget // 4 is 87 - and a 350 byte budget then pays for only one.
+        # This is the mechanism that caps reachable depth at budget // largest_range.
+        self.assertEqual(
+            _ring_sizing(MemoryCapMode.limited, self.files([250], [10] * 10), 1000), (250, 1)
+        )
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
-    def test_count_never_exceeds_the_data(self):
-        # 1000 byte budget would allow 10 buffers, but there are only 150 bytes to read
-        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([50] * 3), 1000), (100, 2))
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
+    def test_depth_never_exceeds_the_number_of_requests(self):
+        # 150 bytes in 50 byte buffers is 3 requests, so the 4th buffer could never hold one
+        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([50] * 3), 10_000), (50, 3))
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "3"})
-    def test_min_ring_buffers_is_a_floor_not_a_target(self):
-        buffer_size, num_buffers = _ring_sizing(MemoryCapMode.limited, self.files([10] * 5), 50)
-        self.assertEqual(buffer_size, 50)
-        self.assertEqual(num_buffers, 3)
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
+    def test_a_single_request_stream_gets_a_single_buffer(self):
+        # one range, so one request: a ring here would be buffers with nothing to pipeline against.
+        # This is what the safetensors metadata reads look like - a handful of bytes, twice per load.
+        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([8]), 10_000_000_000), (8, 1))
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100"})
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
     def test_unlimited_budgets_the_whole_stream(self):
-        # -1 keeps its documented meaning: unlimited really is unlimited, so the ring spans the data
-        self.assertEqual(_ring_sizing(MemoryCapMode.unlimited, self.files([100] * 7), None), (100, 7))
+        # -1 keeps its documented meaning: the budget is the data, so the ring spans it at the target
+        # depth - 700 bytes over 4 buffers of 175
+        self.assertEqual(_ring_sizing(MemoryCapMode.unlimited, self.files([100] * 7), None), (175, 4))
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
     def test_largest_chunk_mode_stays_a_single_buffer(self):
         # mode 0 exists to mean minimal memory; a ring would defeat the only reason to ask for it
         self.assertEqual(_ring_sizing(MemoryCapMode.largest_chunk, self.files([10, 40], [25]), None), (40, 1))
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "4"})
     def test_nothing_to_read_gives_one_empty_buffer(self):
         self.assertEqual(_ring_sizing(MemoryCapMode.unlimited, self.files([], []), None), (0, 1))
         self.assertEqual(_ring_sizing(MemoryCapMode.unlimited, self.files([0, 0]), None), (0, 1))
@@ -84,11 +81,38 @@ class TestRingSizing(unittest.TestCase):
         with self.assertRaises(RunaiStreamerMemoryLimitException):
             _ring_sizing(MemoryCapMode.limited, self.files([10]), None)
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "0"})
-    def test_zero_min_ring_buffers_still_yields_a_ring(self):
+    def test_the_ring_never_exceeds_the_limit(self):
+        """The property that replaced the floor-exceeded warning.
+
+        The old rule had MIN_RING_BUFFERS as a floor that could push N x B past what the caller asked
+        for, so it warned. Depth is now clamped by budget // buffer_size instead of floored, which
+        makes overrunning the limit unrepresentable - asserted here across the shapes that used to
+        produce it (a limit far below the data, a limit equal to one range, awkward divisors)."""
+        for depth in ("1", "2", "3", "4", "16"):
+            for sizes, limit in (
+                ([10] * 20, 60),        # limit far below the data - the old warning case
+                ([10] * 20, 10),        # limit exactly one range: one buffer, no more
+                ([7] * 13, 100),        # nothing divides evenly
+                ([250], 250),           # a single range exactly filling the limit
+                ([1] * 100, 999_999),   # limit far above the data
+            ):
+                with patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: depth}):
+                    buffer_size, num_buffers = _ring_sizing(
+                        MemoryCapMode.limited, self.files(sizes), limit
+                    )
+                self.assertLessEqual(
+                    buffer_size * num_buffers, limit,
+                    f"depth={depth} sizes={sizes[:3]}... limit={limit} -> "
+                    f"{num_buffers} x {buffer_size}",
+                )
+                self.assertGreaterEqual(num_buffers, 1)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "0"})
+    def test_zero_ring_buffers_still_yields_a_ring(self):
+        # a hostile 0 must not produce a pool with no buffers to hand out
         _, num_buffers = _ring_sizing(MemoryCapMode.largest_chunk, self.files([10]), None)
         self.assertEqual(num_buffers, 1)
-        _, num_buffers = _ring_sizing(MemoryCapMode.unlimited, self.files([10]), None)
+        _, num_buffers = _ring_sizing(MemoryCapMode.unlimited, self.files([10] * 5), None)
         self.assertGreaterEqual(num_buffers, 1)
 
 
@@ -378,12 +402,14 @@ class TestFilesRequestsIterator(unittest.TestCase):
 
 
 class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "1"})
     def test_memory_cap_unlimited(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.unlimited, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])], 100
         )
         self.assertEqual(requests_iterator.buffer_size, 10)
 
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "1"})
     def test_memory_cap_limited(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.limited, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])], 5
@@ -432,6 +458,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         self.assertIsNotNone(files_requests)
         self.assertEqual(files_requests.num_ranges, 2)
 
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "1"})
     def test_limited_memory_cap_and_smaller_chunks(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.limited,
@@ -467,6 +494,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         self.assertEqual(files_requests.range_dsts, [base, base + 4, base + 5])
         self.assertEqual(files_requests.file_base, [0, 1])
 
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "1"})
     def test_get_global_file_and_range_aliases_the_buffer(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.unlimited,
@@ -489,12 +517,11 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         self.assertEqual(len(view), 3)
         self.assertEqual(view[0], 8)
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "4",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "2"})
     def test_consecutive_requests_get_distinct_buffers(self):
-        # 3 ranges of 4 bytes with a 4 byte buffer, and a budget affording exactly 2 buffers: one range
-        # per request, and the second request must NOT land in the first one's buffer - that is the
-        # whole point of the pool.
+        # 3 ranges of 4 bytes and an 8 byte budget over 2 buffers: 4 bytes each, one range per request,
+        # and the second request must NOT land in the first one's buffer - that is the whole point of
+        # the pool.
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.limited, [FileChunks.contiguous(17, "a.txt", 10, [4, 4, 4])], 8
         )
@@ -517,8 +544,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         self.assertEqual(third.buffer_index, first_index)
         self.assertEqual(third.range_dsts, [requests_iterator.buffer_addresses[first_index]])
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "4",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "2"})
     def test_releasing_twice_is_rejected(self):
         # a double release would put the same buffer in the free list twice, so two live requests would
         # silently share it and overwrite each other's data
@@ -530,8 +556,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         with self.assertRaises(ValueError):
             requests_iterator.release(request)
 
-    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "4",
-                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "3"})
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "3"})
     def test_buffers_are_distinct_slices_of_one_allocation(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.limited, [FileChunks.contiguous(17, "a.txt", 10, [4, 4, 4])], 12
@@ -555,6 +580,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         self.assertIsNone(requests_iterator.next_request())
         self.assertTrue(requests_iterator.has_free_buffer())
 
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFERS_ENV_VAR_NAME: "1"})
     def test_get_global_file_and_range_zero_sized_range(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.unlimited, [FileChunks.contiguous(17, "a.txt", 10, [5, 0, 3])], None

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -86,12 +86,14 @@ class TestRingSizing(unittest.TestCase):
             _ring_sizing(MemoryCapMode.limited, self.files([10]), None)
 
     def test_the_ring_never_exceeds_the_limit(self):
-        """The property that replaced the floor-exceeded warning.
+        """The ring never allocates more than the caller asked for.
 
-        The old rule had MIN_RING_BUFFERS as a floor that could push N x B past what the caller asked
-        for, so it warned. Depth is now clamped by budget // buffer_size instead of floored, which
-        makes overrunning the limit unrepresentable - asserted here across the shapes that used to
-        produce it (a limit far below the data, a limit equal to one range, awkward divisors)."""
+        This replaced a runtime warning: an earlier draft of the sizing rule had a minimum depth that
+        could push N x B past the limit, so it warned instead of preventing it. Nothing in the code now
+        can produce that, by two separate arguments - depth is clamped by budget // buffer_size on the
+        ordinary path, and the span search is capped at limit // target - which is exactly why it is
+        worth asserting as a property rather than trusting either argument. Covers the shapes that used
+        to trip it: a limit far below the data, a limit equal to one range, awkward divisors."""
         for depth in ("1", "2", "3", "4", "16"):
             for sizes, limit in (
                 ([10] * 20, 60),        # limit far below the data - the old warning case

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -1,11 +1,95 @@
+import os
 import unittest
+from unittest.mock import patch
 from runai_model_streamer.file_streamer.requests_iterator import (
     FileChunksIterator,
     FilesRequestsIterator,
     FilesRequestsIteratorWithBuffer,
     FileChunks,
-    MemoryCapMode
+    MemoryCapMode,
+    RunaiStreamerMemoryLimitException,
+    RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME,
+    RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME,
+    _ring_sizing,
 )
+
+
+class TestRingSizing(unittest.TestCase):
+    """The ring's (buffer_size, num_buffers). Ranges are sized in bytes, and the configured minimum
+    buffer size is overridden per test so the fixtures stay small and readable."""
+
+    def files(self, *sizes_per_file):
+        return [
+            FileChunks.contiguous(i, f"{i}.txt", 0, list(sizes))
+            for i, sizes in enumerate(sizes_per_file)
+        ]
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_limited_derives_count_from_budget(self):
+        # budget 500, buffer 100 -> 5 buffers, and there is data for all 5
+        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([100] * 5), 500), (100, 5))
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_limit_tighter_than_configured_size_shrinks_the_buffer(self):
+        # the user's cap wins over the configured minimum size: a 60 byte budget must not hand out
+        # a 100 byte buffer. The MIN_RING_BUFFERS floor then exceeds the budget, which is deliberate.
+        buffer_size, num_buffers = _ring_sizing(MemoryCapMode.limited, self.files([10] * 20), 60)
+        self.assertEqual(buffer_size, 60)
+        self.assertEqual(num_buffers, 2)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_largest_range_floors_the_buffer_size(self):
+        # a single range larger than the configured size must still fit, or the stream cannot progress
+        buffer_size, _ = _ring_sizing(MemoryCapMode.limited, self.files([250], [10]), 1000)
+        self.assertEqual(buffer_size, 250)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_count_never_exceeds_the_data(self):
+        # 1000 byte budget would allow 10 buffers, but there are only 150 bytes to read
+        self.assertEqual(_ring_sizing(MemoryCapMode.limited, self.files([50] * 3), 1000), (100, 2))
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "3"})
+    def test_min_ring_buffers_is_a_floor_not_a_target(self):
+        buffer_size, num_buffers = _ring_sizing(MemoryCapMode.limited, self.files([10] * 5), 50)
+        self.assertEqual(buffer_size, 50)
+        self.assertEqual(num_buffers, 3)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100"})
+    def test_unlimited_budgets_the_whole_stream(self):
+        # -1 keeps its documented meaning: unlimited really is unlimited, so the ring spans the data
+        self.assertEqual(_ring_sizing(MemoryCapMode.unlimited, self.files([100] * 7), None), (100, 7))
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_largest_chunk_mode_stays_a_single_buffer(self):
+        # mode 0 exists to mean minimal memory; a ring would defeat the only reason to ask for it
+        self.assertEqual(_ring_sizing(MemoryCapMode.largest_chunk, self.files([10, 40], [25]), None), (40, 1))
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "100",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_nothing_to_read_gives_one_empty_buffer(self):
+        self.assertEqual(_ring_sizing(MemoryCapMode.unlimited, self.files([], []), None), (0, 1))
+        self.assertEqual(_ring_sizing(MemoryCapMode.unlimited, self.files([0, 0]), None), (0, 1))
+
+    def test_limit_below_largest_range_is_rejected(self):
+        with self.assertRaises(RunaiStreamerMemoryLimitException):
+            _ring_sizing(MemoryCapMode.limited, self.files([250]), 100)
+
+    def test_limited_without_a_limit_is_rejected(self):
+        with self.assertRaises(RunaiStreamerMemoryLimitException):
+            _ring_sizing(MemoryCapMode.limited, self.files([10]), None)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "0"})
+    def test_zero_min_ring_buffers_still_yields_a_ring(self):
+        _, num_buffers = _ring_sizing(MemoryCapMode.largest_chunk, self.files([10]), None)
+        self.assertEqual(num_buffers, 1)
+        _, num_buffers = _ring_sizing(MemoryCapMode.unlimited, self.files([10]), None)
+        self.assertGreaterEqual(num_buffers, 1)
 
 
 class TestFileChunks(unittest.TestCase):
@@ -298,19 +382,19 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.unlimited, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])], 100
         )
-        self.assertEqual(len(requests_iterator.buffer), 10)
+        self.assertEqual(requests_iterator.buffer_size, 10)
 
     def test_memory_cap_limited(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.limited, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])], 5
         )
-        self.assertEqual(len(requests_iterator.buffer), 5)
+        self.assertEqual(requests_iterator.buffer_size, 5)
 
     def test_memory_cap_largest_chunk(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.largest_chunk, [FileChunks.contiguous(17, "a.txt", 10, [1, 2, 3, 4])], 5
         )
-        self.assertEqual(len(requests_iterator.buffer), 4)
+        self.assertEqual(requests_iterator.buffer_size, 4)
 
     def test_memory_cap_largest_chunk_multi_file(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
@@ -319,7 +403,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
              FileChunks.contiguous(18, "b.txt", 10, [1, 2, 7, 4])],
             5,
         )
-        self.assertEqual(len(requests_iterator.buffer), 7)
+        self.assertEqual(requests_iterator.buffer_size, 7)
 
     def test_memory_cap_largest_chunk_no_files(self):
         # the largest_chunk branch used to call a bare max() and raise on an empty sequence, while the
@@ -327,7 +411,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.largest_chunk, [], None
         )
-        self.assertEqual(len(requests_iterator.buffer), 0)
+        self.assertEqual(requests_iterator.buffer_size, 0)
         self.assertIsNone(requests_iterator.next_request())
 
     def test_memory_cap_largest_chunk_empty_shard(self):
@@ -336,13 +420,13 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
             [FileChunks(17, "empty.txt", [], []), FileChunks.contiguous(18, "a.txt", 10, [4])],
             None,
         )
-        self.assertEqual(len(requests_iterator.buffer), 4)
+        self.assertEqual(requests_iterator.buffer_size, 4)
 
     def test_memory_cap_largest_chunk_only_zero_sized_ranges(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
             MemoryCapMode.largest_chunk, [FileChunks.contiguous(17, "zeros.txt", 10, [0, 0])], None
         )
-        self.assertEqual(len(requests_iterator.buffer), 0)
+        self.assertEqual(requests_iterator.buffer_size, 0)
 
         files_requests = requests_iterator.next_request()
         self.assertIsNotNone(files_requests)
@@ -354,7 +438,7 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
             [FileChunks.contiguous(17, "a.txt", 10, [1, 2]), FileChunks.contiguous(18, "b.txt", 10, [3, 4])],
             50,
         )
-        self.assertEqual(len(requests_iterator.buffer), 10)
+        self.assertEqual(requests_iterator.buffer_size, 10)
 
     def test_range_dsts_pack_the_request(self):
         # replaces the old per-file file_buffers: destinations are per range now, packed back to back
@@ -365,17 +449,21 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
              FileChunks.contiguous(18, "b.txt", 10, [1, 2, 7, 4])],
             5,
         )
-        self.assertEqual(len(requests_iterator.buffer), 7)
-        base = requests_iterator.buffer_address
+        self.assertEqual(requests_iterator.buffer_size, 7)
+        base = requests_iterator.buffer_addresses[0]
 
         files_requests = requests_iterator.next_request()
         self.assertEqual([f.id for f in files_requests.files], [17])
         self.assertEqual(files_requests.range_dsts, [base, base + 1, base + 3])
 
+        # largest_chunk mode is a ring of one, so the single buffer has to come back before the next
+        # request can be built - and the next request then packs from that same base.
+        requests_iterator.release(files_requests)
+
         files_requests = requests_iterator.next_request()
         self.assertEqual([f.id for f in files_requests.files], [17, 18])
-        # a.txt's remaining 4 bytes, then b.txt's 1 and 2 - one destination per range, and the buffer
-        # is reused from its start for every request
+        # a.txt's remaining 4 bytes, then b.txt's 1 and 2 - one destination per range, packed from the
+        # start of the buffer this request was given
         self.assertEqual(files_requests.range_dsts, [base, base + 4, base + 5])
         self.assertEqual(files_requests.file_base, [0, 1])
 
@@ -385,11 +473,11 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
             [FileChunks.contiguous(17, "a.txt", 10, [1, 2]), FileChunks.contiguous(18, "b.txt", 10, [3, 4])],
             5,
         )
-        self.assertEqual(len(requests_iterator.buffer), 10)
+        self.assertEqual(requests_iterator.buffer_size, 10)
 
         request = requests_iterator.next_request()
-        requests_iterator.buffer[0] = 9
-        requests_iterator.buffer[3] = 8
+        requests_iterator.buffers[0][0] = 9
+        requests_iterator.buffers[0][3] = 8
 
         file_id, range_index, view = requests_iterator.get_global_file_and_range(request, 0, 0)
         self.assertEqual((file_id, range_index), (17, 0))
@@ -400,6 +488,72 @@ class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
         self.assertEqual((file_id, range_index), (18, 0))
         self.assertEqual(len(view), 3)
         self.assertEqual(view[0], 8)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "4",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_consecutive_requests_get_distinct_buffers(self):
+        # 3 ranges of 4 bytes with a 4 byte buffer, and a budget affording exactly 2 buffers: one range
+        # per request, and the second request must NOT land in the first one's buffer - that is the
+        # whole point of the pool.
+        requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.limited, [FileChunks.contiguous(17, "a.txt", 10, [4, 4, 4])], 8
+        )
+        self.assertEqual((requests_iterator.buffer_size, requests_iterator.num_buffers), (4, 2))
+
+        first = requests_iterator.next_request()
+        first_index = first.buffer_index
+        second = requests_iterator.next_request()
+        self.assertNotEqual(first_index, second.buffer_index)
+        self.assertNotEqual(first.range_dsts, second.range_dsts)
+
+        # exhausted: a third request has nowhere to go until one comes back
+        self.assertFalse(requests_iterator.has_free_buffer())
+        with self.assertRaises(RuntimeError):
+            requests_iterator.next_request()
+
+        # released, so the third request reuses the first one's buffer and packs from its base
+        requests_iterator.release(first)
+        third = requests_iterator.next_request()
+        self.assertEqual(third.buffer_index, first_index)
+        self.assertEqual(third.range_dsts, [requests_iterator.buffer_addresses[first_index]])
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "4",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "2"})
+    def test_releasing_twice_is_rejected(self):
+        # a double release would put the same buffer in the free list twice, so two live requests would
+        # silently share it and overwrite each other's data
+        requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.limited, [FileChunks.contiguous(17, "a.txt", 10, [4, 4])], 8
+        )
+        request = requests_iterator.next_request()
+        requests_iterator.release(request)
+        with self.assertRaises(ValueError):
+            requests_iterator.release(request)
+
+    @patch.dict(os.environ, {RUNAI_STREAMER_RING_BUFFER_SIZE_BYTES_ENV_VAR_NAME: "4",
+                             RUNAI_STREAMER_MIN_RING_BUFFERS_ENV_VAR_NAME: "3"})
+    def test_buffers_are_distinct_slices_of_one_allocation(self):
+        requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.limited, [FileChunks.contiguous(17, "a.txt", 10, [4, 4, 4])], 12
+        )
+        self.assertEqual(len(requests_iterator.buffers), 3)
+        self.assertEqual(len(requests_iterator.pool), 12)
+
+        # writing through one buffer must not disturb another, and each view must alias the pool
+        for index, buffer in enumerate(requests_iterator.buffers):
+            buffer[:] = index
+        self.assertEqual(list(requests_iterator.pool), [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2])
+        self.assertEqual(
+            requests_iterator.buffer_addresses,
+            [requests_iterator.pool.ctypes.data + 4 * i for i in range(3)],
+        )
+
+    def test_end_of_stream_does_not_consume_a_buffer(self):
+        requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(
+            MemoryCapMode.largest_chunk, [], None
+        )
+        self.assertIsNone(requests_iterator.next_request())
+        self.assertTrue(requests_iterator.has_free_buffer())
 
     def test_get_global_file_and_range_zero_sized_range(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -272,6 +272,33 @@ class SafetensorsStreamer:
             device=device,
             is_distributed=is_distributed,
         )
+        self._log_ring()
+
+    def _log_ring(self) -> None:
+        """Report the ring once per load, at the session boundary.
+
+        Here rather than where the ring is built, for two reasons. The rank: a distributed load builds
+        one ring per rank, and FilesRequestsIteratorWithBuffer cannot know which rank it is, so at INFO
+        it would emit N unattributable copies. And the count: stream_files runs three times per load,
+        twice for the safetensors metadata (`1 x 8 Bytes`), so only this one describes the model read.
+
+        Worth INFO at all because the depth is DERIVED - from the limit, the ranks on the node and the
+        largest tensor - not taken from the setting, so a ring clamped to one buffer is otherwise
+        indistinguishable from the configured four, and they perform very differently. A failure to
+        report must never break a load, hence the broad except."""
+        try:
+            ring = self.file_streamer.ring_info()
+            if ring is None:
+                return
+            rank, num_buffers, buffer_size = ring
+            logger.info(
+                f"[RunAI Streamer] Rank {rank}: CPU ring {num_buffers} x "
+                f"{humanize.naturalsize(buffer_size, binary=True)} = "
+                f"{humanize.naturalsize(num_buffers * buffer_size, binary=True)} "
+                f"for {humanize.naturalsize(self.total_size, binary=True)} in {len(self.files_to_tensors_metadata)} file(s)"
+            )
+        except Exception:
+            logger.debug("[RunAI Streamer] could not report the CPU ring", exc_info=True)
 
     def get_tensors(self) -> Iterator[torch.tensor]:
         for file_index, ready_chunk_index, buffer in self.file_streamer.get_chunks():

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_metadata_ordering.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_metadata_ordering.py
@@ -58,7 +58,9 @@ class TestMetadataOrdering(unittest.TestCase):
 
         with SafetensorsStreamer() as streamer:
             streamer.stream_file(path)
-            tensors = {name: tensor for name, tensor in streamer.get_tensors()}
+            # clone: the yielded tensor is a VIEW into a ring buffer that is recycled once the
+            # generator advances, so anything compared after the loop must own its data
+            tensors = {name: tensor.clone() for name, tensor in streamer.get_tensors()}
 
         self.assertEqual(sorted(tensors), ["empty", "first", "second"])
         self.assertEqual(tuple(tensors["empty"].shape), (0, 3))

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_mock.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_mock.py
@@ -57,7 +57,9 @@ class TestSafetensorsStreamerMock(unittest.TestCase):
             # Pass the *fake* path here. The patcher will rewrite it.
             run_sf.stream_file(fake_s3_path, None, "cpu")
             for name, tensor in run_sf.get_tensors():
-                our[name] = tensor
+                # clone: the yielded tensor is a VIEW into a ring buffer that is recycled once
+                # the generator advances, so anything compared after the loop must own its data
+                our[name] = tensor.clone()
 
         # 5. Load baseline from the REAL LOCAL PATH
         their = {}
@@ -96,7 +98,9 @@ class TestSafetensorsStreamerMock(unittest.TestCase):
         with SafetensorsStreamer() as run_sf:
             run_sf.stream_file(fake_gs_path, None, "cpu")
             for name, tensor in run_sf.get_tensors():
-                our[name] = tensor
+                # clone: the yielded tensor is a VIEW into a ring buffer that is recycled once
+                # the generator advances, so anything compared after the loop must own its data
+                our[name] = tensor.clone()
 
         # 5. Load baseline from the REAL LOCAL PATH
         their = {}

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_safetensors_streamer.py
@@ -103,6 +103,49 @@ class TestSafetensorsStreamer(unittest.TestCase):
         with DistributedStreamer() as streamer:
             self.assertIsNone(streamer.ring_info())
 
+    def test_ring_info_is_none_for_a_rank_whose_partition_is_empty(self):
+        """A rank that read no model data must report no ring - not the metadata read's ring.
+
+        The FileStreamer is shared with the safetensors metadata reads, so requests_iterator is ALWAYS
+        set by the time the model read starts. A rank whose share of the partition is empty returns from
+        _distributedStreamer.stream_files before calling it again, so reading the iterator on demand
+        answers with the 8 byte metadata ring - which printed against the model's byte total looks
+        exactly like a ring clamped to a single buffer, the failure this report exists to expose.
+        """
+        from unittest.mock import patch
+        from runai_model_streamer.distributed_streamer import DistributedStreamer
+        from runai_model_streamer.file_streamer import FileChunks
+
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        file_path = os.path.join(base_dir, "test_files", "test.safetensors")
+        if not os.path.exists(file_path):
+            self.skipTest(f"Original test file not found at {file_path}")
+        requests = [FileChunks.contiguous(0, file_path, 0, [os.path.getsize(file_path)])]
+
+        with DistributedStreamer() as streamer:
+            # A real read first, standing in for the metadata reads: it leaves an iterator behind.
+            streamer.stream_files(requests, None, "cpu", False)
+            for _chunk in streamer.get_chunks():
+                pass
+            self.assertIsNotNone(streamer.ring_info())
+
+            # Now the model read on the empty rank. Both patches reproduce distributed_streamer.py
+            # exactly: is_distributed True (the fallback checks need a real process group otherwise),
+            # and the empty-partition early return, which sets reading_from_storage False and returns
+            # without touching the FileStreamer.
+            def empty_partition(*_args, **_kwargs):
+                streamer.distributed_streamer.reading_from_storage = False
+
+            with patch.object(
+                streamer, "set_is_distributed",
+                side_effect=lambda *_a: setattr(streamer, "is_distributed", True),
+            ), patch.object(
+                streamer.distributed_streamer, "stream_files", side_effect=empty_partition
+            ):
+                streamer.stream_files(requests, None, "cpu", True)
+
+            self.assertIsNone(streamer.ring_info())
+
     def test_valid_file(self):
         # Assuming test_files exists relative to the script location
         base_dir = os.path.dirname(os.path.abspath(__file__))

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_safetensors_streamer.py
@@ -5,6 +5,7 @@ import struct
 import json
 import tempfile
 import shutil
+import humanize
 from safetensors import safe_open
 from runai_model_streamer.safetensors_streamer.safetensors_streamer import (
     SafetensorsStreamer,
@@ -49,6 +50,58 @@ class TestSafetensorsStreamer(unittest.TestCase):
             f.write(tensor_data)
         
         return filepath
+
+    def ring_records(self, logs):
+        return [r for r in logs.records if "CPU ring" in r.getMessage()]
+
+    def test_the_ring_is_reported_once_per_load_with_the_rank(self):
+        """One INFO line per load, carrying the rank.
+
+        Both halves matter. ONCE: stream_files runs three times per load - twice for the safetensors
+        metadata - so reporting where the ring is BUILT gives three lines, two of them describing an
+        8 byte read. WITH THE RANK: every rank builds its own ring, so without it a distributed load
+        emits N indistinguishable copies, which is why the line lives at the session boundary rather
+        than inside FilesRequestsIteratorWithBuffer.
+        """
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        file_path = os.path.join(base_dir, "test_files", "test.safetensors")
+        if not os.path.exists(file_path):
+            self.skipTest(f"Original test file not found at {file_path}")
+
+        with self.assertLogs("runai_model_streamer", level="INFO") as logs:
+            with SafetensorsStreamer() as run_sf:
+                run_sf.stream_file(file_path, None, "cpu")
+                for _name, _tensor in run_sf.get_tensors():
+                    pass
+
+        records = self.ring_records(logs)
+        self.assertEqual(len(records), 1, f"expected one ring line, got {[r.getMessage() for r in records]}")
+        self.assertIn("Rank 0", records[0].getMessage())
+
+        # ...and it describes the MODEL read, not one of the metadata reads: the payload it reports is
+        # the file's tensor bytes. Asserting the size rather than the absence of a metadata-sized string
+        # on purpose - `assertNotIn("8 Bytes", ...)` looks like it says that but is a substring of
+        # "198 Bytes", so it fails on any fixture whose size happens to end in 8.
+        with safe_open(file_path, framework="pt", device="cpu") as f:
+            total = sum(f.get_tensor(name).nbytes for name in f.keys())
+        self.assertIn(humanize.naturalsize(total, binary=True), records[0].getMessage())
+
+        # the per-request line still exists for debugging - it is just below INFO now, so raising the
+        # level brings back one line per stream_files (the two metadata reads plus the model read)
+        with self.assertLogs("runai_model_streamer", level="DEBUG") as logs:
+            with SafetensorsStreamer() as run_sf:
+                run_sf.stream_file(file_path, None, "cpu")
+                for _name, _tensor in run_sf.get_tensors():
+                    pass
+        self.assertGreater(len(self.ring_records(logs)), 1)
+
+    def test_ring_info_is_none_before_streaming(self):
+        # a rank whose share is empty never builds an iterator, and list_files-only use never does
+        # either; the reporter must treat that as normal rather than raising
+        from runai_model_streamer.distributed_streamer import DistributedStreamer
+
+        with DistributedStreamer() as streamer:
+            self.assertIsNone(streamer.ring_info())
 
     def test_valid_file(self):
         # Assuming test_files exists relative to the script location

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_safetensors_streamer.py
@@ -62,7 +62,9 @@ class TestSafetensorsStreamer(unittest.TestCase):
         with SafetensorsStreamer() as run_sf:
             run_sf.stream_file(file_path, None, "cpu")
             for name, tensor in run_sf.get_tensors():
-                our[name] = tensor
+                # clone: the yielded tensor is a VIEW into a ring buffer that is recycled once
+                # the generator advances, so anything compared after the loop must own its data
+                our[name] = tensor.clone()
 
         their = {}
         with safe_open(file_path, framework="pt", device="cpu") as f:
@@ -299,7 +301,9 @@ class TestSafetensorsStreamer(unittest.TestCase):
             streamer.stream_file(path, None, "cpu")
             tensors = {}
             for name, tensor in streamer.get_tensors():
-                tensors[name] = tensor
+                # clone: the yielded tensor is a VIEW into a ring buffer that is recycled once
+                # the generator advances, so anything compared after the loop must own its data
+                tensors[name] = tensor.clone()
             
             self.assertIn("First", tensors)
             self.assertIn("Second", tensors)

--- a/tests/cases/testcases.py
+++ b/tests/cases/testcases.py
@@ -92,7 +92,9 @@ got = {}
 with SafetensorsStreamer() as run_sf:
     run_sf.stream_file(url, None, "cpu")
     for name, tensor in run_sf.get_tensors():
-        got[name] = tensor
+        # clone: the yielded tensor is a VIEW into a ring buffer that is recycled once the
+        # generator advances, so anything compared after the loop must own its data
+        got[name] = tensor.clone()
 
 expected = {}
 with safe_open(expected_file, framework="pt", device="cpu") as f:
@@ -124,7 +126,9 @@ def compatibility_test_cases(backend_class, scheme, bucket_name):
             with SafetensorsStreamer() as run_sf:
                 run_sf.stream_file(f"{self.scheme}://{self.bucket_name}/model.safetensors", None, "cpu")
                 for name, tensor in run_sf.get_tensors():
-                    our[name] = tensor
+                    # clone: the yielded tensor is a VIEW into a ring buffer that is recycled
+                    # once the generator advances, so a comparison after the loop must own it
+                    our[name] = tensor.clone()
 
             their = {}
             with safe_open(file_path, framework="pt", device="cpu") as f:
@@ -344,7 +348,9 @@ def compatibility_test_cases(backend_class, scheme, bucket_name):
             with SafetensorsStreamer() as run_sf:
                 run_sf.stream_file(url, None, "cpu")
                 for name, tensor in run_sf.get_tensors():
-                    our[name] = tensor
+                    # clone: the yielded tensor is a VIEW into a ring buffer that is recycled
+                    # once the generator advances, so a comparison after the loop must own it
+                    our[name] = tensor.clone()
 
             their = {}
             with safe_open(file_path, framework="pt", device="cpu") as f:

--- a/tests/fuzzing/test_recovery.py
+++ b/tests/fuzzing/test_recovery.py
@@ -9,11 +9,11 @@ from runai_model_streamer.file_streamer import (FileStreamer, FileChunks)
 class TestRecoveryAfterRangeError(unittest.TestCase):
     """A per-range error must not break the streamer for everything after it.
 
-    Runs against the REAL library on purpose. The mock cannot express this: it serves one submission at a
-    time and resets its state on every runai_request, so responses abandoned by a previous submission simply
-    vanish and the streamer always appears to recover.
+    Runs against the REAL library on purpose. The mock cannot express this: it serves every range
+    synchronously from the calling thread, so a range is never genuinely in flight when the error fires
+    and the streamer always appears to recover.
 
-    Nothing here is filesystem specific. The drain lives in FileStreamer.request_ready_chunks, above the
+    Nothing here is filesystem specific. The drain lives in FileStreamer.get_chunks, above the
     backend, so an object-storage submission fails and recovers through the very same code - the filesystem
     is used only because it needs no emulator. Object storage differs in severity, not behaviour: its reads
     are genuinely in flight when the error fires, so more ranges are still writing into a buffer the next

--- a/tests/fuzzing/test_safetensors_streamer.py
+++ b/tests/fuzzing/test_safetensors_streamer.py
@@ -43,7 +43,9 @@ class TestSafetensorStreamerFuzzing(unittest.TestCase):
         with SafetensorsStreamer() as run_sf:
             run_sf.stream_file(file_path, None, "cpu", False)
             for name, tensor in run_sf.get_tensors():
-                our[name] = tensor
+                # clone: the yielded tensor is a VIEW into a ring buffer that is recycled once
+                # the generator advances, so anything compared after the loop must own its data
+                our[name] = tensor.clone()
 
         their = {}
         # This MUST succeed now. If safe_open fails, our generator is producing invalid files.
@@ -63,7 +65,9 @@ class TestSafetensorStreamerFuzzing(unittest.TestCase):
         with SafetensorsStreamer() as run_sf:
             run_sf.stream_files(file_paths)
             for name, tensor in run_sf.get_tensors():
-                our[name] = tensor
+                # clone: the yielded tensor is a VIEW into a ring buffer that is recycled once
+                # the generator advances, so anything compared after the loop must own its data
+                our[name] = tensor.clone()
 
         their = {}
         for file_path in file_paths:

--- a/tests/s3/test_s3.py
+++ b/tests/s3/test_s3.py
@@ -132,7 +132,9 @@ class TestS3UnsignedPublicBucket(unittest.TestCase):
             with SafetensorsStreamer() as streamer:
                 streamer.stream_file(f"s3://{self.PUBLIC_BUCKET}/model.safetensors", None, "cpu")
                 for name, tensor in streamer.get_tensors():
-                    our[name] = tensor
+                    # clone: the yielded tensor is a VIEW into a ring buffer that is recycled
+                    # once the generator advances, so a comparison after the loop must own it
+                    our[name] = tensor.clone()
 
         their = {}
         with safe_open(self.file_path, framework="pt", device="cpu") as f:


### PR DESCRIPTION
 CPU ring buffer: concurrent submissions, and `RUNAI_STREAMER_MEMORY_LIMIT` as a total for distributed streaming

Closes #164 .

The single CPU buffer that every request was drained into and reused becomes a **ring of N buffers** with several submissions in flight. A buffer returns to the ring the moment the consumer finishes the last tensor in it, and is refilled immediately.

This removes the choice the streamer forced on callers: uncapped ran at full speed with a **model-sized** buffer, capped saved RAM but made every request boundary a barrier. Neither is necessary — vLLM and SGLang copy each yielded tensor, so nothing needs to stay resident past its yield. And the RAM mattered for more than RAM: at TP=8 on a 831 GiB model the old default drove the node into page reclaim (395 GB reclaimed, host free down to 681 GB), which costs more than any barrier
it avoids.

Nothing in `cpp/streamer` changes — the C++ layer already supported concurrent submissions.

## Breaking change

**`RUNAI_STREAMER_MEMORY_LIMIT` now applies to distributed streaming, as a node total.** It was previously ignored there and forced to `-1` (unlimited). It is now divided by the ranks **on that node** — the ranks that share the node's RAM, and the set the partitioning already works over.

- **Unset:** distributed streaming defaults to 40 GB per node instead of unlimited.
- **Set:** the meaning changed. 40 GB was per rank; at 8 ranks per node it is now 5 GB per rank.
  Multiply by ranks-per-node to keep the old amount, or set `-1` for the old behaviour.

RAM floor to document: `N × largest_tensor × ranks-per-node`.

## New environment variable

`RUNAI_STREAMER_RING_BUFFERS` — ring **depth**, default 4; the buffer size is derived from it.

Depth is the right knob because it saturates and so has a meaningful default: on a 207 GiB model at a fixed 10 GiB limit, 1→2 buffers was worth 6.2% and 2→4 a further 1.5%, nothing beyond. A buffer size has no such default. It also removes a foot-gun — at a fixed limit, shrinking the buffer to "save memory" saves nothing (`N × B` is the budget) and costs up to 36%.

## Review guide

| Order | File | What to look at |
| --- | --- | --- |
| 1 | `py/.../file_streamer/requests_iterator.py` | Self-describing `FilesRequest`; pool, free list, `release`; `_ring_sizing` |
| 2 | `py/.../file_streamer/file_streamer.py` | One response loop demuxed by submission id; where a buffer is released |
| 3 | `py/.../distributed_streamer/distributed_streamer.py` | `rank_memory_limit` |
| 4 | `cpp/mock/streamer-mock.cc` | Per-streamer state, round-robin responses |
| 5 | test files | The consumer-contract change (`.clone()`) |

**1. A request that describes itself.** Responses used to be interpreted from *iterator state* — which submission was current, how many ranges consumed — which has moved on by the time a response arrives with several submissions live. `FilesRequest` now freezes `file_base` and `range_base` when a file is appended, so a response is resolved entirely from its own request. The pool is one `np.empty(N × B)` allocation sliced into N views (simpler for the OS, and the shape O_DIRECT will need).

Sizing: `budget = min(limit, total)`; `B = max(largest_range, budget // N)`; `N = min(N, budget // B)`. The floor exists because a range carries one destination address and cannot span two buffers — which also caps reachable depth at `budget // largest_range`. The old floor-exceeded warning is unreachable and is replaced by a property test.

One special case: when the stream is **smaller than the limit** the ring should span it entirely, and `B = total // N` misses by exactly the packing waste — tensors are indivisible, so a remainder request is arithmetic, not bad luck. Llama-3-8B at the 40 GB default packed 4 × 3.660 GiB into 3.739 GiB buffers, then needed a 5th request for the last 336 MiB that could not start until a buffer freed. The sizing now spends the headroom the limit already granted (+108 MiB here). It binary-searches prefix
sums, `O(depth × log ranges)`, and is skipped unless there is headroom — a 150k-tensor model reaches it only if the limit exceeds the whole model.

**2. One response loop.** `get_chunks` is a single loop over all live submissions, demuxed by id; `request_ready_chunks` / `submit_active_request` / `active_request` are gone. A buffer is released when the generator **resumes past** the yield of the `submission_done` response — the exact instant every view into it has been consumed — and the ring refills there, which is also the backpressure. `drain_live_submissions` runs in a `finally` so every submission drains however the generator ends;
otherwise a range still in flight writes into freed memory.

`stream_files` now rejects being called with responses outstanding. Not a style guard: `self.requests_iterator` is a single slot, so assigning a new one drops the only reference to the previous pool while C++ still holds raw pointers into it — a use-after-free that surfaced as a misleading "unknown submission" error much later.

**3. The node-total divisor.** Ranks on the node, not world size: with TP spanning hosts, world size counts ranks whose RAM is elsewhere and every buffer would shrink for nothing. Floored at the largest range; `-1` and `0` are modes and pass through. The limit is passed explicitly through `stream_files` instead of the previous `os.environ` mutate-and-restore, which was visible to every other rank.

**4. Mock.** Submissions are a per-id map served **round robin**, because the real responder makes no ordering promise — an in-order mock would certify a caller that wrongly assumes ordering. State is now owned by the handle (`new`/`delete`), mirroring `impl::Streamer`; it was in process-wide globals that `runai_start` cleared, so a second streamer wiped a live one's submissions — failing under the mockwhile working in production. Reachable: `list_files` starts a temporary streamer outside the context manager.

**5. Consumer contract.** Yielded tensors are views into the ring, which now recycles *during* iteration. The contract always existed (`usage.md` said to clone) but rarely bit, because the old unlimited default meant one request covered the whole model. 11 test call sites collected tensors into a dict and compared after the loop; they now `.clone()`. They were passing by accident of fixture scale.

## Results

**DeepSeek-V4-Pro 831 GiB fp8, TP=8, 8×H200, virtiofs, cold cache, mean of 3, round-robin ordering.**
Metric is vLLM's `Model loading took ... seconds`.

| loader | time | page reclaim | host RAM low-water |
| --- | --- | --- | --- |
| **this branch (40 GB node default)** | **114.36 s** | **0** | **1479 GB** |
| upstream 0.16.1, distributed, unlimited | 120.46 s | 395 GB | 681 GB |

5.06% faster than upstream, but **the memory result is the headline** and reproduced every round.

**Llama-3-8B over S3** — does depth help when the ring spans the model and never recycles? 4 buffers
3.9935 s (n=11) vs 1 buffer 4.0776 s (n=10): **2.06%, exact permutation p = 0.0043**. 

## Testing

`make test` plus object storage: **C++ 37/37, Python unit 190, distributed 10 × 2 ranks, fuzzing
7 × 10, S3 17, GCS 14, Azure 16.**

Two things the mock cannot express were checked against the real library: 180 randomised end-to-end trials (1–4 files, depths 1–16, random limits, position-encoded payloads so a misattributed response yields a wrong *value*), and 80 abandon-and-restream trials asserting the drain leaves nothing outstanding. Correctness was also verified byte-for-byte against `safetensors.safe_open` on Llama-3-8B (291 tensors) and Nemotron-3-Nano-Omni-30B (7349 tensors, 61.50 GiB) at every depth, comparing inside the yield loop. Every new test was run once against the un-fixed code to confirm it fails, and fails
for the right reason.

## Not in this PR

- **Docs** — `docs/` describes the released version, so it is untouched. The full set of edits will be applied at release time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable ring-buffer streaming with multiple concurrent in-flight requests.
  * Added per-rank memory-limit handling for distributed streaming.
  * Added ring-buffer metrics, including rank, buffer count, buffer size, and capacity.
  * Added support for independent streams and abandoned or interrupted streams.

* **Bug Fixes**
  * Improved request tracking and response handling across concurrent streams.
  * Prevented recycled buffer data from corrupting retained streamed tensors.

* **Documentation**
  * Clarified streaming recovery behavior and memory-based buffer sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->