### PR TITLE
Force platform-specific wheel generation

### DIFF
--- a/py/runai_model_streamer/setup.py
+++ b/py/runai_model_streamer/setup.py
@@ -1,8 +1,24 @@
 import os
 from setuptools import setup, find_packages
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
 
 VERSION = os.getenv("PACKAGE_VERSION", "0.0.0")
 LIB = "libstreamer/lib/libstreamer.so"
+
+
+class bdist_wheel(_bdist_wheel):
+    """Force platform-specific wheel without Python ABI"""
+
+    def finalize_options(self):
+        super().finalize_options()
+        # create platform-specific wheel (platlib)
+        self.root_is_pure = False
+
+    def get_tag(self):
+        _, _, plat = super().get_tag()
+        # wheel tag, e.g. py3-none-linux_x86_64
+        return "py3", "none", plat
 
 
 def assert_lib_exists():
@@ -33,4 +49,5 @@ setup(
         "gcs": [f"runai_model_streamer_gcs=={VERSION}"],
         "azure": [f"runai_model_streamer_azure=={VERSION}"],
     },
+    cmdclass={"bdist_wheel": bdist_wheel},
 )

--- a/py/runai_model_streamer_azure/setup.py
+++ b/py/runai_model_streamer_azure/setup.py
@@ -1,8 +1,24 @@
 import os
 from setuptools import setup, find_packages
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
 
 VERSION = os.getenv("PACKAGE_VERSION", "0.0.0")
 LIB = "libstreamerazure.so"
+
+
+class bdist_wheel(_bdist_wheel):
+    """Force platform-specific wheel without Python ABI"""
+
+    def finalize_options(self):
+        super().finalize_options()
+        # create platform-specific wheel (platlib)
+        self.root_is_pure = False
+
+    def get_tag(self):
+        _, _, plat = super().get_tag()
+        # wheel tag, e.g. py3-none-linux_x86_64
+        return "py3", "none", plat
 
 
 def assert_lib_exists():
@@ -26,4 +42,5 @@ setup(
     packages=find_packages(),
     install_requires=["azure-storage-blob", "azure-identity"],
     data_files=[("/runai_model_streamer/libstreamer/lib/", [LIB])],
+    cmdclass={"bdist_wheel": bdist_wheel},
 )

--- a/py/runai_model_streamer_gcs/setup.py
+++ b/py/runai_model_streamer_gcs/setup.py
@@ -1,8 +1,24 @@
 import os
 from setuptools import setup, find_packages
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
 
 VERSION = os.getenv("PACKAGE_VERSION", "0.0.0")
 LIB = "libstreamergcs.so"
+
+
+class bdist_wheel(_bdist_wheel):
+    """Force platform-specific wheel without Python ABI"""
+
+    def finalize_options(self):
+        super().finalize_options()
+        # create platform-specific wheel (platlib)
+        self.root_is_pure = False
+
+    def get_tag(self):
+        _, _, plat = super().get_tag()
+        # wheel tag, e.g. py3-none-linux_x86_64
+        return "py3", "none", plat
 
 
 def assert_lib_exists():
@@ -26,4 +42,5 @@ setup(
     packages=find_packages(),
     install_requires=["google-cloud-storage", "google-auth"],
     data_files=[("/runai_model_streamer/libstreamer/lib/", [LIB])],
+    cmdclass={"bdist_wheel": bdist_wheel},
 )

--- a/py/runai_model_streamer_s3/setup.py
+++ b/py/runai_model_streamer_s3/setup.py
@@ -1,8 +1,24 @@
 import os
 from setuptools import setup, find_packages
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
 
 VERSION = os.getenv("PACKAGE_VERSION", "0.0.0")
 LIB = "libstreamers3.so"
+
+
+class bdist_wheel(_bdist_wheel):
+    """Force platform-specific wheel without Python ABI"""
+
+    def finalize_options(self):
+        super().finalize_options()
+        # create platform-specific wheel (platlib)
+        self.root_is_pure = False
+
+    def get_tag(self):
+        _, _, plat = super().get_tag()
+        # wheel tag, e.g. py3-none-linux_x86_64
+        return "py3", "none", plat
 
 
 def assert_lib_exists():
@@ -26,4 +42,5 @@ setup(
     packages=find_packages(),
     install_requires=["boto3"],
     data_files=[("/runai_model_streamer/libstreamer/lib/", [LIB])],
+    cmdclass={"bdist_wheel": bdist_wheel},
 )


### PR DESCRIPTION
The runai-model-streamer packages bundle shared libraries (.so files) but setuptools generates pure-Python (purelib) wheels by default, which can install them into the wrong location. Override bdist_wheel to produce platform-specific wheels without a Python ABI dependency (e.g. py3-none-linux_x86_64).

Fixes: #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-specific wheel packaging for the model streaming packages.
  * Wheels now use a consistent `py3-none-<platform>` format without a Python ABI tag.
  * Improved compatibility when installing packages across supported deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->