### PR TITLE
Add a device type to the C API

### DIFF
--- a/cpp/common/device/BUILD
+++ b/cpp/common/device/BUILD
@@ -1,0 +1,5 @@
+load("//:rules.bzl", "runai_cc_auto_library")
+
+runai_cc_auto_library(
+    name = "device",
+)

--- a/cpp/common/device/device.h
+++ b/cpp/common/device/device.h
@@ -1,0 +1,22 @@
+#ifndef NV_FILE_STREAMER_DEVICE_H
+#define NV_FILE_STREAMER_DEVICE_H
+
+// Plain C that also compiles as C++, because this header ships in the SDK tarball and a C program
+// must be able to include it.
+
+typedef enum NvFileStreamerDeviceType
+{
+    NV_FILE_STREAMER_DEVICE_CPU  = 0,
+    NV_FILE_STREAMER_DEVICE_CUDA = 1,
+} NvFileStreamerDeviceType;
+
+typedef struct NvFileStreamerDevice
+{
+    // CPU is zero, so a zeroed struct asks for the host.
+    NvFileStreamerDeviceType type;
+
+    // The CUDA ordinal, typed as CUdevice is. Ignored when type is NV_FILE_STREAMER_DEVICE_CPU.
+    int id;
+} NvFileStreamerDevice;
+
+#endif // NV_FILE_STREAMER_DEVICE_H

--- a/cpp/common/response_code/response_code.cc
+++ b/cpp/common/response_code/response_code.cc
@@ -46,6 +46,7 @@ constexpr std::array<const char *, static_cast<size_t>(ResponseCode::__Max)> __m
     "The filesystem read strategy was already set to a different value; set RUNAI_STREAMER_FS_STRATEGY, or call runai_set_fs_strategy, once before the first request",
     "None of the filesystem read strategies in the list can be served on this host; add sync_buffered to the list to allow the synchronous reader",
     "The asynchronous filesystem reader for this mount failed and will not be used again; the storage itself is healthy, and re-requesting these ranges reads them through the synchronous reader",
+    "The requested device type is not supported by this build of the streamer; only NV_FILE_STREAMER_DEVICE_CPU can be read into",
 };
 
 const char * description(int response_code)

--- a/cpp/common/response_code/response_code.h
+++ b/cpp/common/response_code/response_code.h
@@ -60,6 +60,10 @@ enum class ResponseCode : int
     // it was, and with what errno, is in the log.
     FsAsyncEngineError,
 
+    // The submission named a device this build cannot serve. Appended, like the codes above, so no
+    // released number moves.
+    UnsupportedDeviceType,
+
     __Max,
 };
 

