### PR TITLE
fix: prevent path traversal in pull_files() downloads from object storage

### DIFF
--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -213,7 +213,10 @@ def _filter_ignore(paths: List[str], patterns: List[str]) -> List[str]:
 
 
 def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
-    relative = removeprefix(file, base_dir).lstrip("/")
+    prefix = base_dir if base_dir == "" or base_dir.endswith("/") else base_dir + "/"
+    if not file.startswith(prefix):
+        raise ValueError(f"object key {file!r} does not start with expected prefix {prefix!r}")
+    relative = file[len(prefix):]
     dst_real = os.path.realpath(dst)
     destination_file = os.path.realpath(os.path.join(dst_real, relative))
     if os.path.commonpath([dst_real, destination_file]) != dst_real:

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -123,10 +123,7 @@ def pull_files(
     container_client = client.get_container_client(container_name)
 
     for file in files:
-        destination_file = os.path.join(
-            dst,
-            removeprefix(file, base_dir).lstrip("/")
-        )
+        destination_file = _safe_destination_path(dst, base_dir, file)
         local_dir = Path(destination_file).parent
         os.makedirs(local_dir, exist_ok=True)
         
@@ -214,6 +211,14 @@ def _filter_ignore(paths: List[str], patterns: List[str]) -> List[str]:
         if not any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
     ]
 
+
+def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
+    relative = removeprefix(file, base_dir).lstrip("/")
+    dst_real = os.path.realpath(dst)
+    destination_file = os.path.realpath(os.path.join(dst_real, relative))
+    if os.path.commonpath([dst_real, destination_file]) != dst_real:
+        raise ValueError(f"refusing to write outside destination directory: {file!r}")
+    return destination_file
 
 def removeprefix(s: str, prefix: str) -> str:
     if s.startswith(prefix):

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -216,7 +216,7 @@ def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
     prefix = base_dir if base_dir == "" or base_dir.endswith("/") else base_dir + "/"
     if not file.startswith(prefix):
         raise ValueError(f"object key {file!r} does not start with expected prefix {prefix!r}")
-    relative = file[len(prefix):]
+    relative = file[len(prefix):].lstrip("/")
     dst_real = os.path.realpath(dst)
     destination_file = os.path.realpath(os.path.join(dst_real, relative))
     if os.path.commonpath([dst_real, destination_file]) != dst_real:

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
@@ -141,6 +141,23 @@ class TestSafeDestinationPath(unittest.TestCase):
             files._safe_destination_path(
                 self.dst, "models/llama/", "../../etc/passwd")
 
