### PR TITLE
Fix typo in CMAKE_NM path in CMake file

### DIFF
--- a/.devcontainer/aarch64-linux-gnu.cmake
+++ b/.devcontainer/aarch64-linux-gnu.cmake
@@ -7,7 +7,7 @@ SET(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc)
 SET(CMAKE_CXX_COMPILER /usr/bin/aarch64-linux-gnu-g++)
 SET(CMAKE_LINKER /usr/bin/aarch64-linux-gnu-ld)
 SET(CMAKE_AR /usr/bin/aarch64-linux-gnu-ar)
-SET(CMAKE_NM /ousr/bin/aarch64-linux-gnu-nm)
+SET(CMAKE_NM /usr/bin/aarch64-linux-gnu-nm)
 SET(CMAKE_RANLIB /usr/bin/aarch64-linux-gnu-ranlib)
 
 # Specify sysroot if needed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the AArch64 build configuration to use the proper system tool path, improving build setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->