--- a/cpp/mock/BUILD
+++ b/cpp/mock/BUILD
@@ -5,6 +5,8 @@ runai_portable_so(
     srcs = ["streamer-mock.cc"],
     deps = [
         "//utils/fd",
+        "//common/device",
+        "//common/response_code",
         "//common/submission",
         # For runai_direct_block_size only. Checked: this pulls in no liburing and no libaio - the
         # mock stays free of the engines it is standing in for.

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -224,6 +224,13 @@ extern "C" int runai_request(
     NvFileStreamerDevice device
 )
 {
+    // Zeroed here, before anything that can fail, exactly as the real runai_request does: the contract
+    // says the id is left 0 when the call fails before one is assigned, and a caller reusing the
+    // variable would otherwise read the previous submission's id as if this one were live.
+    if (out_submission_id != nullptr) {
+        *out_submission_id = 0;
+    }
+
     // Refused like the real C API, so a Python test that asks for a device gets the same answer here.
     if (device.type != NV_FILE_STREAMER_DEVICE_CPU) {
         return static_cast<int>(common::ResponseCode::UnsupportedDeviceType);

--- a/cpp/mock/streamer-mock.cc
+++ b/cpp/mock/streamer-mock.cc
@@ -10,6 +10,8 @@
 #include <vector>
 #include "utils/fd/fd.h"
 #include "utils/logging/logging.h"
+#include "common/device/device.h"
+#include "common/response_code/response_code.h"
 #include "common/submission/submission_id.h"
 
 
@@ -160,9 +162,7 @@ extern "C" int runai_start(void ** streamer)
     }
     catch (...)
     {
-        // Literal rather than the enum, following this file's convention: mock/BUILD deps are only
-        // //utils/fd and //common/submission, so common/response_code is not on the include path.
-        return 11;   // common::ResponseCode::UnknownError
+        return static_cast<int>(common::ResponseCode::UnknownError);
     }
     return 0;
 }
@@ -220,9 +220,15 @@ extern "C" int runai_request(
     unsigned * num_ranges,
     size_t * range_offsets,
     size_t * range_sizes,
-    void ** range_dsts
+    void ** range_dsts,
+    NvFileStreamerDevice device
 )
 {
+    // Refused like the real C API, so a Python test that asks for a device gets the same answer here.
+    if (device.type != NV_FILE_STREAMER_DEVICE_CPU) {
+        return static_cast<int>(common::ResponseCode::UnsupportedDeviceType);
+    }
+
     Submission submission;
 
     // The range arrays are flat and grouped by file in the order of paths; base walks that grouping.

--- a/cpp/streamer/BUILD
+++ b/cpp/streamer/BUILD
@@ -5,7 +5,7 @@ runai_portable_so(
     srcs = ["streamer.h",
             "streamer.cc",
     ],
-    deps = ["//streamer/impl", "//common/submission", "//posix_io/alignment"],
+    deps = ["//streamer/impl", "//common/device", "//common/submission", "//posix_io/alignment"],
     ldscript = ":streamer.ldscript",
     defines = ["_RUNAI_STREAMER_SO"],
     linkopts = ["-lpthread", "-Wl,-rpath,$$ORIGIN"]
@@ -13,7 +13,7 @@ runai_portable_so(
 
 runai_cc_auto_library(
     name = "streamer",
-    deps = ["//streamer/impl", "//common/submission", "//posix_io/alignment"],
+    deps = ["//streamer/impl", "//common/device", "//common/submission", "//posix_io/alignment"],
 )
 
 runai_cc_test(

--- a/cpp/streamer/streamer.cc
+++ b/cpp/streamer/streamer.cc
@@ -77,8 +77,15 @@ int submit_request(impl::Streamer * s,
                    SubmissionId * out_submission_id,
                    unsigned num_files,
                    const char ** paths, unsigned * num_ranges,
-                   size_t * range_offsets, size_t * range_sizes, void ** range_dsts)
+                   size_t * range_offsets, size_t * range_sizes, void ** range_dsts,
+                   NvFileStreamerDevice device)
 {
+    // Rejected before anything is committed, so a submission this build cannot serve owes no responses.
+    if (device.type != NV_FILE_STREAMER_DEVICE_CPU)
+    {
+        return static_cast<int>(common::ResponseCode::UnsupportedDeviceType);
+    }
+
     if (num_files > 0 && (paths == nullptr || num_ranges == nullptr))
     {
         return static_cast<int>(common::ResponseCode::InvalidParameterError);
@@ -185,7 +192,8 @@ _RUNAI_EXTERN_C int runai_request(
     unsigned * num_ranges,
     size_t * range_offsets,
     size_t * range_sizes,
-    void ** range_dsts
+    void ** range_dsts,
+    NvFileStreamerDevice device
 )
 {
     // default the id to 0 ("none") so every return path - including early failures and a throw
@@ -204,7 +212,7 @@ _RUNAI_EXTERN_C int runai_request(
         }
 
         // credentials are streamer-scoped (runai_set_credentials), not per request
-        return submit_request(s, out_submission_id, num_files, paths, num_ranges, range_offsets, range_sizes, range_dsts);
+        return submit_request(s, out_submission_id, num_files, paths, num_ranges, range_offsets, range_sizes, range_dsts, device);
     }
     catch (const common::Exception & e)
     {

--- a/cpp/streamer/streamer.h
+++ b/cpp/streamer/streamer.h
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 
+#include "common/device/device.h"
 #include "common/submission/submission_id.h"
 
 namespace runai::llm::streamer
@@ -82,6 +83,7 @@ _RUNAI_EXTERN_C int runai_set_fs_strategy(
 // range_offsets : flat array of sum(num_ranges) source offsets, each within its owning file
 // range_sizes   : flat array of sum(num_ranges) range sizes in bytes
 // range_dsts    : flat array of sum(num_ranges) destination pointers
+// device        : where those destinations live - one device for the whole submission
 //
 // The three flat arrays are indexed identically and grouped by file in the order of paths: file f's
 // ranges occupy [sum(num_ranges[0..f)), sum(num_ranges[0..f])). Destinations must not overlap.
@@ -93,6 +95,11 @@ _RUNAI_EXTERN_C int runai_set_fs_strategy(
 // Size the response loop by that sum. runai_response blocks indefinitely at timeout_ms = 0, so a
 // caller that skips zero-sized ranges when counting waits for a response that has already been
 // delivered. A submission with sum(num_ranges) == 0 owes nothing and completes immediately.
+//
+// DEVICE - one per submission, so every destination in it lives on the same device. A load that
+// scatters across several GPUs is sent as several submissions, which run together and are drained by
+// their own ids. Only NV_FILE_STREAMER_DEVICE_CPU is served today; anything else returns UnsupportedDeviceType and
+// commits nothing, so no responses are owed for it.
 //
 // Credentials are NOT passed here - set them once via runai_set_credentials.
 //  out_submission_id : always set to this submission's id once one is assigned, and left 0 only
@@ -108,7 +115,8 @@ _RUNAI_EXTERN_C int runai_request(
     unsigned * num_ranges,
     size_t * range_offsets,
     size_t * range_sizes,
-    void ** range_dsts
+    void ** range_dsts,
+    NvFileStreamerDevice device
 );
 
 // Multi-request response. Returns the next ready range from any in-flight submission.

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -62,7 +62,7 @@ inline int submit(void * streamer, unsigned num_files, const char ** paths, size
 
     SubmissionId submission_id = 0;
     return runai_request(streamer, &submission_id, num_files, paths, num_ranges.data(),
-                         range_offsets.data(), range_sizes.data(), range_dsts.data());
+                         range_offsets.data(), range_sizes.data(), range_dsts.data(), NvFileStreamerDevice{});
 }
 
 inline int next_response(void * streamer, unsigned * file_index, unsigned * index)
@@ -787,7 +787,7 @@ TEST_F(StreamerTest, Filesystem_And_Object_Storage_Submissions_Coexist)
         size_t size = fs_data.size();
 
         SubmissionId submission_id = 0;
-        EXPECT_EQ(runai_request(streamer, &submission_id, 1, &path, &num_ranges, &offset, &size, &dst_ptr),
+        EXPECT_EQ(runai_request(streamer, &submission_id, 1, &path, &num_ranges, &offset, &size, &dst_ptr, NvFileStreamerDevice{}),
                   static_cast<int>(common::ResponseCode::Success));
 
         unsigned file_index = 0;
@@ -868,7 +868,7 @@ TEST_F(StreamerTest, Object_Storage_Then_Filesystem_Submission)
         size_t size = fs_data.size();
 
         SubmissionId submission_id = 0;
-        EXPECT_EQ(runai_request(streamer, &submission_id, 1, &path, &n_ranges, &offset, &size, &dst_ptr),
+        EXPECT_EQ(runai_request(streamer, &submission_id, 1, &path, &n_ranges, &offset, &size, &dst_ptr, NvFileStreamerDevice{}),
                   static_cast<int>(common::ResponseCode::Success));
 
         unsigned file_index = 0;

--- a/cpp/streamer/streamer_test.cc
+++ b/cpp/streamer/streamer_test.cc
@@ -61,7 +61,7 @@ inline int submit(void * streamer, unsigned num_files, const char ** paths, size
 
     SubmissionId submission_id = 0;
     return runai_request(streamer, &submission_id, num_files, paths, num_ranges.data(),
-                         range_offsets.data(), range_sizes.data(), range_dsts.data());
+                         range_offsets.data(), range_sizes.data(), range_dsts.data(), NvFileStreamerDevice{});
 }
 
 // Single-file variant that reports the submission id, for the concurrent-submission tests. The sub ranges
@@ -84,7 +84,7 @@ inline int submit_one(void * streamer, SubmissionId * id, const char * path, siz
     }
 
     return runai_request(streamer, id, 1, &path, &num_ranges,
-                         range_offsets.data(), sizes.data(), range_dsts.data());
+                         range_offsets.data(), sizes.data(), range_dsts.data(), NvFileStreamerDevice{});
 }
 
 inline int next_response(void * streamer, unsigned * file_index, unsigned * index)
@@ -171,27 +171,27 @@ TEST(Request, Null_Parameters)
 
     const auto invalid = static_cast<int>(common::ResponseCode::InvalidParameterError);
 
-    EXPECT_EQ(runai_request(streamer, &id, 1, nullptr, &num_ranges, &offset, &size, &dst), invalid);
-    EXPECT_EQ(runai_request(streamer, &id, 1, &path, nullptr, &offset, &size, &dst), invalid);
-    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, nullptr, &size, &dst), invalid);
-    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, nullptr, &dst), invalid);
-    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &size, nullptr), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, nullptr, &num_ranges, &offset, &size, &dst, NvFileStreamerDevice{}), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, nullptr, &offset, &size, &dst, NvFileStreamerDevice{}), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, nullptr, &size, &dst, NvFileStreamerDevice{}), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, nullptr, &dst, NvFileStreamerDevice{}), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &size, nullptr, NvFileStreamerDevice{}), invalid);
 
     // a null path entry is caught before it is used to construct a std::string - the previous code built
     // the vector straight from the array, which was undefined behaviour on a null element
     const char * null_path = nullptr;