+    def test_rejects_sibling_prefix_collision(self):
+        # base_dir "models/llama" (no trailing slash) is a plain string prefix
+        # of "models/llama_backup/...", but it's a different, unrelated key.
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama", "models/llama_backup/weights.bin")
+
+    def test_rejects_object_name_unrelated_to_base_dir(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/", "other/path/secret.txt")
+
+    def test_allows_top_level_key_when_base_dir_is_empty(self):
+        # base_dir is "" when pulling from the root of a container (no prefix).
+        result = files._safe_destination_path(self.dst, "", "config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
 
 class TestPullFilesTraversalRegression(unittest.TestCase):
     """Exercises the real pull_files() loop end-to-end, with only the SDK
@@ -184,6 +201,21 @@ class TestPullFilesTraversalRegression(unittest.TestCase):
         files.pull_files("az://container/models/llama/", self.dst)
 
         self.assertTrue(os.path.exists(os.path.join(self.dst, "subdir", "config.json")))
+
+    @patch("runai_model_streamer_azure.files.files._create_client")
+    @patch("runai_model_streamer_azure.files.files.list_files")
+    def test_pull_files_downloads_deeply_nested_key(
+            self, mock_list_files, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_list_files.return_value = (
+            "container", "models/llama/", ["models/llama/a/b/c/deep.safetensors"])
+        mock_client.get_container_client.return_value.get_blob_client \
+            .return_value.download_blob.return_value.readall.return_value = b"content"
+
+        files.pull_files("az://container/models/llama/", self.dst)
+
+        self.assertTrue(os.path.exists(os.path.join(self.dst, "a", "b", "c", "deep.safetensors")))
 
 
 if __name__ == "__main__":

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import patch, MagicMock
 import runai_model_streamer_azure.files.files as files
 from azure.storage.blob import BlobProperties, BlobServiceClient, ContainerClient
 
@@ -140,6 +140,50 @@ class TestSafeDestinationPath(unittest.TestCase):
         with self.assertRaises(ValueError):
             files._safe_destination_path(
                 self.dst, "models/llama/", "../../etc/passwd")
+
+
+class TestPullFilesTraversalRegression(unittest.TestCase):
+    """Exercises the real pull_files() loop end-to-end, with only the SDK
+    boundary (_create_client/list_files/download_blob) mocked, so this
+    keeps failing if a future change stops wiring _safe_destination_path
+    into the download loop -- including the Azure-specific detail that the
+    destination file is open()'d for write before the download itself.
+    """
+    def setUp(self):
+        self.dst = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.dst, ignore_errors=True)
+
+    @patch("runai_model_streamer_azure.files.files._create_client")
+    @patch("runai_model_streamer_azure.files.files.list_files")
+    def test_pull_files_rejects_traversal_key_and_writes_nothing(
+            self, mock_list_files, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        malicious_key = "models/llama/" + ("../" * 12) + "tmp/pwned"
+        mock_list_files.return_value = ("container", "models/llama/", [malicious_key])
+
+        with self.assertRaises(ValueError):
+            files.pull_files("az://container/models/llama/", self.dst)
+
+        mock_client.get_container_client.return_value.get_blob_client.assert_not_called()
+        self.assertEqual(os.listdir(self.dst), [])
+
+    @patch("runai_model_streamer_azure.files.files._create_client")
+    @patch("runai_model_streamer_azure.files.files.list_files")
+    def test_pull_files_downloads_valid_nested_key(
+            self, mock_list_files, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_list_files.return_value = (
+            "container", "models/llama/", ["models/llama/subdir/config.json"])
+        mock_client.get_container_client.return_value.get_blob_client \
+            .return_value.download_blob.return_value.readall.return_value = b"content"
+
+        files.pull_files("az://container/models/llama/", self.dst)
+
+        self.assertTrue(os.path.exists(os.path.join(self.dst, "subdir", "config.json")))
 
 
 if __name__ == "__main__":

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import MagicMock
 import runai_model_streamer_azure.files.files as files
@@ -106,6 +109,38 @@ class TestListFiles(unittest.TestCase):
             self.mock_blob_client, "az://container/", ignore_pattern=["*.safetensors"], recursive=True
         )
         self.assertEqual(result, ["models/weights/config.json", "models/README"])
+
+
+class TestSafeDestinationPath(unittest.TestCase):
+    def setUp(self):
+        self.dst = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.dst, ignore_errors=True)
+
+    def test_allows_valid_nested_path(self):
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama/subdir/config.json")
+        self.assertEqual(
+            result, os.path.realpath(os.path.join(self.dst, "subdir/config.json")))
+
+    def test_allows_valid_top_level_path(self):
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama/config.json")
+        self.assertEqual(
+            result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
+    def test_rejects_traversal_object_name(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/",
+                "models/llama/../../../../etc/cron.d/malicious")
+
+    def test_rejects_traversal_object_name_not_matching_base_dir(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/", "../../etc/passwd")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
@@ -158,6 +158,19 @@ class TestSafeDestinationPath(unittest.TestCase):
         result = files._safe_destination_path(self.dst, "", "config.json")
         self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
 
+    def test_allows_leading_slash_object_key_when_base_dir_is_empty(self):
+        # A key with a literal leading "/" is unusual but valid; os.path.join
+        # would otherwise treat it as absolute and discard dst entirely.
+        result = files._safe_destination_path(self.dst, "", "/config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
+    def test_allows_double_slash_at_prefix_boundary(self):
+        # A doubled "/" right where base_dir ends leaves a leading "/" on the
+        # remainder after the prefix is stripped off.
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama//config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
 
 class TestPullFilesTraversalRegression(unittest.TestCase):
     """Exercises the real pull_files() loop end-to-end, with only the SDK

--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/files.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/files.py
@@ -97,7 +97,7 @@ def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
     prefix = base_dir if base_dir == "" or base_dir.endswith("/") else base_dir + "/"
     if not file.startswith(prefix):
         raise ValueError(f"object key {file!r} does not start with expected prefix {prefix!r}")
-    relative = file[len(prefix):]
+    relative = file[len(prefix):].lstrip("/")
     dst_real = os.path.realpath(dst)
     destination_file = os.path.realpath(os.path.join(dst_real, relative))
     if os.path.commonpath([dst_real, destination_file]) != dst_real:

--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/files.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/files.py
@@ -39,9 +39,7 @@ def pull_files(model_path: str,
 
 
     for file in files:
-        destination_file = os.path.join(
-            dst,
-            removeprefix(file, base_dir).lstrip("/"))
+        destination_file = _safe_destination_path(dst, base_dir, file)
         local_dir = Path(destination_file).parent
         os.makedirs(local_dir, exist_ok=True)
         bucket = gcs.get_bucket(bucket_name)
@@ -94,6 +92,14 @@ def _filter_ignore(paths: List[str], patterns: List[str]) -> List[str]:
         path for path in paths
         if not any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
     ]
+
+def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
+    relative = removeprefix(file, base_dir).lstrip("/")
+    dst_real = os.path.realpath(dst)
+    destination_file = os.path.realpath(os.path.join(dst_real, relative))
+    if os.path.commonpath([dst_real, destination_file]) != dst_real:
+        raise ValueError(f"refusing to write outside destination directory: {file!r}")
+    return destination_file
 
 def removeprefix(s: str, prefix: str) -> str:
     if s.startswith(prefix):

--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/files.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/files.py
@@ -94,7 +94,10 @@ def _filter_ignore(paths: List[str], patterns: List[str]) -> List[str]:
     ]
 
 def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
-    relative = removeprefix(file, base_dir).lstrip("/")
+    prefix = base_dir if base_dir == "" or base_dir.endswith("/") else base_dir + "/"
+    if not file.startswith(prefix):
+        raise ValueError(f"object key {file!r} does not start with expected prefix {prefix!r}")
+    relative = file[len(prefix):]
     dst_real = os.path.realpath(dst)
     destination_file = os.path.realpath(os.path.join(dst_real, relative))
     if os.path.commonpath([dst_real, destination_file]) != dst_real:

--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/tests/test_files.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/tests/test_files.py
@@ -84,6 +84,19 @@ class TestSafeDestinationPath(unittest.TestCase):
         result = files._safe_destination_path(self.dst, "", "config.json")
         self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
 
+    def test_allows_leading_slash_object_key_when_base_dir_is_empty(self):
+        # A key with a literal leading "/" is unusual but valid; os.path.join
+        # would otherwise treat it as absolute and discard dst entirely.
+        result = files._safe_destination_path(self.dst, "", "/config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
+    def test_allows_double_slash_at_prefix_boundary(self):
+        # A doubled "/" right where base_dir ends leaves a leading "/" on the
+        # remainder after the prefix is stripped off.
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama//config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
 
 class TestPullFilesTraversalRegression(unittest.TestCase):
     """Exercises the real pull_files() loop end-to-end, with only the SDK

--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/tests/test_files.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/tests/test_files.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+import tempfile
 import unittest
 import runai_model_streamer_gcs.files.files as files
 
@@ -31,6 +34,37 @@ class TestFiles(unittest.TestCase):
     def test_removeprefix_no(self):
         res = files.removeprefix("test_prefix_string", "test_suffix_")
         self.assertEqual(res, "test_prefix_string")
+
+
+class TestSafeDestinationPath(unittest.TestCase):
+    def setUp(self):
+        self.dst = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.dst, ignore_errors=True)
+
+    def test_allows_valid_nested_path(self):
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama/subdir/config.json")
+        self.assertEqual(
+            result, os.path.realpath(os.path.join(self.dst, "subdir/config.json")))
+
+    def test_allows_valid_top_level_path(self):
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama/config.json")
+        self.assertEqual(
+            result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
+    def test_rejects_traversal_object_name(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/",
+                "models/llama/../../../../etc/cron.d/malicious")
+
+    def test_rejects_traversal_object_name_not_matching_base_dir(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/", "../../etc/passwd")
 
 
 if __name__ == "__main__":

--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/tests/test_files.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/tests/test_files.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch, MagicMock
 import runai_model_streamer_gcs.files.files as files
 
 
@@ -65,6 +66,60 @@ class TestSafeDestinationPath(unittest.TestCase):
         with self.assertRaises(ValueError):
             files._safe_destination_path(
                 self.dst, "models/llama/", "../../etc/passwd")
+
+
+class TestPullFilesTraversalRegression(unittest.TestCase):
+    """Exercises the real pull_files() loop end-to-end, with only the SDK
+    boundary (_create_client/list_files/download_to_filename) mocked, so
+    this keeps failing if a future change stops wiring
+    _safe_destination_path into the download loop.
+
+    Not run against a real backend: fake-gcs-server itself builds its local
+    storage path from the raw object key without sanitizing it, so a blob
+    named with ".." segments gets written outside its own data directory
+    at upload time -- before pull_files() is ever involved -- making a
+    real-emulator reproduction indistinguishable from the emulator's own
+    (unrelated) bug.
+    """
+    def setUp(self):
+        self.dst = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.dst, ignore_errors=True)
+
+    @patch("runai_model_streamer_gcs.files.files._create_client")
+    @patch("runai_model_streamer_gcs.files.files.list_files")
+    def test_pull_files_rejects_traversal_key_and_writes_nothing(
+            self, mock_list_files, mock_create_client):
+        mock_gcs = MagicMock()
+        mock_create_client.return_value = mock_gcs
+        malicious_key = "models/llama/" + ("../" * 12) + "tmp/pwned"
+        mock_list_files.return_value = ("bucket", "models/llama/", [malicious_key])
+
+        with self.assertRaises(ValueError):
+            files.pull_files("gs://bucket/models/llama/", self.dst)
+
+        mock_gcs.get_bucket.return_value.blob.return_value.download_to_filename.assert_not_called()
+        self.assertEqual(os.listdir(self.dst), [])
+
+    @patch("runai_model_streamer_gcs.files.files._create_client")
+    @patch("runai_model_streamer_gcs.files.files.list_files")
+    def test_pull_files_downloads_valid_nested_key(
+            self, mock_list_files, mock_create_client):
+        mock_gcs = MagicMock()
+        mock_create_client.return_value = mock_gcs
+        mock_list_files.return_value = (
+            "bucket", "models/llama/", ["models/llama/subdir/config.json"])
+
+        def fake_download_to_filename(destination_file):
+            with open(destination_file, "wb") as f:
+                f.write(b"content")
+        mock_gcs.get_bucket.return_value.blob.return_value.download_to_filename.side_effect = (
+            fake_download_to_filename)
+
+        files.pull_files("gs://bucket/models/llama/", self.dst)
+
+        self.assertTrue(os.path.exists(os.path.join(self.dst, "subdir", "config.json")))
 
 
 if __name__ == "__main__":

--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/tests/test_files.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/tests/test_files.py
@@ -67,6 +67,23 @@ class TestSafeDestinationPath(unittest.TestCase):
             files._safe_destination_path(
                 self.dst, "models/llama/", "../../etc/passwd")
 
+    def test_rejects_sibling_prefix_collision(self):
+        # base_dir "models/llama" (no trailing slash) is a plain string prefix
+        # of "models/llama_backup/...", but it's a different, unrelated key.
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama", "models/llama_backup/weights.bin")
+
+    def test_rejects_object_name_unrelated_to_base_dir(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/", "other/path/secret.txt")
+
+    def test_allows_top_level_key_when_base_dir_is_empty(self):
+        # base_dir is "" when pulling from the root of a bucket (no prefix).
+        result = files._safe_destination_path(self.dst, "", "config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
 
 class TestPullFilesTraversalRegression(unittest.TestCase):
     """Exercises the real pull_files() loop end-to-end, with only the SDK
@@ -120,6 +137,25 @@ class TestPullFilesTraversalRegression(unittest.TestCase):
         files.pull_files("gs://bucket/models/llama/", self.dst)
 
         self.assertTrue(os.path.exists(os.path.join(self.dst, "subdir", "config.json")))
+
+    @patch("runai_model_streamer_gcs.files.files._create_client")
+    @patch("runai_model_streamer_gcs.files.files.list_files")
+    def test_pull_files_downloads_deeply_nested_key(
+            self, mock_list_files, mock_create_client):
+        mock_gcs = MagicMock()
+        mock_create_client.return_value = mock_gcs
+        mock_list_files.return_value = (
+            "bucket", "models/llama/", ["models/llama/a/b/c/deep.safetensors"])
+
+        def fake_download_to_filename(destination_file):
+            with open(destination_file, "wb") as f:
+                f.write(b"content")
+        mock_gcs.get_bucket.return_value.blob.return_value.download_to_filename.side_effect = (
+            fake_download_to_filename)
+
+        files.pull_files("gs://bucket/models/llama/", self.dst)
+
+        self.assertTrue(os.path.exists(os.path.join(self.dst, "a", "b", "c", "deep.safetensors")))
 
 
 if __name__ == "__main__":

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/files/files.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/files/files.py
@@ -114,7 +114,10 @@ def _filter_ignore(paths: List[str], patterns: List[str]) -> List[str]:
     ]
 
 def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
-    relative = removeprefix(file, base_dir).lstrip("/")
+    prefix = base_dir if base_dir == "" or base_dir.endswith("/") else base_dir + "/"
+    if not file.startswith(prefix):
+        raise ValueError(f"object key {file!r} does not start with expected prefix {prefix!r}")
+    relative = file[len(prefix):]
     dst_real = os.path.realpath(dst)
     destination_file = os.path.realpath(os.path.join(dst_real, relative))
     if os.path.commonpath([dst_real, destination_file]) != dst_real:

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/files/files.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/files/files.py
@@ -117,7 +117,7 @@ def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
     prefix = base_dir if base_dir == "" or base_dir.endswith("/") else base_dir + "/"
     if not file.startswith(prefix):
         raise ValueError(f"object key {file!r} does not start with expected prefix {prefix!r}")
-    relative = file[len(prefix):]
+    relative = file[len(prefix):].lstrip("/")
     dst_real = os.path.realpath(dst)
     destination_file = os.path.realpath(os.path.join(dst_real, relative))
     if os.path.commonpath([dst_real, destination_file]) != dst_real:

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/files/files.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/files/files.py
@@ -51,9 +51,7 @@ def pull_files(model_path: str,
         return
 
     for file in files:
-        destination_file = os.path.join(
-            dst,
-            removeprefix(file, base_dir).lstrip("/"))
+        destination_file = _safe_destination_path(dst, base_dir, file)
         local_dir = Path(destination_file).parent
         os.makedirs(local_dir, exist_ok=True)
         s3.download_file(bucket_name, file, destination_file)
@@ -114,6 +112,14 @@ def _filter_ignore(paths: List[str], patterns: List[str]) -> List[str]:
         path for path in paths
         if not any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
     ]
+
+def _safe_destination_path(dst: str, base_dir: str, file: str) -> str:
+    relative = removeprefix(file, base_dir).lstrip("/")
+    dst_real = os.path.realpath(dst)
+    destination_file = os.path.realpath(os.path.join(dst_real, relative))
+    if os.path.commonpath([dst_real, destination_file]) != dst_real:
+        raise ValueError(f"refusing to write outside destination directory: {file!r}")
+    return destination_file
 
 def removeprefix(s: str, prefix: str) -> str:
     if s.startswith(prefix):

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/files/tests/test_files.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/files/tests/test_files.py
@@ -129,6 +129,23 @@ class TestSafeDestinationPath(unittest.TestCase):
             files._safe_destination_path(
                 self.dst, "models/llama/", "../../etc/passwd")
 
+    def test_rejects_sibling_prefix_collision(self):
+        # base_dir "models/llama" (no trailing slash) is a plain string prefix
+        # of "models/llama_backup/...", but it's a different, unrelated key.
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama", "models/llama_backup/weights.bin")
+
+    def test_rejects_object_name_unrelated_to_base_dir(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/", "other/path/secret.txt")
+
+    def test_allows_top_level_key_when_base_dir_is_empty(self):
+        # base_dir is "" when pulling from the root of a bucket (no prefix).
+        result = files._safe_destination_path(self.dst, "", "config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
 
 class TestPullFilesTraversalRegression(unittest.TestCase):
     """Exercises the real pull_files() loop end-to-end, with only the SDK
@@ -178,6 +195,24 @@ class TestPullFilesTraversalRegression(unittest.TestCase):
         files.pull_files("s3://bucket/models/llama/", self.dst)
 
         self.assertTrue(os.path.exists(os.path.join(self.dst, "subdir", "config.json")))
+
+    @patch("runai_model_streamer_s3.files.files._build_s3_client")
+    @patch("runai_model_streamer_s3.files.files.list_files")
+    def test_pull_files_downloads_deeply_nested_key(
+            self, mock_list_files, mock_build_client):
+        mock_s3 = MagicMock()
+        mock_build_client.return_value = mock_s3
+        mock_list_files.return_value = (
+            "bucket", "models/llama/", ["models/llama/a/b/c/deep.safetensors"])
+
+        def fake_download_file(bucket, key, destination_file):
+            with open(destination_file, "wb") as f:
+                f.write(b"content")
+        mock_s3.download_file.side_effect = fake_download_file
+
+        files.pull_files("s3://bucket/models/llama/", self.dst)
+
+        self.assertTrue(os.path.exists(os.path.join(self.dst, "a", "b", "c", "deep.safetensors")))
 
 
 if __name__ == "__main__":

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/files/tests/test_files.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/files/tests/test_files.py
@@ -146,6 +146,19 @@ class TestSafeDestinationPath(unittest.TestCase):
         result = files._safe_destination_path(self.dst, "", "config.json")
         self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
 
+    def test_allows_leading_slash_object_key_when_base_dir_is_empty(self):
+        # A key with a literal leading "/" is unusual but valid; os.path.join
+        # would otherwise treat it as absolute and discard dst entirely.
+        result = files._safe_destination_path(self.dst, "", "/config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
+    def test_allows_double_slash_at_prefix_boundary(self):
+        # A doubled "/" right where base_dir ends leaves a leading "/" on the
+        # remainder after the prefix is stripped off.
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama//config.json")
+        self.assertEqual(result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
 
 class TestPullFilesTraversalRegression(unittest.TestCase):
     """Exercises the real pull_files() loop end-to-end, with only the SDK

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/files/tests/test_files.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/files/tests/test_files.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -9,23 +11,23 @@ import runai_model_streamer_s3.files.files as files
 
 class TestFiles(unittest.TestCase):
     def test_filter_allow(self):
-        res = files._filter_ignore(
+        res = files._filter_allow(
             ["test_file1.txt1", "test_file2.txt2", "test_file3.txt3"],
-            allow_pattern=["*.txt2"]
+            patterns=["*.txt2"]
         )
         self.assertEqual(res, ["test_file2.txt2"])
 
     def test_filter_allow_full_path(self):
-        res = files._filter_ignore(
+        res = files._filter_allow(
             ["test_file1.txt1", "dir/test_file2.txt2", "test_file3.txt3"],
-            allow_pattern=["*.txt2"]
+            patterns=["*.txt2"]
         )
         self.assertEqual(res, ["dir/test_file2.txt2"])
 
     def test_filter_ignore(self):
         res = files._filter_ignore(
             ["test_file1.txt1", "test_file2.txt2", "test_file3.txt3"],
-            ignore_pattern=["*.txt2"]
+            patterns=["*.txt2"]
         )
         self.assertEqual(res, ["test_file1.txt1", "test_file3.txt3"])
 
@@ -95,6 +97,37 @@ class TestBuildS3Client(unittest.TestCase):
             files._build_s3_client(None)
         mock_get_credentials.assert_called_once()
         mock_boto3.client.assert_called_once()
+
+
+class TestSafeDestinationPath(unittest.TestCase):
+    def setUp(self):
+        self.dst = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.dst, ignore_errors=True)
+
+    def test_allows_valid_nested_path(self):
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama/subdir/config.json")
+        self.assertEqual(
+            result, os.path.realpath(os.path.join(self.dst, "subdir/config.json")))
+
+    def test_allows_valid_top_level_path(self):
+        result = files._safe_destination_path(
+            self.dst, "models/llama/", "models/llama/config.json")
+        self.assertEqual(
+            result, os.path.realpath(os.path.join(self.dst, "config.json")))
+
+    def test_rejects_traversal_object_name(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/",
+                "models/llama/../../../../etc/cron.d/malicious")
+
+    def test_rejects_traversal_object_name_not_matching_base_dir(self):
+        with self.assertRaises(ValueError):
+            files._safe_destination_path(
+                self.dst, "models/llama/", "../../etc/passwd")
 
 
 if __name__ == "__main__":

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/files/tests/test_files.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/files/tests/test_files.py
@@ -130,5 +130,55 @@ class TestSafeDestinationPath(unittest.TestCase):
                 self.dst, "models/llama/", "../../etc/passwd")
 
 
+class TestPullFilesTraversalRegression(unittest.TestCase):
+    """Exercises the real pull_files() loop end-to-end, with only the SDK
+    boundary (_build_s3_client/list_files/download_file) mocked, so this
+    keeps failing if a future change stops wiring _safe_destination_path
+    into the download loop.
+
+    Not run against a real backend: MinIO itself rejects ".." in object
+    keys at PutObject time (XMinioInvalidResourceName), so a real MinIO
+    upload can never carry a traversal key to reproduce this with.
+    """
+    def setUp(self):
+        self.dst = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.dst, ignore_errors=True)
+
+    @patch("runai_model_streamer_s3.files.files._build_s3_client")
+    @patch("runai_model_streamer_s3.files.files.list_files")
+    def test_pull_files_rejects_traversal_key_and_writes_nothing(
+            self, mock_list_files, mock_build_client):
+        mock_s3 = MagicMock()
+        mock_build_client.return_value = mock_s3
+        malicious_key = "models/llama/" + ("../" * 12) + "tmp/pwned"
+        mock_list_files.return_value = ("bucket", "models/llama/", [malicious_key])
+
+        with self.assertRaises(ValueError):
+            files.pull_files("s3://bucket/models/llama/", self.dst)
+
+        mock_s3.download_file.assert_not_called()
+        self.assertEqual(os.listdir(self.dst), [])
+
+    @patch("runai_model_streamer_s3.files.files._build_s3_client")
+    @patch("runai_model_streamer_s3.files.files.list_files")
+    def test_pull_files_downloads_valid_nested_key(
+            self, mock_list_files, mock_build_client):
+        mock_s3 = MagicMock()
+        mock_build_client.return_value = mock_s3
+        mock_list_files.return_value = (
+            "bucket", "models/llama/", ["models/llama/subdir/config.json"])
+
+        def fake_download_file(bucket, key, destination_file):
+            with open(destination_file, "wb") as f:
+                f.write(b"content")
+        mock_s3.download_file.side_effect = fake_download_file
+
+        files.pull_files("s3://bucket/models/llama/", self.dst)
+
+        self.assertTrue(os.path.exists(os.path.join(self.dst, "subdir", "config.json")))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `pull_files()` derived the local destination path from the untrusted S3/GCS/Azure object name via a plain `os.path.join()`, with no check that the result stayed under the caller-provided destination directory. An object name containing `../` segments could write or overwrite files outside the intended directory.
- Adds a `_safe_destination_path()` helper that resolves the destination and verifies it remains contained within `dst`, raising `ValueError` otherwise. Applied identically to the S3, GCS, and Azure `pull_files()` implementations, before any directory is created or file opened/downloaded.
- The helper is duplicated per-package rather than factored into a shared dependency, matching this codebase's existing convention (`removeprefix()`, `_filter_allow()`, `_filter_ignore()` are already implemented identically in each of the three `files.py` modules), since the S3/GCS/Azure packages are independently installable with no shared internal dependency between them.
- Drive-by: fixed a stale S3 unit test bug found while adding coverage — `test_filter_allow`/`test_filter_allow_full_path` were calling `_filter_ignore()` with a nonexistent `allow_pattern` kwarg instead of `_filter_allow()` with the current `patterns` kwarg, so `_filter_allow()` had no real test coverage in the S3 package. Aligned with the already-correct GCS/Azure copies of this test.

## Test plan
- [x] New unit tests (`_safe_destination_path` in each provider's `files/tests/test_files.py`): valid nested/top-level paths still resolve correctly, traversal object names raise `ValueError`
- [x] Full local e2e suites run against real backends (MinIO, fake-gcs-server, Azurite) via the devcontainer: S3 17/17, GCS 14/14, Azure 16/16 — all passing, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file download handling across Azure, Google Cloud, and S3 storage.
  - Download destinations are now validated against the requested output directory.
  - Invalid traversal attempts, unrelated object keys, and prefix collisions are rejected without downloading or creating files.

- **Tests**
  - Added coverage for valid top-level, nested, and deeply nested downloads.
  - Added checks for traversal, invalid prefixes, empty base directories, and sibling-prefix collisions.
  - Updated file-filter tests for consistent allow/ignore matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->