-    EXPECT_EQ(runai_request(streamer, &id, 1, &null_path, &num_ranges, &offset, &size, &dst), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &null_path, &num_ranges, &offset, &size, &dst, NvFileStreamerDevice{}), invalid);
 
     // A null destination ELEMENT (the array itself is fine) is caught deeper, by verify_requests, which
     // throws rather than returning. The specific code has to survive the C boundary: UnknownError is what
     // tells a caller to abort everything, while an argument error is attributable and recoverable, so
     // collapsing this to UnknownError would turn a bad argument into a dead stream.
     void * null_dst = nullptr;
-    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &size, &null_dst), invalid);
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &size, &null_dst, NvFileStreamerDevice{}), invalid);
 
     // a zero-sized range writes nothing, so a null destination there is accepted
     size_t zero = 0;
-    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &zero, &null_dst),
+    EXPECT_EQ(runai_request(streamer, &id, 1, &path, &num_ranges, &offset, &zero, &null_dst, NvFileStreamerDevice{}),
               static_cast<int>(common::ResponseCode::Success));
 
     // The only submission accepted above, so it owes one response and must be drained before the test

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
@@ -8,6 +8,22 @@ STREAMER_LIBRARY = os.environ.get("STREAMER_LIBRARY", DEFAULT_STREAMER_LIBRARY)
 
 t_streamer = ctypes.c_void_p
 
+# NvFileStreamerDeviceType, from cpp/common/device/device.h. Only CPU is served today.
+NV_FILE_STREAMER_DEVICE_CPU = 0
+NV_FILE_STREAMER_DEVICE_CUDA = 1
+
+
+class NvFileStreamerDevice(ctypes.Structure):
+    """Mirrors the C struct of the same name, passed to runai_request BY VALUE.
+
+    Both fields are 4 bytes: a C enum whose enumerators are 0 and 1 is int-sized, and c_int matches its
+    size and alignment whichever signedness the compiler picks - only 0 and 1 ever cross."""
+
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("id", ctypes.c_int),      # the CUDA ordinal, ignored for CPU
+    ]
+
 
 class LibstreamerDLLWrapper:
     def __init__(self, library_path):
@@ -42,6 +58,7 @@ class LibstreamerDLLWrapper:
             ctypes.POINTER(ctypes.c_size_t),                 # range_offsets
             ctypes.POINTER(ctypes.c_size_t),                 # range_sizes
             ctypes.POINTER(ctypes.c_void_p),                 # range_dsts
+            NvFileStreamerDevice,                            # device, by value
         ]
         self.fn_runai_request.restype = ctypes.c_int
 

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -1,4 +1,9 @@
-from runai_model_streamer.libstreamer import dll, t_streamer
+from runai_model_streamer.libstreamer import (
+    dll,
+    t_streamer,
+    NvFileStreamerDevice,
+    NV_FILE_STREAMER_DEVICE_CPU,
+)
 from typing import Callable, Dict, List, Optional, Tuple
 import ctypes
 import logging
@@ -164,6 +169,10 @@ def runai_request(
         c_range_offsets,
         c_range_sizes,
         c_range_dsts,
+        # Always the host. range_dsts point into the ring's numpy buffer (requests_iterator.py,
+        # `self._raw = np.empty(...)`), and the move to the caller's device happens afterwards in
+        # FileStreamer.get_chunks, so the C layer is never asked for anything but CPU.
+        NvFileStreamerDevice(NV_FILE_STREAMER_DEVICE_CPU, 0),
     )
     if error_code != SUCCESS_ERROR_CODE:
         raise ValueError(


### PR DESCRIPTION
# Add a device type to the C API

`runai_request` now takes the device its destinations live on. Only the host is served; the point is
to fix the shape of the API before we ship it, so a C++ SDK can be built against it while the pinned
memory work continues separately.

## The API

```c
int runai_request(
    void * streamer,
    SubmissionId * out_submission_id,
    unsigned num_files,
    const char ** paths,
    unsigned * num_ranges,
    size_t * range_offsets,
    size_t * range_sizes,
    void ** range_dsts,
    NvFileStreamerDevice device       // new
);
```

`NvFileStreamerDevice` is a type and an ordinal:

```c
typedef struct NvFileStreamerDevice
{
    NvFileStreamerDeviceType type;   // NV_FILE_STREAMER_DEVICE_CPU or _CUDA
    int                      id;     // the CUDA ordinal, ignored for CPU
} NvFileStreamerDevice;
```

Anything but `NV_FILE_STREAMER_DEVICE_CPU` returns the new `UnsupportedDeviceType`. It is refused before the
submission is committed, so no responses are owed for it and nothing has to be drained.

## Python

The callers are updated, not extended. `libstreamer/__init__.py` gains a ctypes `Structure` mirroring
the C struct and appends it to `runai_request`'s `argtypes` as a by-value argument;
`libstreamer.py` passes CPU. The Python signature is unchanged and takes no `device`, because Python
reads into the ring's numpy buffer and moves to the caller's device afterwards in
`FileStreamer.get_chunks` - so there is nothing yet that could pass anything else, and an unused
parameter would be worse than none.

Checked against the built `libstreamer.so`, since a struct crossing ctypes by value is worth proving
rather than assuming: CPU returns Success with a submission id assigned, CUDA and an out-of-range
value both return `UnsupportedDeviceType` with the id left at 0, and `sizeof` is 8, matching the C
struct.

## Three decisions worth reviewing

**The ordinal is passed, not discovered.** `pinned-memory-staging` resolves one device per process:
`cuda_loader.cc` reads the ambient device with `cuCtxGetCurrent` / `cuCtxGetDevice` and keeps its
primary context in a singleton. Its comment says why that was enough - in tensor parallel work each
rank is its own process, with its own current device. That breaks when one process serves several
GPUs, as when a running service is restored, because then no ambient device is the right one. The
ordinal is not read back from the destination pointers either: the context and the stream have to be
chosen before the copy, not once a pointer is in hand.

**One device per submission, not per range.** A load that scatters across several GPUs is sent as
several submissions, which run together and are drained by their own ids. The caller partitions its
ranges by device; in exchange every batch is homogeneous, so `Batches` needs no change and the copy
needs no per-range lookup.

**The header is plain C, and carries no `runai` prefix.** `cpp/common/device/device.h` has an include
guard, no namespace and no `enum class`, so a C program can include it - the shape the SDK issue
requires of a shipped header, and the one `common/submission/submission_id.h` does not have. Checked
with `gcc -std=c99 -pedantic` and `g++ -std=c++17 -pedantic`.

`NV_FILE_STREAMER_DEVICE_CPU` is 0 on purpose, so a zeroed struct asks for the host.

## Not in this PR

The device is validated at the C boundary and goes no further. `impl::Streamer::async_request` is
untouched, because there is nothing for it to do with a value that can only be CPU.

**No test asserts the refusal.** Deliberately: such a test only states that CUDA is not implemented
yet, so implementing it would mean deleting the test rather than changing it. The existing suites do
cover the new argument - every call site in `streamer_test.cc` and `streamer_s3_test.cc` now passes a
device, and the argument-validation cases still return `InvalidParameterError`, which they could only
do if the device were read as CPU.

## Tests

C++ `streamer_test`, `streamer_s3_test` and `response_code_test` pass, and `libstreamer-mock.so`
builds - the mock takes the same argument and gives the same refusal, so the Python suite binds
against a signature that matches the product. Python: 242 tests pass, 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device descriptors supporting CPU and CUDA device types.
  * Updated streaming requests to specify a device for all destinations.
  * Python requests now explicitly target CPU-host memory.
* **Bug Fixes**
  * Requests using unsupported device types now fail with a clear response code before submission.
  * Replaced an allocation-failure numeric error with the corresponding named error code.
* **Tests**
  * Updated streamer and S3 coverage for device-aware requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->